### PR TITLE
docs: add codex hooks tts prototype

### DIFF
--- a/.codex/.gitignore
+++ b/.codex/.gitignore
@@ -1,0 +1,2 @@
+logs/
+state/

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,7 @@
+#:schema https://developers.openai.com/codex/config-schema.json
+
+[features]
+codex_hooks = true
+
+# Experimental probe: record whatever payload Codex sends to the notify command.
+notify = ["node", ".codex/hooks/notify-dump.mjs"]

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$(git rev-parse --show-toplevel)/.codex/hooks/stop-tts.mjs\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/notify-dump.mjs
+++ b/.codex/hooks/notify-dump.mjs
@@ -17,7 +17,17 @@ async function readStdin() {
 
 async function main() {
   await mkdir(logDir, { recursive: true });
+  const rawArg = process.argv[2] ?? "";
   const rawStdin = await readStdin();
+
+  let parsedArg = null;
+  if (rawArg.trim().length > 0) {
+    try {
+      parsedArg = JSON.parse(rawArg);
+    } catch {
+      parsedArg = rawArg;
+    }
+  }
 
   let parsedStdin = null;
   if (rawStdin.trim().length > 0) {
@@ -32,7 +42,9 @@ async function main() {
     timestamp: new Date().toISOString(),
     argv: process.argv,
     cwd: process.cwd(),
+    arg: parsedArg,
     stdin: parsedStdin,
+    event: parsedArg ?? parsedStdin,
     env: {
       TERM_PROGRAM: process.env.TERM_PROGRAM ?? null,
       TMUX: process.env.TMUX ?? null,

--- a/.codex/hooks/notify-dump.mjs
+++ b/.codex/hooks/notify-dump.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+import { mkdir, appendFile } from "node:fs/promises";
+import path from "node:path";
+
+const hookRoot = path.resolve(process.cwd(), ".codex");
+const logDir = path.join(hookRoot, "logs");
+const logPath = path.join(logDir, "notify-events.jsonl");
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+  }
+  return chunks.join("");
+}
+
+async function main() {
+  await mkdir(logDir, { recursive: true });
+  const rawStdin = await readStdin();
+
+  let parsedStdin = null;
+  if (rawStdin.trim().length > 0) {
+    try {
+      parsedStdin = JSON.parse(rawStdin);
+    } catch {
+      parsedStdin = rawStdin;
+    }
+  }
+
+  const entry = {
+    timestamp: new Date().toISOString(),
+    argv: process.argv,
+    cwd: process.cwd(),
+    stdin: parsedStdin,
+    env: {
+      TERM_PROGRAM: process.env.TERM_PROGRAM ?? null,
+      TMUX: process.env.TMUX ?? null,
+      CODEX_HOME: process.env.CODEX_HOME ?? null,
+    },
+  };
+
+  await appendFile(logPath, `${JSON.stringify(entry)}\n`, "utf8");
+}
+
+main().catch(async (error) => {
+  try {
+    await mkdir(logDir, { recursive: true });
+    await appendFile(
+      logPath,
+      `${JSON.stringify({
+        timestamp: new Date().toISOString(),
+        error: error instanceof Error ? { message: error.message, stack: error.stack } : String(error),
+      })}\n`,
+      "utf8",
+    );
+  } catch {}
+  process.exitCode = 0;
+});

--- a/.codex/hooks/stop-tts.mjs
+++ b/.codex/hooks/stop-tts.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile, appendFile } from "node:fs/promises";
+import path from "node:path";
+
+const hookRoot = path.resolve(process.cwd(), ".codex");
+const stateDir = path.join(hookRoot, "state");
+const logDir = path.join(hookRoot, "logs");
+const seenTurnsPath = path.join(stateDir, "stop-tts-seen-turns.json");
+const logPath = path.join(logDir, "stop-tts.jsonl");
+
+const runtimeBaseUrl = process.env.CODEX_HOOK_TTS_BASE_URL ?? "http://127.0.0.1:7337";
+const liveSpeechEndpoint = new URL("/speech/live", runtimeBaseUrl).toString();
+const defaultProfileName = process.env.CODEX_HOOK_TTS_PROFILE_NAME ?? "default-femme";
+const skipContinuedTurns = (process.env.CODEX_HOOK_TTS_SKIP_CONTINUATIONS ?? "true") !== "false";
+const maxSeenTurns = Number.parseInt(process.env.CODEX_HOOK_TTS_MAX_SEEN_TURNS ?? "200", 10);
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+  }
+  return chunks.join("");
+}
+
+async function ensureRuntimePaths() {
+  await mkdir(stateDir, { recursive: true });
+  await mkdir(logDir, { recursive: true });
+}
+
+async function loadSeenTurns() {
+  try {
+    const raw = await readFile(seenTurnsPath, "utf8");
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((item) => typeof item === "string") : [];
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+async function saveSeenTurns(turns) {
+  await writeFile(seenTurnsPath, `${JSON.stringify(turns.slice(-maxSeenTurns), null, 2)}\n`, "utf8");
+}
+
+async function appendLog(entry) {
+  const serialized = `${JSON.stringify({ timestamp: new Date().toISOString(), ...entry })}\n`;
+  await appendFile(logPath, serialized, "utf8");
+}
+
+function normalizeMessage(input) {
+  if (typeof input !== "string") return null;
+  const trimmed = input.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+async function main() {
+  await ensureRuntimePaths();
+
+  const rawInput = await readStdin();
+  const payload = rawInput.trim().length > 0 ? JSON.parse(rawInput) : {};
+  const {
+    session_id: sessionId = null,
+    turn_id: turnId = null,
+    stop_hook_active: stopHookActive = false,
+    last_assistant_message: lastAssistantMessage = null,
+    transcript_path: transcriptPath = null,
+    cwd = process.cwd(),
+    model = null,
+  } = payload;
+
+  const message = normalizeMessage(lastAssistantMessage);
+  const dedupeKey = sessionId && turnId ? `${sessionId}:${turnId}` : null;
+
+  if (!message) {
+    await appendLog({
+      outcome: "skipped",
+      reason: "missing-last-assistant-message",
+      sessionId,
+      turnId,
+      stopHookActive,
+      transcriptPath,
+      cwd,
+      model,
+    });
+    return;
+  }
+
+  if (skipContinuedTurns && stopHookActive) {
+    await appendLog({
+      outcome: "skipped",
+      reason: "continued-stop-turn",
+      sessionId,
+      turnId,
+      stopHookActive,
+      transcriptPath,
+      cwd,
+      model,
+      preview: message.slice(0, 160),
+    });
+    return;
+  }
+
+  const seenTurns = await loadSeenTurns();
+  if (dedupeKey && seenTurns.includes(dedupeKey)) {
+    await appendLog({
+      outcome: "skipped",
+      reason: "duplicate-turn",
+      sessionId,
+      turnId,
+      stopHookActive,
+      transcriptPath,
+      cwd,
+      model,
+      preview: message.slice(0, 160),
+    });
+    return;
+  }
+
+  const response = await fetch(liveSpeechEndpoint, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      text: message,
+      profile_name: defaultProfileName,
+    }),
+  });
+
+  const responseBody = await response.text();
+  if (!response.ok) {
+    await appendLog({
+      outcome: "error",
+      reason: "speech-route-rejected-request",
+      sessionId,
+      turnId,
+      stopHookActive,
+      transcriptPath,
+      cwd,
+      model,
+      status: response.status,
+      statusText: response.statusText,
+      responseBody,
+      profileName: defaultProfileName,
+      endpoint: liveSpeechEndpoint,
+      preview: message.slice(0, 160),
+    });
+    return;
+  }
+
+  if (dedupeKey) {
+    seenTurns.push(dedupeKey);
+    await saveSeenTurns(seenTurns);
+  }
+
+  let parsedResponse = null;
+  try {
+    parsedResponse = JSON.parse(responseBody);
+  } catch {
+    parsedResponse = responseBody;
+  }
+
+  await appendLog({
+    outcome: "queued",
+    sessionId,
+    turnId,
+    stopHookActive,
+    transcriptPath,
+    cwd,
+    model,
+    endpoint: liveSpeechEndpoint,
+    profileName: defaultProfileName,
+    request: parsedResponse,
+    preview: message.slice(0, 160),
+  });
+}
+
+main().catch(async (error) => {
+  try {
+    await ensureRuntimePaths();
+    await appendLog({
+      outcome: "error",
+      reason: "unexpected-hook-failure",
+      error: error instanceof Error ? { message: error.message, stack: error.stack } : String(error),
+    });
+  } catch {}
+  process.exitCode = 0;
+});

--- a/docs/codex-hooks-tts.md
+++ b/docs/codex-hooks-tts.md
@@ -1,0 +1,49 @@
+# Codex Hooks TTS Prototype
+
+This worktree includes a small repo-local Codex prototype for speaking final
+assistant replies and inspecting Codex notification payloads.
+
+## Files
+
+- `.codex/config.toml`
+  Enables `features.codex_hooks = true` for this trusted project and wires a
+  `notify` probe command.
+- `.codex/hooks.json`
+  Registers one `Stop` hook handler.
+- `.codex/hooks/stop-tts.mjs`
+  Reads the Codex `Stop` payload from `stdin`, skips empty or duplicate turns,
+  ignores continuation passes by default, and queues speech through the local
+  `SpeakSwiftlyServer` HTTP route at `POST /speech/live`.
+- `.codex/hooks/notify-dump.mjs`
+  Records whatever Codex passes to the `notify` command so we can inspect the
+  real payload shape.
+- `.codex/logs/stop-tts.jsonl`
+  Runtime log for queued, skipped, and failed TTS attempts.
+- `.codex/logs/notify-events.jsonl`
+  Runtime log for `notify` payload inspection.
+- `.codex/state/stop-tts-seen-turns.json`
+  Dedupe state keyed by `session_id + turn_id`.
+
+## Environment Overrides
+
+The `Stop` hook script accepts a few optional environment overrides:
+
+- `CODEX_HOOK_TTS_BASE_URL`
+  Override the default `http://127.0.0.1:7337`.
+- `CODEX_HOOK_TTS_PROFILE_NAME`
+  Override the default voice profile name `default-femme`.
+- `CODEX_HOOK_TTS_SKIP_CONTINUATIONS`
+  Defaults to `true`. Set to `false` if you want continued `Stop` turns read
+  aloud too.
+- `CODEX_HOOK_TTS_MAX_SEEN_TURNS`
+  Controls how many dedupe keys are retained in the local state file.
+
+## Validation Notes
+
+The current prototype was validated with a synthetic `Stop` payload and queued a
+live speech request successfully against the local server.
+
+The current `notify` probe was only validated with synthetic JSON over `stdin`.
+The Codex docs say the notify command receives a JSON payload, but they do not
+currently document the exact runtime shape, so the probe intentionally records
+raw input instead of assuming field names.

--- a/docs/codex-hooks-tts.md
+++ b/docs/codex-hooks-tts.md
@@ -16,7 +16,9 @@ assistant replies and inspecting Codex notification payloads.
   `SpeakSwiftlyServer` HTTP route at `POST /speech/live`.
 - `.codex/hooks/notify-dump.mjs`
   Records whatever Codex passes to the `notify` command so we can inspect the
-  real payload shape.
+  real payload shape. The probe captures both the documented JSON argument and
+  any unexpected stdin payload so we can compare real behavior across Codex
+  surfaces.
 - `.codex/logs/stop-tts.jsonl`
   Runtime log for queued, skipped, and failed TTS attempts.
 - `.codex/logs/notify-events.jsonl`
@@ -43,7 +45,7 @@ The `Stop` hook script accepts a few optional environment overrides:
 The current prototype was validated with a synthetic `Stop` payload and queued a
 live speech request successfully against the local server.
 
-The current `notify` probe was only validated with synthetic JSON over `stdin`.
-The Codex docs say the notify command receives a JSON payload, but they do not
-currently document the exact runtime shape, so the probe intentionally records
-raw input instead of assuming field names.
+The current `notify` probe was validated with synthetic JSON passed both as the
+documented command-line argument and over `stdin`. The current Codex docs say
+the notify command receives a single JSON argument, so the probe now logs both
+paths in case any Codex surface differs in practice.


### PR DESCRIPTION
## Summary
- add a repo-local Codex hooks prototype for `Stop`-driven TTS via the local HTTP speech route
- add a `notify` probe that captures the documented JSON argument path plus stdin fallback logging
- document the hook wiring, payload assumptions, and local validation notes

## Verification
- validated `stop-tts.mjs` with a synthetic `Stop` payload against `POST /speech/live`
- validated `notify-dump.mjs` with synthetic JSON passed both as a command-line argument and over stdin
