### PR TITLE
plugin: add SpeakSwiftly MCP skill bundle

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,20 @@
 {
-  "name": "local-repo",
+  "name": "speak-swiftly-server-local",
   "interface": {
-    "displayName": "Local Repo"
+    "displayName": "SpeakSwiftlyServer Local Plugins"
   },
-  "plugins": []
+  "plugins": [
+    {
+      "name": "speak-swiftly-server",
+      "source": {
+        "source": "local",
+        "path": "."
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "speak-swiftly-server",
-  "version": "2.0.4",
-  "description": "Local Codex plugin packaging for the SpeakSwiftlyServer MCP surface and repo-shared skills.",
+  "version": "2.1.0",
+  "description": "Repo-local Codex plugin for the SpeakSwiftlyServer MCP surface, focused operator skills, and shared local MCP configuration.",
   "author": {
     "name": "Gale",
     "email": "mail@galewilliams.com",
@@ -23,7 +23,7 @@
   "interface": {
     "displayName": "SpeakSwiftlyServer",
     "shortDescription": "Local speech and playback workflows for Codex.",
-    "longDescription": "Repo-root Codex plugin for the local SpeakSwiftlyServer MCP surface, plus repo-shared skills and future app surfaces.",
+    "longDescription": "Repo-local Codex plugin for the SpeakSwiftlyServer MCP surface, including focused skills for runtime operation, voice workflows, and text-profile authoring.",
     "developerName": "Gale",
     "category": "Productivity",
     "capabilities": [
@@ -32,9 +32,9 @@
     ],
     "websiteURL": "https://github.com/gaelic-ghost/SpeakSwiftlyServer",
     "defaultPrompt": [
-      "Read this reply aloud through SpeakSwiftly.",
-      "Inspect the local SpeakSwiftly runtime state.",
-      "Create and manage SpeakSwiftly text profiles."
+      "Use SpeakSwiftly to read this reply aloud.",
+      "Inspect the local SpeakSwiftly runtime and queue state.",
+      "Create or edit a SpeakSwiftly text profile."
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Swift executable package for a shared localhost host process that exposes the pu
 - [Overview](#overview)
 - [Setup](#setup)
 - [Usage](#usage)
+- [Codex Plugin](#codex-plugin)
 - [Embedding](#embedding)
 - [Configuration](#configuration)
 - [Contributing](#contributing)
@@ -221,6 +222,19 @@ let layout = ServerInstallLayout.defaultForCurrentUser()
 print(layout.standardErrorLogURL.path)
 print(layout.runtimeProfileRootURL.path)
 ```
+
+## Codex Plugin
+
+This repository is also packaged as a repo-local Codex plugin through [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json). The plugin points at the checked-in [`.mcp.json`](./.mcp.json) connection for the local `speak_swiftly` MCP server and the tracked [skills](./skills/) bundle that teaches Codex how to use the surface intentionally.
+
+The first plugin pass currently ships four focused skills:
+
+- [`speak-swiftly-mcp`](./skills/speak-swiftly-mcp/SKILL.md) for broad MCP orientation and workflow selection
+- [`speak-swiftly-runtime-operator`](./skills/speak-swiftly-runtime-operator/SKILL.md) for runtime state, playback, queue, and request control
+- [`speak-swiftly-voice-workflows`](./skills/speak-swiftly-voice-workflows/SKILL.md) for voice profiles, live speech, and retained artifacts
+- [`speak-swiftly-text-profiles`](./skills/speak-swiftly-text-profiles/SKILL.md) for normalization styles, stored profiles, and replacement editing
+
+The repo-local marketplace advertisement lives in [`.agents/plugins/marketplace.json`](./.agents/plugins/marketplace.json). That entry intentionally points at the repository root so this checkout itself can be discovered and installed as one local plugin instead of forcing a second nested plugin copy inside the repo.
 
 The package also now exposes [`ServerInstalledLogs`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/Sources/SpeakSwiftlyServer/AppManagedInstallLayout.swift), which lets the app read the owned stdout and stderr files as plain text, line arrays, or decodable JSON-line payloads:
 

--- a/docs/maintainers/source-layout.md
+++ b/docs/maintainers/source-layout.md
@@ -61,6 +61,21 @@ This document is the maintainer map for the current `SpeakSwiftly 3.x`-aligned s
 - `Tests/SpeakSwiftlyServerE2ETests/SpeakSwiftlyServerE2EAudioRouteHelpers.swift`
   Keeps audible-suite-only CoreAudio route stabilization out of the request and lane helpers so the machine-level workaround stays obvious and isolated.
 
+## Plugin And Skill Sources
+
+- `.codex-plugin/plugin.json`
+  Holds the repo-root Codex plugin manifest for this checkout, including the tracked skill and MCP config paths.
+- `.agents/plugins/marketplace.json`
+  Holds the repo-local marketplace advertisement that lets this repository surface as an installable local Codex plugin.
+- `skills/speak-swiftly-mcp/`
+  Holds the general MCP orientation skill for broad SpeakSwiftly surface requests.
+- `skills/speak-swiftly-runtime-operator/`
+  Holds the runtime, queue, playback, and request-control skill.
+- `skills/speak-swiftly-voice-workflows/`
+  Holds the voice-profile, live-speech, and retained-artifact skill.
+- `skills/speak-swiftly-text-profiles/`
+  Holds the text-normalization, stored-profile, and replacement-authoring skill.
+
 ## Current Cleanup Follow-Through
 
 - Keep same-type `ServerHost` extensions as the preferred split mechanism for host refactors. Do not introduce helper coordinators or wrapper objects unless a real ownership boundary changes.

--- a/skills/speak-swiftly-mcp/SKILL.md
+++ b/skills/speak-swiftly-mcp/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: speak-swiftly-mcp
+description: Use when a user wants general help with the SpeakSwiftlyServer MCP surface, including broad requests to inspect runtime state, read replies aloud, manage voice or text profiles, or decide which SpeakSwiftly MCP workflow to use. This skill is the orientation layer for the local `speak_swiftly` MCP server and routes work into the narrower runtime, voice, and text-profile skills.
+---
+
+# SpeakSwiftly MCP
+
+Use this skill as the first orientation pass when the request is about the SpeakSwiftly MCP surface broadly rather than one narrow operation.
+
+## Start Here
+
+- Treat the local `speak_swiftly` MCP server from this repository's [`.mcp.json`](../../.mcp.json) as the default surface.
+- For a broad status question, read `get_runtime_overview` first.
+- For a "what can this surface do?" question, use [API.md](../../API.md) first, then the current source-of-truth catalog files:
+  - [MCPToolCatalog.swift](../../Sources/SpeakSwiftlyServer/MCP/MCPToolCatalog.swift)
+  - [MCPResources.swift](../../Sources/SpeakSwiftlyServer/MCP/MCPResources.swift)
+  - [MCPPromptCatalog.swift](../../Sources/SpeakSwiftlyServer/MCP/MCPPromptCatalog.swift)
+
+## Workflow Split
+
+- Runtime, queue, playback, request tracking, backend switching, and cancellation:
+  Use `$speak-swiftly-runtime-operator`.
+- Voice creation, voice selection, live speech, retained files, and retained batches:
+  Use `$speak-swiftly-voice-workflows`.
+- Text normalization styles, stored text profiles, and replacement authoring:
+  Use `$speak-swiftly-text-profiles`.
+
+## General Operating Rules
+
+- Prefer resources for orientation and verification, then use tools for mutations.
+- When a tool returns `request_id`, follow it with `speak://requests/{request_id}` or `get_runtime_overview` instead of guessing whether the work finished.
+- Distinguish generation backlog from playback backlog. A request can be done generating and still be queued for playback.
+- Do not silently substitute a different voice profile when the requested profile is missing unless the user explicitly asks for fallback behavior.
+- When repository docs and the live MCP server seem out of sync, trust the current source files in `Sources/SpeakSwiftlyServer/MCP/` over older prose.

--- a/skills/speak-swiftly-mcp/agents/openai.yaml
+++ b/skills/speak-swiftly-mcp/agents/openai.yaml
@@ -1,0 +1,15 @@
+interface:
+  display_name: "SpeakSwiftly MCP"
+  short_description: "Orient Codex on the SpeakSwiftly MCP surface."
+  default_prompt: "Use $speak-swiftly-mcp to inspect the local SpeakSwiftly MCP surface and choose the right workflow."
+
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "speak_swiftly"
+      description: "Local SpeakSwiftlyServer MCP surface for runtime, speech, voice, and text-profile workflows."
+      transport: "streamable_http"
+      url: "http://127.0.0.1:7337/mcp"
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/speak-swiftly-runtime-operator/SKILL.md
+++ b/skills/speak-swiftly-runtime-operator/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: speak-swiftly-runtime-operator
+description: Use when a user wants to inspect or control the running SpeakSwiftlyServer MCP runtime, including readiness, queues, playback state, active requests, generation backlog, playback backlog, backend switching, model reloads, queue clearing, or request cancellation.
+---
+
+# SpeakSwiftly Runtime Operator
+
+Use this skill for operator-style runtime work on the local `speak_swiftly` MCP surface.
+
+## Primary Reads
+
+- Start with `get_runtime_overview` for any broad runtime question.
+- Use `get_runtime_status` when the user specifically needs the worker stage, resident-model state, or current backend.
+- Use `get_playback_state` when the question is about whether anything is actively playing.
+- Read `speak://requests` or `list_active_requests` when the user is asking about one specific tracked request or recent server work.
+
+## Queue And Request Triage
+
+- Use `list_generation_queue` for "what is still generating?"
+- Use `list_playback_queue` for "what is waiting to be heard?"
+- Use `speak://requests/{request_id}` after any accepted request or cancellation so the user can see the retained state directly.
+- When multiple similar requests exist, confirm the exact `request_id` from the resource before cancelling anything.
+
+## Control Operations
+
+- Use `pause_playback` or `resume_playback` only after confirming current playback state when that matters to the user.
+- Use `clear_playback_queue` only when the user wants to drop queued audible work broadly without stopping the active request.
+- Use `cancel_request` when the user wants one specific request stopped.
+- Use `switch_speech_backend` for an immediate backend flip on the running runtime.
+- Use `set_staged_config` when the user wants a different backend on the next restart without changing the current one.
+- Use `reload_models` or `unload_models` only when the user is explicitly asking about model residency or memory pressure.
+
+## Verification
+
+- After any mutation, read `get_runtime_overview` again so the response is grounded in the post-change state.
+- When a control path fails, cite the actual runtime or request snapshot instead of paraphrasing vaguely.
+- The playback and queue workflow guidance embedded in [MCPResources.swift](../../Sources/SpeakSwiftlyServer/MCP/MCPResources.swift) is the best repo-local explanation of intended operator flow.

--- a/skills/speak-swiftly-runtime-operator/agents/openai.yaml
+++ b/skills/speak-swiftly-runtime-operator/agents/openai.yaml
@@ -1,0 +1,15 @@
+interface:
+  display_name: "SpeakSwiftly Runtime"
+  short_description: "Operate runtime, queue, playback, and requests."
+  default_prompt: "Use $speak-swiftly-runtime-operator to inspect the local SpeakSwiftly runtime and control playback or queued work."
+
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "speak_swiftly"
+      description: "Local SpeakSwiftlyServer MCP surface for runtime state, queue inspection, and control actions."
+      transport: "streamable_http"
+      url: "http://127.0.0.1:7337/mcp"
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/speak-swiftly-text-profiles/SKILL.md
+++ b/skills/speak-swiftly-text-profiles/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: speak-swiftly-text-profiles
+description: Use when a user wants to inspect or change SpeakSwiftly text normalization through the MCP surface, including built-in style changes, active or stored text profiles, replacement authoring, persistence reload or save operations, and effective-profile verification before speech generation.
+---
+
+# SpeakSwiftly Text Profiles
+
+Use this skill for text-normalization work on the local `speak_swiftly` MCP surface.
+
+## Orientation
+
+- Start with `get_text_normalizer_snapshot` or `speak://text-profiles` for any broad question.
+- Use `get_text_profile_style` or `speak://text-profiles/style` when the user is really asking about the built-in normalization mode.
+- Use `speak://text-profiles/effective/{profile_id}` before speech generation when the user wants to verify what will actually be applied after profile merging.
+
+## Mutation Workflow
+
+- Use `set_text_profile_style` only when the user is intentionally changing the built-in balanced, compact, or explicit mode.
+- Use `create_text_profile` for a new stored reusable profile with a simple replacement list.
+- Use `store_text_profile` when the full stored profile payload is already known.
+- Use `use_text_profile` when the user wants a temporary active custom profile without changing the stored catalog.
+- Use `delete_text_profile` only after confirming the exact stored `profile_id`.
+- Use `reset_active_text_profile` when the user wants to clear the temporary active custom profile back to defaults.
+
+## Replacement Editing
+
+- Use `add_text_replacement`, `replace_text_replacement`, and `remove_text_replacement` for targeted rule edits.
+- Prefer `whole_token` for identifiers and acronyms, and `exact_phrase` for multi-word substitutions.
+- Be deliberate about whether a rule should run before or after built-in normalization.
+- Restrict `formats` when the user only wants the rule to affect source code, CLI output, or another narrow content kind.
+
+## Persistence
+
+- Use `save_text_profiles` when the user wants an explicit persistence checkpoint.
+- Use `load_text_profiles` when another process changed the underlying profile store and the runtime should refresh from disk.
+- The best repo-local authoring guidance for these flows lives in the text-profile guide embedded in [MCPResources.swift](../../Sources/SpeakSwiftlyServer/MCP/MCPResources.swift).

--- a/skills/speak-swiftly-text-profiles/agents/openai.yaml
+++ b/skills/speak-swiftly-text-profiles/agents/openai.yaml
@@ -1,0 +1,15 @@
+interface:
+  display_name: "SpeakSwiftly Text Profiles"
+  short_description: "Shape text normalization before speech generation."
+  default_prompt: "Use $speak-swiftly-text-profiles to inspect or edit SpeakSwiftly text normalization rules."
+
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "speak_swiftly"
+      description: "Local SpeakSwiftlyServer MCP surface for text-profile snapshots, replacement editing, and persistence."
+      transport: "streamable_http"
+      url: "http://127.0.0.1:7337/mcp"
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/speak-swiftly-voice-workflows/SKILL.md
+++ b/skills/speak-swiftly-voice-workflows/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: speak-swiftly-voice-workflows
+description: Use when a user wants SpeakSwiftly voice-profile or speech-generation help through the MCP surface, including voice creation from text or audio, profile listing, renaming, rerolling, deletion, immediate spoken playback, retained audio files, retained batches, and generation artifact tracking.
+---
+
+# SpeakSwiftly Voice Workflows
+
+Use this skill for voice selection, voice creation, and speech-generation work on the local `speak_swiftly` MCP surface.
+
+## Start Here
+
+- Read `list_voice_profiles` or `speak://voices` before creating, renaming, rerolling, deleting, or choosing a profile.
+- Use `speak://voices/{profile_name}` when the user is working on one specific stored voice.
+- If the user wants help designing a voice rather than executing immediately, prefer the prompt and guide flow documented in [MCPResources.swift](../../Sources/SpeakSwiftlyServer/MCP/MCPResources.swift).
+
+## Creation And Editing
+
+- Use `create_voice_profile_from_description` when the user has target sound qualities and source text.
+- Use `create_voice_profile_from_audio` when the user has reference audio. Provide `transcript` whenever the spoken words are already known.
+- Use `update_voice_profile_name` for a pure rename.
+- Use `reroll_voice_profile` when the user wants the same stored name rebuilt from its original inputs.
+- Use `delete_voice_profile` only after confirming the exact stored `profile_name`.
+
+## Speech And Artifacts
+
+- Use `generate_speech` when the user wants audible playback now.
+- Use `generate_audio_file` when the user wants a saved retained artifact instead of immediate playback.
+- Use `generate_batch` when the user wants multiple generated files under one voice profile.
+- Pass `text_profile_name` only when the user explicitly wants a stored normalization profile on that request.
+- Pass `text_format`, `nested_source_format`, or `source_format` when the input is code, structured output, or other content where automatic detection is likely to misread intent.
+
+## Tracking
+
+- After `generate_speech`, read `speak://requests/{request_id}` or `get_runtime_overview`.
+- After retained-file or batch requests, follow the returned job or artifact resource instead of assuming completion.
+- Use `list_generation_jobs`, `get_generation_job`, `list_generated_files`, `get_generated_file`, `list_generated_batches`, and `get_generated_batch` to inspect retained outputs.
+- Use `expire_generation_job` only when the user explicitly wants one retained generation job removed.

--- a/skills/speak-swiftly-voice-workflows/agents/openai.yaml
+++ b/skills/speak-swiftly-voice-workflows/agents/openai.yaml
@@ -1,0 +1,15 @@
+interface:
+  display_name: "SpeakSwiftly Voices"
+  short_description: "Create voices and generate spoken output."
+  default_prompt: "Use $speak-swiftly-voice-workflows to create or choose a SpeakSwiftly voice profile and generate speech."
+
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "speak_swiftly"
+      description: "Local SpeakSwiftlyServer MCP surface for voice profiles, live playback, and retained generation artifacts."
+      transport: "streamable_http"
+      url: "http://127.0.0.1:7337/mcp"
+
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
## Summary
- add a repo-tracked SpeakSwiftly MCP skill bundle with focused runtime, voice, and text-profile workflows
- advertise the repository itself as a local Codex plugin and populate the repo-local marketplace entry
- document the new plugin and skill surfaces in the README and maintainer source-layout doc

## Verification
- sh scripts/repo-maintenance/validate-all.sh
- sh scripts/repo-maintenance/release.sh --mode standard --version v3.2.0 --skip-live-service-refresh
- uv run --with pyyaml python /Users/galew/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/speak-swiftly-mcp
- uv run --with pyyaml python /Users/galew/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/speak-swiftly-runtime-operator
- uv run --with pyyaml python /Users/galew/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/speak-swiftly-voice-workflows
- uv run --with pyyaml python /Users/galew/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/speak-swiftly-text-profiles

## Notes
- The repo-local marketplace entry currently uses `source.path: "."` so the repository root itself is advertised as the plugin surface.
