### PR TITLE
release: prepare v4.0.0

### DIFF
--- a/Tests/SpeakSwiftlyServerE2ETests/E2EServerProcess.swift
+++ b/Tests/SpeakSwiftlyServerE2ETests/E2EServerProcess.swift
@@ -323,7 +323,11 @@ final class E2ELiveServerExecutionLaneLease: @unchecked Sendable {
             .split(separator: "\n")
             .map(String.init)
             .filter { line in
-                line.contains("SpeakSwiftlyServerTool serve") && !line.hasPrefix(currentProcessIdentifier + " ")
+                guard line.contains("SpeakSwiftlyServerTool serve") else { return false }
+                guard !line.hasPrefix(currentProcessIdentifier + " ") else { return false }
+                guard !line.contains("\(pgrepPath) -fl SpeakSwiftlyServerTool serve") else { return false }
+
+                return true
             }
 
         guard competingProcesses.isEmpty else {

--- a/docs/maintainers/v4.0.0-release-checklist.md
+++ b/docs/maintainers/v4.0.0-release-checklist.md
@@ -1,0 +1,62 @@
+# `v4.0.0` Release Checklist
+
+## Purpose
+
+This checklist is the maintainer-facing candidate path for the final `v4.0.0` release after `v4.0.0-rc.1`.
+
+Use it when the release scope is the flattened embedded consumer model, the public-surface cleanup, and the end-to-end harness repair that let the full live suite pass in the repo-approved one-suite-at-a-time shape.
+
+For the standing branch-versus-main release contract, keep using [release-workflow.md](./release-workflow.md). This document is only the candidate-specific checklist and release-shape note for `v4.0.0`.
+
+## Proposed Release Number
+
+Target the next release as `v4.0.0`.
+
+That major bump matches the current change shape:
+
+- breaking replacement of the old embedded session-plus-state consumer story with the single observable `EmbeddedServer` owner
+- breaking lifecycle and binding vocabulary shift to direct `liftoff()` and app-facing properties on that one object
+- intentional removal of accidental public library surface that previously leaked CLI-only or transport-local implementation details
+- stabilized live end-to-end coverage for the release gate by fixing the competing-process detector so the repo-approved serial suite runs complete successfully
+
+## Pre-Tag Checklist
+
+- keep the worktree clean before release preparation or publish
+- confirm the default package lane still passes:
+
+```bash
+xcrun swift build
+xcrun swift test
+```
+
+- confirm the maintainer validation path passes:
+
+```bash
+sh scripts/repo-maintenance/validate-all.sh
+```
+
+- run the full live end-to-end surface in the repo-approved serial shape:
+
+```bash
+SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter HTTPWorkflowE2ETests
+SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter MCPWorkflowE2ETests
+SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter ControlE2ETests
+```
+
+## Suggested Release Notes Shape
+
+Center the release notes on four points:
+
+- the new `EmbeddedServer` consumer model
+- the breaking embedded-lifecycle and observable-surface flattening
+- the package-surface cleanup that removes accidental public exports
+- the live E2E harness repair and the now-green full serial E2E gate
+
+## Publish Reminder
+
+If this candidate moves forward, use the split release workflow rather than tagging directly from a feature branch:
+
+1. run `scripts/repo-maintenance/release-prepare.sh --version v4.0.0` from the release branch or worktree candidate
+2. let the PR merge back to `main`
+3. fast-forward local `main`
+4. run `scripts/repo-maintenance/release-publish.sh --version v4.0.0 --skip-live-service-refresh`

--- a/docs/maintainers/v4.0.0-release-notes.md
+++ b/docs/maintainers/v4.0.0-release-notes.md
@@ -1,0 +1,47 @@
+# v4.0.0 Release Notes
+
+## What changed
+
+- replaced the older embedded session-plus-state model with a single app-owned `EmbeddedServer` observable surface
+- moved the embedded lifecycle entrypoint and consumer-facing control actions onto that public object so app code can create one server object, call `liftoff()`, and bind SwiftUI directly to its properties
+- tightened the package surface so internal transport payload models and CLI-only helper types are no longer exported from the library product
+- fixed the live E2E competing-process detector so the repo-approved serial HTTP, MCP, and control-suite release gate now runs cleanly end to end
+
+## Breaking changes
+
+- the embedded consumer entrypoint is now `EmbeddedServer` instead of the earlier `EmbeddedServerSession` plus `ServerState` split
+- embedded app code should now retain one `EmbeddedServer`, call `liftoff()` and `land()` on that object, and bind directly to its observable properties
+- downstream code that reached into previously public helper or transport types from the library product will need to migrate away from those now-hidden symbols
+
+## Migration or upgrade notes
+
+- create and retain one `EmbeddedServer` per embedded server instance
+- drive SwiftUI directly from `EmbeddedServer` properties such as runtime overview, playback state, queues, voice profiles, and related app-facing controls
+- use `land()` for teardown on the same object that performed `liftoff()`
+- callers that were only embedding the server and not depending on internal helper types should see a simpler public model after the rename
+
+## Verification performed
+
+```bash
+xcrun swift build
+```
+
+```bash
+xcrun swift test
+```
+
+```bash
+sh scripts/repo-maintenance/validate-all.sh
+```
+
+```bash
+SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter HTTPWorkflowE2ETests
+```
+
+```bash
+SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter MCPWorkflowE2ETests
+```
+
+```bash
+SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter ControlE2ETests
+```


### PR DESCRIPTION
## Release Prepare

- prepares release candidate `v4.0.0`
- stages the local artifact under `.release-artifacts/v4.0.0`
- leaves final tag creation and GitHub release publication for `scripts/repo-maintenance/release-publish.sh` after this pull request lands on `main`

## Publish Follow-Up

After this pull request merges, switch to `main` locally and run:

```bash
scripts/repo-maintenance/release-publish.sh --version v4.0.0 --skip-live-service-refresh
```
