### PR TITLE
plugin: rename SpeakSwiftly plugin display surface

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "speak-swiftly-server-local",
   "interface": {
-    "displayName": "SpeakSwiftlyServer Local Plugins"
+    "displayName": "SpeakSwiftly Local Plugins"
   },
   "plugins": [
     {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "speak-swiftly-server",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Repo-local Codex plugin for the SpeakSwiftlyServer MCP surface, focused operator skills, and shared local MCP configuration.",
   "author": {
     "name": "Gale",
@@ -21,7 +21,7 @@
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "interface": {
-    "displayName": "SpeakSwiftlyServer",
+    "displayName": "SpeakSwiftly",
     "shortDescription": "Local speech and playback workflows for Codex.",
     "longDescription": "Repo-local Codex plugin for the SpeakSwiftlyServer MCP surface, including focused skills for runtime operation, voice workflows, and text-profile authoring.",
     "developerName": "Gale",

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,7 @@
     "speak_swiftly": {
       "type": "http",
       "url": "http://127.0.0.1:7337/mcp",
-      "note": "Connects to the local SpeakSwiftlyServer MCP surface exposed by the shared HTTP server. Expected local defaults are APP_MCP_ENABLED=true, APP_MCP_PATH=/mcp, and APP_PORT=7337."
+      "note": "Connects to the local SpeakSwiftlyServer MCP surface exposed by the shared HTTP server. The usual live local service listens on APP_PORT=7337 with APP_MCP_PATH=/mcp, but built-in runtime defaults keep APP_MCP_ENABLED=false until MCP is turned on through APP_CONFIG_FILE or APP_MCP_ENABLED=true."
     }
   }
 }


### PR DESCRIPTION
Why:
Bring the repo-local plugin display name in line with the intended SpeakSwiftly surface name and fix the checked-in MCP note while keeping the child marketplace label consistent.

Verification:
- verified .codex-plugin/plugin.json now reports displayName "SpeakSwiftly" and version 2.1.1
- verified .mcp.json still parses as valid JSON
- pushed the subtree branch to gaelic-ghost/SpeakSwiftlyServer