### PR TITLE
release: prepare v3.3.0

### DIFF
--- a/.codex/hooks/stop-tts.mjs
+++ b/.codex/hooks/stop-tts.mjs
@@ -15,6 +15,7 @@ const runtimeBaseUrl = process.env.CODEX_HOOK_TTS_BASE_URL ?? "http://127.0.0.1:
 const liveSpeechEndpoint = new URL("/speech/live", runtimeBaseUrl).toString();
 const defaultProfileName = process.env.CODEX_HOOK_TTS_PROFILE_NAME ?? "default-femme";
 const skipContinuedTurns = (process.env.CODEX_HOOK_TTS_SKIP_CONTINUATIONS ?? "true") !== "false";
+const logFullPayload = (process.env.CODEX_HOOK_TTS_LOG_FULL_PAYLOAD ?? "true") !== "false";
 const maxSeenTurns = Number.parseInt(process.env.CODEX_HOOK_TTS_MAX_SEEN_TURNS ?? "200", 10);
 
 async function readStdin() {
@@ -58,6 +59,14 @@ function normalizeMessage(input) {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function payloadLogFields(rawInput, payload) {
+  if (!logFullPayload) return {};
+  return {
+    rawPayload: rawInput,
+    payload,
+  };
+}
+
 async function main() {
   await ensureRuntimePaths();
 
@@ -72,6 +81,7 @@ async function main() {
     cwd = process.cwd(),
     model = null,
   } = payload;
+  const fullPayloadLog = payloadLogFields(rawInput, payload);
 
   const message = normalizeMessage(lastAssistantMessage);
   const dedupeKey = sessionId && turnId ? `${sessionId}:${turnId}` : null;
@@ -86,6 +96,7 @@ async function main() {
       transcriptPath,
       cwd,
       model,
+      ...fullPayloadLog,
     });
     return;
   }
@@ -101,6 +112,7 @@ async function main() {
       cwd,
       model,
       preview: message.slice(0, 160),
+      ...fullPayloadLog,
     });
     return;
   }
@@ -117,6 +129,7 @@ async function main() {
       cwd,
       model,
       preview: message.slice(0, 160),
+      ...fullPayloadLog,
     });
     return;
   }
@@ -149,6 +162,7 @@ async function main() {
       profileName: defaultProfileName,
       endpoint: liveSpeechEndpoint,
       preview: message.slice(0, 160),
+      ...fullPayloadLog,
     });
     return;
   }
@@ -177,15 +191,18 @@ async function main() {
     profileName: defaultProfileName,
     request: parsedResponse,
     preview: message.slice(0, 160),
+    ...fullPayloadLog,
   });
 }
 
 main().catch(async (error) => {
   try {
     await ensureRuntimePaths();
+    const rawInput = await readStdin().catch(() => "");
     await appendLog({
       outcome: "error",
       reason: "unexpected-hook-failure",
+      ...(logFullPayload ? { rawPayload: rawInput } : {}),
       error: error instanceof Error ? { message: error.message, stack: error.stack } : String(error),
     });
   } catch {}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a81143250d5fbc334f03f522aad042f0af6b6e7e978371d15f3a342622a396ea",
+  "originHash" : "b5514178fdc5323011dbc28ac8a414abe1adbe613ff5b16086d9c03987a6254f",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/mlx-audio-swift.git",
       "state" : {
-        "revision" : "b0a75a89562c8514d68892498955354a62380b83",
-        "version" : "69.1.3"
+        "revision" : "ce483e503595c2e01a11efaa6716ffd1ebc496c1",
+        "version" : "69.1.5"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/SpeakSwiftly.git",
       "state" : {
-        "revision" : "0651a03834f5a5ba4c6662b42ef6167a2ffcdaf0",
-        "version" : "3.0.5"
+        "revision" : "4f8be62437a8b5adebb3ce29337fe516ad29b37a",
+        "version" : "3.0.6"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
         .package(
             url: "https://github.com/gaelic-ghost/SpeakSwiftly.git",
-            from: "3.0.5",
+            from: "3.0.6",
         ),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "2.30.6"),
         .package(url: "https://github.com/gaelic-ghost/TextForSpeech.git", from: "0.17.0"),

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The package stays intentionally narrow. Hummingbird owns transport hosting, `Spe
 
 ### Current SpeakSwiftly Alignment
 
-This server is aligned to the current public library surface of its resolved [`SpeakSwiftly`](https://github.com/gaelic-ghost/SpeakSwiftly) `3.0.5` package dependency.
+This server is aligned to the current public library surface of its resolved [`SpeakSwiftly`](https://github.com/gaelic-ghost/SpeakSwiftly) `3.0.6` package dependency.
 
 Today the server relies on the current typed runtime capabilities that matter for transport hosting:
 
@@ -98,11 +98,13 @@ That alignment means the remaining translation layer is intentionally transport-
 
 For generation requests, the server also supports one server-owned default voice profile. HTTP and MCP callers may omit `profile_name` for live speech, retained audio, and retained batch requests when the server has `app.defaultVoiceProfileName` or `APP_DEFAULT_VOICE_PROFILE_NAME` configured. When neither the request nor the server configuration provides a voice profile, the server rejects the request with a descriptive validation error instead of silently guessing.
 
+Across the HTTP, MCP, tool-catalog, and embedded control surfaces, the server now publishes the normalized backend identifiers `qwen3`, `chatterbox_turbo`, and `marvis`. Compatibility input using the older `qwen3_custom_voice` backend name is still accepted on transport-facing runtime-control requests and is normalized to `qwen3` before persistence or response shaping.
+
 That narrowness also informs platform policy. The package should prefer maintainable Apple-platform architecture for the current macOS and near-future iOS use cases over speculative cross-platform compromises.
 
 ## Setup
 
-This package resolves its SwiftPM dependencies from GitHub source control in [`Package.swift`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/Package.swift) and locks the resolved revisions in [`Package.resolved`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/Package.resolved). `SpeakSwiftly` uses a normal semantic-version requirement here, and this package currently follows it with an up-to-next-major constraint starting at `3.0.5`. The server's direct `TextForSpeech` dependency now tracks `0.17.0`, matching the current upstream `SpeakSwiftly` graph.
+This package resolves its SwiftPM dependencies from GitHub source control in [`Package.swift`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/Package.swift) and locks the resolved revisions in [`Package.resolved`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/Package.resolved). `SpeakSwiftly` uses a normal semantic-version requirement here, and this package currently follows it with an up-to-next-major constraint starting at `3.0.6`. The server's direct `TextForSpeech` dependency now tracks `0.17.0`, matching the current upstream `SpeakSwiftly` graph.
 
 Build the package with SwiftPM through Xcode's selected toolchain:
 

--- a/Sources/SpeakSwiftlyServer/Host/ServerModels.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerModels.swift
@@ -3,6 +3,20 @@ import Hummingbird
 import SpeakSwiftly
 import TextForSpeech
 
+// MARK: - Speech Backend Surface Helpers
+
+func exposedSpeechBackendIdentifiers() -> [String] {
+    SpeakSwiftly.SpeechBackend.allCases.map(\.rawValue)
+}
+
+func supportedSpeechBackendDescription() -> String {
+    exposedSpeechBackendIdentifiers().joined(separator: ", ")
+}
+
+func legacySpeechBackendNormalizationNote() -> String {
+    "The legacy value '\(SpeakSwiftly.SpeechBackend.legacyQwenCustomVoiceRawValue)' is still accepted and normalized to 'qwen3'."
+}
+
 // MARK: - SpeakRequestPayload
 
 struct SpeakRequestPayload: Decodable {
@@ -303,11 +317,10 @@ private func resolveSpeechBackend(
     _ rawValue: String,
     fieldName: String,
 ) throws -> SpeakSwiftly.SpeechBackend {
-    guard let speechBackend = SpeakSwiftly.SpeechBackend(rawValue: rawValue) else {
-        let supportedBackends = SpeakSwiftly.SpeechBackend.allCases.map(\.rawValue).joined(separator: ", ")
+    guard let speechBackend = SpeakSwiftly.SpeechBackend.normalized(rawValue: rawValue) else {
         throw HTTPError(
             .badRequest,
-            message: "Runtime configuration field '\(fieldName)' used unsupported value '\(rawValue)'. Expected one of: \(supportedBackends).",
+            message: "Runtime configuration field '\(fieldName)' used unsupported value '\(rawValue)'. Expected one of: \(supportedSpeechBackendDescription()). \(legacySpeechBackendNormalizationNote())",
         )
     }
 

--- a/Sources/SpeakSwiftlyServer/MCP/MCPToolCatalog.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPToolCatalog.swift
@@ -149,7 +149,7 @@ enum MCPToolCatalog {
                 "type": "object",
                 "required": ["speech_backend"],
                 "properties": [
-                    "speech_backend": ["type": "string", "enum": ["qwen3", "marvis"]],
+                    "speech_backend": ["type": "string", "enum": ["qwen3", "chatterbox_turbo", "marvis"]],
                 ],
             ],
         ),
@@ -160,7 +160,7 @@ enum MCPToolCatalog {
                 "type": "object",
                 "required": ["speech_backend"],
                 "properties": [
-                    "speech_backend": ["type": "string", "enum": ["qwen3", "marvis"]],
+                    "speech_backend": ["type": "string", "enum": ["qwen3", "chatterbox_turbo", "marvis"]],
                 ],
             ],
         ),

--- a/Sources/SpeakSwiftlyServer/MCP/MCPToolSupport.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPToolSupport.swift
@@ -139,10 +139,9 @@ func requiredSpeechBackend(
     in arguments: [String: Value],
 ) throws -> SpeakSwiftly.SpeechBackend {
     let rawValue = try requiredString(key, in: arguments)
-    guard let speechBackend = SpeakSwiftly.SpeechBackend(rawValue: rawValue) else {
-        let acceptedValues = SpeakSwiftly.SpeechBackend.allCases.map(\.rawValue).joined(separator: ", ")
+    guard let speechBackend = SpeakSwiftly.SpeechBackend.normalized(rawValue: rawValue) else {
         throw MCPError.invalidParams(
-            "Tool argument '\(key)' used unsupported value '\(rawValue)'. Expected one of: \(acceptedValues).",
+            "Tool argument '\(key)' used unsupported value '\(rawValue)'. Expected one of: \(supportedSpeechBackendDescription()). \(legacySpeechBackendNormalizationNote())",
         )
     }
 

--- a/Tests/SpeakSwiftlyServerTests/HTTPWorkflowTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/HTTPWorkflowTests.swift
@@ -72,6 +72,28 @@ extension ServerTests {
             #expect(updateRuntimeConfigJSON["persisted_speech_backend"] as? String == "marvis")
             #expect(updateRuntimeConfigJSON["persisted_configuration_state"] as? String == "loaded")
 
+            let updateChatterboxRuntimeConfigResponse = try await client.execute(
+                uri: "/runtime/configuration",
+                method: .put,
+                headers: [.contentType: "application/json"],
+                body: byteBuffer(#"{"speech_backend":"chatterbox_turbo"}"#),
+            )
+            let updateChatterboxRuntimeConfigJSON = try jsonObject(from: updateChatterboxRuntimeConfigResponse.body)
+            #expect(updateChatterboxRuntimeConfigResponse.status == .ok)
+            #expect(updateChatterboxRuntimeConfigJSON["next_runtime_speech_backend"] as? String == "chatterbox_turbo")
+            #expect(updateChatterboxRuntimeConfigJSON["persisted_speech_backend"] as? String == "chatterbox_turbo")
+
+            let updateLegacyQwenRuntimeConfigResponse = try await client.execute(
+                uri: "/runtime/configuration",
+                method: .put,
+                headers: [.contentType: "application/json"],
+                body: byteBuffer(#"{"speech_backend":"qwen3_custom_voice"}"#),
+            )
+            let updateLegacyQwenRuntimeConfigJSON = try jsonObject(from: updateLegacyQwenRuntimeConfigResponse.body)
+            #expect(updateLegacyQwenRuntimeConfigResponse.status == .ok)
+            #expect(updateLegacyQwenRuntimeConfigJSON["next_runtime_speech_backend"] as? String == "qwen3")
+            #expect(updateLegacyQwenRuntimeConfigJSON["persisted_speech_backend"] as? String == "qwen3")
+
             let profilesResponse = try await client.execute(uri: "/voices", method: .get)
             let profilesJSON = try jsonObject(from: profilesResponse.body)
             let profiles = try #require(profilesJSON["profiles"] as? [[String: Any]])
@@ -357,7 +379,9 @@ extension ServerTests {
             #expect(persistMessage.contains("speech_backend"))
             #expect(persistMessage.contains("totally_invalid"))
             #expect(persistMessage.contains("qwen3"))
+            #expect(persistMessage.contains("chatterbox_turbo"))
             #expect(persistMessage.contains("marvis"))
+            #expect(persistMessage.contains("qwen3_custom_voice"))
 
             let switchResponse = try await client.execute(
                 uri: "/runtime/backend",
@@ -372,7 +396,9 @@ extension ServerTests {
             #expect(switchMessage.contains("speech_backend"))
             #expect(switchMessage.contains("totally_invalid"))
             #expect(switchMessage.contains("qwen3"))
+            #expect(switchMessage.contains("chatterbox_turbo"))
             #expect(switchMessage.contains("marvis"))
+            #expect(switchMessage.contains("qwen3_custom_voice"))
         }
 
         await host.shutdown()

--- a/Tests/SpeakSwiftlyServerTests/HostStateTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/HostStateTests.swift
@@ -399,10 +399,10 @@ import Testing
     #expect(await host.defaultVoiceProfileName() == nil)
     #expect(await host.resolvedRequestedVoiceProfileName(nil) == nil)
 
-    let switchedSnapshot = try await state.switchSpeechBackend(to: .marvis)
-    #expect(switchedSnapshot.runtimeConfiguration.activeRuntimeSpeechBackend == "marvis")
+    let switchedSnapshot = try await state.switchSpeechBackend(to: .chatterboxTurbo)
+    #expect(switchedSnapshot.runtimeConfiguration.activeRuntimeSpeechBackend == "chatterbox_turbo")
     let runtimeConfigurationAfterSwitch = await MainActor.run { state.runtimeConfiguration }
-    #expect(runtimeConfigurationAfterSwitch.activeRuntimeSpeechBackend == "marvis")
+    #expect(runtimeConfigurationAfterSwitch.activeRuntimeSpeechBackend == "chatterbox_turbo")
 
     let reloadedSnapshot = try await state.reloadModels()
     #expect(reloadedSnapshot.overview.workerStage == "resident_model_ready")

--- a/Tests/SpeakSwiftlyServerTests/MCPCatalogListingTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/MCPCatalogListingTests.swift
@@ -28,6 +28,12 @@ extension ServerTests {
             #expect(tools.contains { $0["name"] as? String == "get_staged_runtime_config" })
             #expect(tools.contains { $0["name"] as? String == "set_staged_config" })
             #expect(tools.contains { $0["name"] as? String == "get_runtime_overview" })
+            let setStagedConfigTool = try #require(tools.first { $0["name"] as? String == "set_staged_config" })
+            let setStagedConfigSchema = try #require(setStagedConfigTool["inputSchema"] as? [String: Any])
+            let setStagedConfigProperties = try #require(setStagedConfigSchema["properties"] as? [String: Any])
+            let setStagedConfigBackend = try #require(setStagedConfigProperties["speech_backend"] as? [String: Any])
+            let setStagedConfigBackendEnum = try #require(setStagedConfigBackend["enum"] as? [String])
+            #expect(setStagedConfigBackendEnum == ["qwen3", "chatterbox_turbo", "marvis"])
 
             let listResourcesEnvelope = try await mcpEnvelope(
                 from: mcpSurface.handle(

--- a/Tests/SpeakSwiftlyServerTests/MCPCatalogRuntimeTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/MCPCatalogRuntimeTests.swift
@@ -234,6 +234,36 @@ extension ServerTests {
             #expect(setRuntimeConfigPayload["active_runtime_speech_backend"] as? String == "qwen3")
             #expect(setRuntimeConfigPayload["next_runtime_speech_backend"] as? String == "marvis")
             #expect(setRuntimeConfigPayload["persisted_speech_backend"] as? String == "marvis")
+
+            let setChatterboxRuntimeConfigEnvelope = try await mcpEnvelope(
+                from: mcpSurface.handle(
+                    mcpPOSTRequest(
+                        body: mcpCallToolRequestJSON(
+                            name: "set_staged_config",
+                            arguments: ["speech_backend": "chatterbox_turbo"],
+                        ),
+                        sessionID: sessionID,
+                    ),
+                ),
+            )
+            let setChatterboxRuntimeConfigPayload = try mcpToolPayload(from: setChatterboxRuntimeConfigEnvelope)
+            #expect(setChatterboxRuntimeConfigPayload["next_runtime_speech_backend"] as? String == "chatterbox_turbo")
+            #expect(setChatterboxRuntimeConfigPayload["persisted_speech_backend"] as? String == "chatterbox_turbo")
+
+            let setLegacyQwenRuntimeConfigEnvelope = try await mcpEnvelope(
+                from: mcpSurface.handle(
+                    mcpPOSTRequest(
+                        body: mcpCallToolRequestJSON(
+                            name: "set_staged_config",
+                            arguments: ["speech_backend": "qwen3_custom_voice"],
+                        ),
+                        sessionID: sessionID,
+                    ),
+                ),
+            )
+            let setLegacyQwenRuntimeConfigPayload = try mcpToolPayload(from: setLegacyQwenRuntimeConfigEnvelope)
+            #expect(setLegacyQwenRuntimeConfigPayload["next_runtime_speech_backend"] as? String == "qwen3")
+            #expect(setLegacyQwenRuntimeConfigPayload["persisted_speech_backend"] as? String == "qwen3")
         }
     }
 }

--- a/docs/maintainers/speakswiftly-api-coverage-matrix.md
+++ b/docs/maintainers/speakswiftly-api-coverage-matrix.md
@@ -10,7 +10,7 @@ It answers three concrete questions:
 2. Which public capabilities are intentionally adapted instead of mirrored exactly?
 3. Which transport is the right client contract for each capability: HTTP, MCP, both, or neither?
 
-Current baseline checked against the `SpeakSwiftly 3.0.4` package state resolved by this repository on `2026-04-14`. The root package now follows `SpeakSwiftly` with an up-to-next-major semantic-version requirement starting at `3.0.4`.
+Current baseline checked against the `SpeakSwiftly 3.0.6` package state resolved by this repository on `2026-04-17`. The root package now follows `SpeakSwiftly` with an up-to-next-major semantic-version requirement starting at `3.0.6`.
 
 ## Summary
 
@@ -21,6 +21,12 @@ Current baseline checked against the `SpeakSwiftly 3.0.4` package state resolved
 - runtime overview, runtime status, backend switching, and model reload or unload controls
 - text-normalizer built-in style, state, persistence, and replacement editing
 - generation queue, playback queue, playback state, queue clearing, request cancellation, retained request inspection, and retained generation artifacts
+
+The server's normalized backend contract is now:
+
+- published backend identifiers: `qwen3`, `chatterbox_turbo`, `marvis`
+- compatibility alias accepted on HTTP and MCP runtime-control input: `qwen3_custom_voice`
+- compatibility alias response behavior: always normalized back to `qwen3`
 
 What remains intentionally non-parity:
 
@@ -40,7 +46,7 @@ That means the server is best understood as a transport adapter over the public 
 | `runtime.statusEvents()` | Adapted | `GET /healthz`, `GET /readyz`, `GET /runtime/host`, `GET /runtime/status`, `GET /requests/{request_id}/events` | `get_runtime_overview`, `get_runtime_status`, live resources and subscriptions | Exposed through host snapshots, retained request history, and typed resource updates instead of raw streams. |
 | `runtime.overview()` | Full | `GET /runtime/host` | `get_runtime_overview`, `speak://runtime/overview` | The host now trusts the atomic runtime overview instead of reconstructing queue or playback state locally. |
 | `runtime.status()` | Full | `GET /runtime/status` | `get_runtime_status`, `speak://runtime/status` | Returned directly as runtime status data with transport-local shaping only. |
-| `runtime.switchSpeechBackend(to:)` | Full | `POST /runtime/backend` | `switch_speech_backend` | Hot-switches the active backend. |
+| `runtime.switchSpeechBackend(to:)` | Full | `POST /runtime/backend` | `switch_speech_backend` | Hot-switches the active backend. Transport-facing input accepts `qwen3`, `chatterbox_turbo`, and `marvis`, and still normalizes legacy `qwen3_custom_voice` input onto `qwen3`. |
 | `runtime.reloadModels()` / `runtime.unloadModels()` | Full | `POST /runtime/models/reload`, `POST /runtime/models/unload` | `reload_models`, `unload_models` | Immediate runtime-control operations. |
 | `runtime.generate.speech(...)` | Full | `POST /speech/live` | `generate_speech` | Carries `text_profile_name`, `cwd`, `repo_root`, `text_format`, `nested_source_format`, and `source_format`. |
 | `runtime.generate.audio(...)` | Full | `POST /speech/files` | `generate_audio_file` | Retains generated file artifacts for later reads. |

--- a/docs/maintainers/v3.3.0-release-checklist.md
+++ b/docs/maintainers/v3.3.0-release-checklist.md
@@ -1,0 +1,59 @@
+# `v3.3.0` Release Checklist
+
+## Purpose
+
+This checklist is the maintainer-facing candidate path for the next minor release after `v3.2.5`.
+
+Use it when the release scope is the `SpeakSwiftly 3.0.6` dependency refresh plus the server-surface backend-alignment pass that now publishes `chatterbox_turbo` and normalizes legacy `qwen3_custom_voice` transport input onto `qwen3`.
+
+For the standing branch-versus-main release contract, keep using [release-workflow.md](./release-workflow.md). This document is only the candidate-specific checklist and release-shape note for `v3.3.0`.
+
+## Proposed Release Number
+
+Target the next release as `v3.3.0`.
+
+That minor bump matches the current change shape:
+
+- additive runtime dependency refresh to `SpeakSwiftly 3.0.6`
+- additive `chatterbox_turbo` exposure across HTTP, MCP, tool-catalog, and embedded runtime-control surfaces
+- additive transport normalization for legacy `qwen3_custom_voice` input
+- additive server-surface capability expansion that changes the published backend contract materially enough to deserve a visible minor release instead of a quiet patch
+
+## Pre-Tag Checklist
+
+- keep the worktree clean before release preparation or publish
+- confirm the default package lane still passes:
+
+```bash
+xcrun swift build
+xcrun swift test
+```
+
+- run the opt-in live suite for the release candidate:
+
+```bash
+SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test
+```
+
+- confirm the runtime-control surfaces now expose the expected normalized backend contract:
+  - published options: `qwen3`, `chatterbox_turbo`, `marvis`
+  - compatibility alias still accepted on HTTP and MCP runtime-control requests: `qwen3_custom_voice`
+  - normalized response and persisted value after alias input: `qwen3`
+
+## Suggested Release Notes Shape
+
+Center the release notes on four points:
+
+- the `SpeakSwiftly 3.0.6` dependency refresh
+- first-class `chatterbox_turbo` exposure on the server runtime-control surfaces
+- transport normalization of legacy Qwen backend input to `qwen3`
+- documentation and coverage-matrix refresh to keep the published contract honest
+
+## Publish Reminder
+
+If this candidate moves forward, use the split release workflow rather than tagging directly from a feature branch:
+
+1. run `scripts/repo-maintenance/release-prepare.sh --version v3.3.0` from the release branch or worktree candidate
+2. let the PR merge back to `main`
+3. fast-forward local `main`
+4. run `scripts/repo-maintenance/release-publish.sh --version v3.3.0`

--- a/docs/maintainers/v3.3.0-release-notes.md
+++ b/docs/maintainers/v3.3.0-release-notes.md
@@ -1,0 +1,28 @@
+# v3.3.0 Release Notes
+
+## What changed
+
+- refreshed the resolved runtime dependency to [`SpeakSwiftly` `3.0.6`](https://github.com/gaelic-ghost/SpeakSwiftly/blob/v3.0.6/docs/releases/v3-0-6-release-notes.md) and the matching upstream `mlx-audio-swift` graph that release now carries
+- exposed `chatterbox_turbo` as a first-class backend option across the server's published runtime-control surfaces, including HTTP runtime routes, MCP tool schemas, and the app-facing embedded session control model
+- normalized transport-facing backend input so older `qwen3_custom_voice` requests are still accepted on HTTP and MCP runtime-control paths but are persisted and reported back as `qwen3`
+- refreshed the maintainer-facing API coverage notes and README so the documented backend contract now matches the resolved `SpeakSwiftly` surface
+
+## Migration or upgrade notes
+
+- published backend identifiers are now `qwen3`, `chatterbox_turbo`, and `marvis`
+- compatibility callers may continue sending `qwen3_custom_voice` on transport-facing runtime-control requests, but the server now treats that value as a legacy alias and normalizes it to `qwen3` in persisted configuration and returned snapshots
+- `chatterbox_turbo` is currently the `SpeakSwiftly` resident Chatterbox path, so its backend-specific behavior and current English-only constraint come from the upstream library rather than server-local translation logic
+
+## Verification performed
+
+```bash
+xcrun swift build
+```
+
+```bash
+xcrun swift test
+```
+
+```bash
+SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test
+```


### PR DESCRIPTION
## Release Prepare

- prepares release candidate `v3.3.0`
- stages the local artifact under `.release-artifacts/v3.3.0`
- leaves final tag creation and GitHub release publication for `scripts/repo-maintenance/release-publish.sh` after this pull request lands on `main`

## Publish Follow-Up

After this pull request merges, switch to `main` locally and run:

```bash
scripts/repo-maintenance/release-publish.sh --version v3.3.0 --skip-live-service-refresh
```
