### PR TITLE
Split README docs into operator and contributor guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,78 +1,135 @@
 # Contributing
 
+Practical contributor and maintainer guide for working on `SpeakSwiftlyServer`, including local setup, validation, live end-to-end coverage, pull request workflow, and release handoff.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Contribution Workflow](#contribution-workflow)
+- [Local Setup](#local-setup)
+- [Development Expectations](#development-expectations)
+- [Pull Request Expectations](#pull-request-expectations)
+- [Communication](#communication)
+- [Documentation Map](#documentation-map)
+- [Monorepo and Submodule Handoff](#monorepo-and-submodule-handoff)
+- [Release Workflow](#release-workflow)
+- [License and Contribution Terms](#license-and-contribution-terms)
+
 ## Overview
 
-This repository is the standalone Swift Package Manager home for `SpeakSwiftlyServer`. Treat it as the source of truth for package development, tags, and releases, even when a downstream monorepo consumes it as a submodule.
+### Who This Guide Is For
 
-Start with [AGENTS.md](AGENTS.md) for the repo's package, architecture, and monorepo handoff rules. Use this document for the practical contribution path: local validation, source layout, documentation upkeep, and release-adjacent verification.
+This guide is for contributors and maintainers making source, docs, test, release, or operator-surface changes in the standalone `SpeakSwiftlyServer` repository.
 
-## Before You Start
+### Before You Start
 
 - Treat `Package.swift` as the source of truth for package structure, dependencies, resources, and deployment targets.
-- Prefer `swift package` subcommands for structural edits when SwiftPM already exposes the right operation.
-- Keep package graph changes together in one pass, including `Package.swift`, `Package.resolved`, target layout, tests, and matching docs.
+- Start with [AGENTS.md](./AGENTS.md) for the repo's package, architecture, and workflow rules.
+- Keep package graph changes together in one pass, including `Package.swift`, `Package.resolved`, tests, and matching docs.
 - Keep transport-local shaping at the HTTP and MCP edges. If `SpeakSwiftly` or `TextForSpeech` can express a concept directly, prefer deleting server-local inference instead of adding another translation layer.
-- Keep the current standalone package baseline on macOS 15 while preserving a clean near-future iOS reuse path for the host and state model.
+- Preserve the current standalone package baseline on macOS 15 while keeping the host and state model friendly to the near-future iOS reuse path.
 
-## Documentation Map
+## Contribution Workflow
 
-- [README.md](README.md) is the operator-facing entrypoint.
-- [API.md](API.md) is the detailed HTTP and MCP contract reference.
-- [docs/maintainers/source-layout.md](docs/maintainers/source-layout.md) is the maintainer map for the current source split.
-- [docs/maintainers/release-workflow.md](docs/maintainers/release-workflow.md) is the maintainer release contract for feature branches, worktrees, and the final publish step on `main`.
-- [docs/maintainers/docc-spi-hosting-plan.md](docs/maintainers/docc-spi-hosting-plan.md) tracks the first DocC pass and the SPI-hosted documentation plan.
-- [ROADMAP.md](ROADMAP.md) tracks planned work and release-gate follow-through.
+### Choosing Work
 
-When the HTTP, MCP, LaunchAgent, release, or source-layout story changes, update the matching docs in the same pass instead of leaving the repo half-realigned.
+Choose work from the current repo state rather than from stale assumptions. Use [README.md](./README.md) for the product and operator story, [ROADMAP.md](./ROADMAP.md) for planned work, and the maintainer docs under [docs/maintainers](./docs/maintainers/) when the task touches releases, source layout, or transport behavior.
 
-## Local Workflow
+For substantial changes, work on a feature branch instead of local `main`. When a task already has active release or bug-fix context on a branch, keep the follow-on work stacked on that line unless maintainers explicitly want a separate branch.
 
-The default first-pass package validation path is still:
+### Making Changes
+
+Use the `xcrun` SwiftPM path intentionally in this repository:
 
 ```bash
 xcrun swift build
 xcrun swift test
 ```
 
-Use the `xcrun` form intentionally. In this repo, the standalone Swiftly-selected Swift 6.3 toolchain currently reproduces a transitive `_NumericsShims` module-loading failure that does not appear when SwiftPM runs through Xcode's selected toolchain.
+This repo documents the `xcrun` form because the standalone Swiftly-selected Swift 6.3 toolchain currently reproduces a transitive `_NumericsShims` module-loading failure that does not appear when SwiftPM runs through Xcode's selected toolchain.
 
-The maintainer wrapper around that baseline is:
+Keep work bounded and coherent:
+
+- keep transport concerns at the HTTP and MCP edges
+- keep host ownership narrow instead of adding new coordinator layers casually
+- update docs in the same pass when HTTP, MCP, LaunchAgent, release, or source-layout behavior changes
+- prefer the repo-maintenance scripts over one-off release or validation command chains when the repo already owns a workflow
+
+### Asking For Review
+
+Before asking for review, make sure the affected docs are in sync, the local validation path for the change has run, and any release-relevant or operator-facing behavior changes are called out plainly. For release work, use the documented branch-to-`main` split instead of trying to tag directly from a feature branch.
+
+## Local Setup
+
+### Runtime Config
+
+The concrete runtime config surfaces in this repo are:
+
+- [`server.yaml`](./server.yaml) for local config examples
+- `APP_CONFIG_FILE` for YAML-backed configuration
+- `SPEAKSWIFTLY_PROFILE_ROOT` for the runtime-owned profile and persistence root
+- the staged release artifact under `.release-artifacts/current/` for LaunchAgent-owned runs
+
+The shared server supports the same environment variables documented in [README.md](./README.md#configuration), including the `APP_*` transport settings and `SPEAKSWIFTLY_PROFILE_ROOT`.
+
+### Runtime Behavior
+
+The default local package workflow is:
 
 ```bash
-scripts/repo-maintenance/validate-all.sh
+xcrun swift build
+xcrun swift test
 ```
 
-## Formatting
+Use the unified tool surface when you want to inspect the operator path directly:
 
-SpeakSwiftlyServer uses the checked-in [.swiftformat](.swiftformat) file as the repository source of truth for Swift formatting and the checked-in [.swiftlint.yml](.swiftlint.yml) file for a deliberately small set of non-formatting policy checks.
+```bash
+xcrun swift run SpeakSwiftlyServerTool help
+xcrun swift run SpeakSwiftlyServerTool launch-agent print-plist
+xcrun swift run SpeakSwiftlyServerTool healthcheck
+```
 
-Use these commands from the package root:
+Before any live end-to-end run, stop the LaunchAgent-backed live service first:
+
+```bash
+./.release-artifacts/current/SpeakSwiftlyServerTool launch-agent uninstall
+```
+
+That matters because the live E2E harness is intentionally a one-speaking-server surface. The helper now fails fast when the LaunchAgent-backed service is still loaded or when a competing `SpeakSwiftlyServerTool serve` process is already running.
+
+## Development Expectations
+
+### Naming Conventions
+
+Keep user-facing lifecycle vocabulary consistent across docs, scripts, and commands. In this repo that means preferring pairs like `install` and `uninstall`, using `promote-live` for staged-to-live promotion, and avoiding alternate verbs for the same operator action unless a compatibility surface already requires them.
+
+Match the current boundary language in the code:
+
+- `EmbeddedServer` is the public app-owned embedding surface
+- transport-local shaping belongs at the HTTP and MCP edges
+- internal host ownership should stay behind the package boundary instead of leaking new public helpers casually
+
+### Accessibility Expectations
+
+This repository does not currently maintain a separate top-level `ACCESSIBILITY.md`. For relevant work, treat accessibility and operator clarity as part of normal change quality: keep user-facing logs, errors, and documentation explicit, readable, and unambiguous, and call out any new user-visible limitation plainly in docs or review notes when it matters.
+
+### Verification
+
+The maintainer validation entrypoint is:
 
 ```bash
 sh scripts/repo-maintenance/validate-all.sh
+```
+
+Direct formatter and linter commands are:
+
+```bash
 swiftformat --lint --config .swiftformat .
 swiftformat --config .swiftformat .
 swiftlint lint --config .swiftlint.yml
 ```
 
-Use `validate-all.sh` when you want the shared repo-maintenance gate that backs the sample pre-commit hook and the repo-maintenance GitHub Actions workflow. Use the first `swiftformat` command when you want to inspect formatting drift without rewriting files. Use the second `swiftformat` command when you intentionally want to apply formatting changes. Use the SwiftLint command for the smaller safety and maintainability checks that intentionally stay outside SwiftFormat.
-
-Treat SwiftFormat as the primary style tool in this repository. Keep SwiftLint focused on non-formatting policy checks instead of duplicating formatter behavior.
-
-Use the unified tool smoke path when you want to verify the operator surface directly:
-
-```bash
-xcrun swift run SpeakSwiftlyServerTool help
-xcrun swift run SpeakSwiftlyServerTool launch-agent print-plist
-```
-
-The `help` path now also has CI coverage so obvious executable-surface regressions are less likely to escape into release or Swift Package Index builds. The `help` path is expected to exit with the tool's usage-error status while still printing the supported command surface.
-
-If your local clone wants automatic hook enforcement, copy `scripts/repo-maintenance/hooks/pre-commit.sample` into `.git/hooks/pre-commit` and make it executable. That hook intentionally stays optional, but it runs the same validation entry point as the repo-maintenance workflow.
-
-## Live End-To-End Verification
-
-The opt-in live E2E coverage now runs as three serialized suites so maintainers can isolate transport and runtime failures without burning time on one giant rerun:
+The full live end-to-end gate should be run one suite at a time, in separate foreground commands:
 
 ```bash
 SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter HTTPWorkflowE2ETests
@@ -80,56 +137,45 @@ SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter MCPWorkflowE2ETests
 SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter ControlE2ETests
 ```
 
-Run those commands one at a time, in separate foreground processes, and never overlap them. Do not background one suite while starting another, and do not run the HTTP, MCP, or control suites in parallel.
+Do not overlap those suites or run the full live target as one giant parallelized process. The repo's live E2E surface is intentionally a serial, one-suite-at-a-time gate.
 
-Before any live E2E run, stop the LaunchAgent-backed live service first:
+## Pull Request Expectations
 
-```bash
-./.release-artifacts/current/SpeakSwiftlyServerTool launch-agent uninstall
-```
+Summarize what changed, why it changed, and what reviewers should pay attention to first. For release work, make sure the branch-side candidate preparation is complete before handing it off to `main` for the final publish step.
 
-That shutdown step matters because the live service and the test-owned helper can both speak audible test strings if they are alive together. The harness now fails fast when the LaunchAgent-backed service is still loaded or when another `SpeakSwiftlyServerTool serve` helper is already running, because live E2E coverage is intentionally a one-speaking-server surface.
+## Communication
 
-Add `SPEAKSWIFTLY_PLAYBACK_TRACE=1` when you want the underlying playback trace logs too.
+Raise uncertainty early when a task starts pushing on architecture, release semantics, or live-service behavior. If the clean path needs wider scope than the original request, say so before the change sprawls. If a behavior changed across docs, HTTP, MCP, LaunchAgent, or embedding surfaces, mention that explicitly instead of assuming reviewers will reconstruct it from the diff.
 
-The suite split is:
+## Documentation Map
 
-- `HTTP Workflow Entry`
-  Covers HTTP voice-design entry, HTTP clone entry with provided or inferred transcripts, HTTP Marvis audible live playback, and HTTP relative-path resolution.
-- `MCP Workflow Entry`
-  Covers the same entry and audible-runtime lanes through the MCP transport.
-- `Control Surfaces`
-  Covers HTTP and MCP text-profile control, playback control, queue mutation, catalog resources, prompts, and subscription behavior.
+- [README.md](./README.md) is the product and operator-facing entrypoint.
+- [API.md](./API.md) is the detailed HTTP and MCP contract reference.
+- [docs/maintainers/source-layout.md](./docs/maintainers/source-layout.md) is the maintainer map for the current source split.
+- [docs/maintainers/release-workflow.md](./docs/maintainers/release-workflow.md) is the branch-versus-`main` release contract.
+- [docs/maintainers](./docs/maintainers/) holds release checklists, release notes, and other maintainer-facing supporting docs.
 
-The checked-in `Tests/SpeakSwiftlyServer-Package-E2E.xctestplan` is the dedicated live E2E plan for the `SpeakSwiftlyServerE2ETests` target, while `Tests/SpeakSwiftlyServer-Package-Main.xctestplan` stays on the non-E2E targets. The suite-level `.serialized` traits in `Tests/SpeakSwiftlyServerE2ETests/E2ESuite.swift` keep each suite ordered within a process, and the helper-side execution-lane lock keeps separate live E2E processes from owning the speaking server at the same time.
-
-The live audible harness pins macOS built-in speakers immediately before audible startup and again immediately before audible request submission so Bluetooth route changes do not create false negatives.
-
-## Source Layout
-
-The shared runtime entrypoint lives in `Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.swift`, and the unified executable wrapper lives in `Sources/SpeakSwiftlyServerTool/SpeakSwiftlyServerToolMain.swift`.
-
-For the current split of host, HTTP, MCP, model, and test files, use [docs/maintainers/source-layout.md](docs/maintainers/source-layout.md) instead of re-deriving ownership from file names ad hoc. If a change starts mixing HTTP, MCP, LaunchAgent, and host-state concerns into one file again, split it before adding more cases.
-
-## Release Workflow
-
-Use the repo-maintenance toolkit's release split intentionally:
-
-```bash
-scripts/repo-maintenance/release-prepare.sh --version vX.Y.Z
-scripts/repo-maintenance/release-publish.sh --version vX.Y.Z --skip-live-service-refresh
-```
-
-Use `release-prepare.sh` from a feature branch or worktree when the job is "push this release candidate, open or update the PR, and queue auto-merge." Use `release-publish.sh` from local `main` after that PR merges when the job is "cut the actual tag and GitHub release." The compatibility wrapper `release.sh` now defaults to the publish path and refuses to run from a non-release branch.
-
-The publish path builds `SpeakSwiftlyServerTool` in `release` mode, stages the binary under `.release-artifacts/<tag>/SpeakSwiftlyServerTool`, copies the adjacent `Resources/default.metallib` into that staged artifact directory, refreshes `.release-artifacts/current` to the tagged build, tags `HEAD`, pushes the tag, creates the GitHub release, and can refresh the live per-user LaunchAgent-backed service by default with `~/Library/Application Support/SpeakSwiftlyServer/server.yaml`. Use `--skip-live-service-refresh` when you need a tag-only or artifact-only release pass, or `--live-service-config-file /absolute/path/to/server.yaml` when the live service should be refreshed against a different config file.
-
-For the current release contract, use [docs/maintainers/release-workflow.md](docs/maintainers/release-workflow.md). For the historical patch release target and the first Swift Package Index submission pass, use [docs/maintainers/v3.1.1-release-and-spi-checklist.md](docs/maintainers/v3.1.1-release-and-spi-checklist.md) instead of reconstructing that older flow from memory.
-
-## Monorepo And Submodule Handoff
+## Monorepo and Submodule Handoff
 
 - Treat `../../speak-to-user/monorepo/packages/SpeakSwiftlyServer` as the integration submodule copy, not the primary development home.
 - Treat the local `../../speak-to-user/monorepo` checkout as a clean base checkout that stays on `main` and stays clean.
 - Never use that clean base checkout for feature work, experiments, release bumps, or submodule-pointer edits.
 - For monorepo work, create a dedicated `git worktree`, do the work there, open a pull request, and then delete the merged worktree and branch afterward.
 - When `speak-to-user` adopts a new server version, prefer updating the submodule pointer to a tagged `SpeakSwiftlyServer` release instead of an arbitrary branch tip.
+
+## Release Workflow
+
+Use the repo-maintenance release split intentionally:
+
+```bash
+scripts/repo-maintenance/release-prepare.sh --version vX.Y.Z
+scripts/repo-maintenance/release-publish.sh --version vX.Y.Z --skip-live-service-refresh
+```
+
+Use `release-prepare.sh` from a feature branch or worktree when the job is "push this release candidate, open or update the PR, and queue auto-merge." Use `release-publish.sh` from local `main` after that PR merges when the job is "cut the actual tag and GitHub release."
+
+For the detailed contract and edge cases, use [docs/maintainers/release-workflow.md](./docs/maintainers/release-workflow.md).
+
+## License and Contribution Terms
+
+This repository is licensed under [Apache License 2.0](./LICENSE). By contributing, you are contributing changes under that same project license.

--- a/README.md
+++ b/README.md
@@ -1,290 +1,103 @@
 # SpeakSwiftlyServer
 
-Swift executable package for a shared localhost host process that exposes the public `SpeakSwiftly` runtime surface through an app-friendly HTTP API and an optional MCP surface.
+Standalone Swift package for hosting the local `SpeakSwiftly` runtime behind an app-friendly HTTP API, an optional MCP surface, and a small embedded Apple-platform API.
 
 ## Table of Contents
 
 - [Overview](#overview)
-- [Setup](#setup)
+- [Quick Start](#quick-start)
 - [Usage](#usage)
-- [Codex Plugin](#codex-plugin)
 - [Embedding](#embedding)
 - [Configuration](#configuration)
-- [Contributing](#contributing)
+- [Codex Plugin](#codex-plugin)
 - [Development](#development)
-- [Repository Layout](#repository-layout)
-- [Verification](#verification)
-- [Roadmap](#roadmap)
+- [Repo Structure](#repo-structure)
+- [Release Notes](#release-notes)
 - [License](#license)
 
 ## Overview
 
-This repository is the standalone Swift service for `SpeakSwiftly`. It uses [Hummingbird](https://github.com/hummingbird-project/hummingbird) to host one macOS process with job tracking, server-sent events, an operator-friendly HTTP API, and an optional MCP surface, while delegating speech, voice-profile management, and worker lifecycle to the typed `SpeakSwiftly` runtime.
+### Status
 
-### Deployment Targets
+This project is actively available and stable enough to try.
 
-Current deployment targets are:
+### What This Project Is
 
-- macOS 15 and newer for the standalone server package and initial app-managed installation path
-- iOS 18 and newer for a near-future app-facing reuse path once the host logic is split cleanly enough to be consumed from an iOS app
+`SpeakSwiftlyServer` is the standalone Swift Package Manager home for the local `SpeakSwiftly` server layer. It ships one reusable library target for embedding and one executable target, `SpeakSwiftlyServerTool`, for running the shared localhost service, LaunchAgent maintenance commands, and health checks.
 
-Linux support is a medium-term consideration rather than a current promise. A separate Linux implementation in Rust is more likely.
+The package exposes three user-facing surfaces:
+
+- a localhost HTTP API for app and operator control
+- an optional MCP surface for tool, resource, and prompt access
+- a small embedded Apple-platform API centered on the public `EmbeddedServer` observable model
 
 ### Motivation
 
-The goal is to give macOS apps one small, typed, app-managed service layer for local speech work without introducing a separate Python runtime or a second control model beside `SpeakSwiftly`.
+The goal is to give macOS and near-future Apple-platform apps one small, typed local speech-service layer without adding a second runtime stack or forcing every consumer to rebuild the same transport and lifecycle glue around `SpeakSwiftly`.
 
-The package stays intentionally narrow. Hummingbird owns transport hosting, `SpeakSwiftly` owns speech, profile, and runtime lifecycle behavior, `TextForSpeech` owns customizable text normalization, and the server keeps only the state it needs for retained snapshots, SSE replay, and MCP resources.
+## Quick Start
 
-### Current SpeakSwiftly Alignment
-
-This server is aligned to the current public library surface of its resolved [`SpeakSwiftly`](https://github.com/gaelic-ghost/SpeakSwiftly) `3.0.6` package dependency.
-
-Today the server relies on the current typed runtime capabilities that matter for transport hosting:
-
-- `SpeakSwiftly.liftoff(configuration:)`
-- `runtime.statusEvents()`
-- `runtime.generate.speech(text:with:textProfileName:textContext:sourceFormat:)`
-- `runtime.generate.audio(text:with:textProfileName:textContext:sourceFormat:)`
-- `runtime.generate.batch(_:with:)`
-- `runtime.voices.create(design:from:vibe:voice:outputPath:)`
-- `runtime.voices.create(clone:from:vibe:transcript:)`
-- `runtime.voices.list()`
-- `runtime.voices.rename(_:to:)`
-- `runtime.voices.reroll(_:)`
-- `runtime.voices.delete(named:)`
-- `runtime.jobs.generationQueue()`
-- `runtime.jobs.list()`
-- `runtime.jobs.job(id:)`
-- `runtime.jobs.expire(id:)`
-- `runtime.artifacts.files()`
-- `runtime.artifacts.file(id:)`
-- `runtime.artifacts.batches()`
-- `runtime.artifacts.batch(id:)`
-- `runtime.player.list()`
-- `runtime.player.state()`
-- `runtime.player.pause()`
-- `runtime.player.resume()`
-- `runtime.player.clearQueue()`
-- `runtime.player.cancelRequest(_:)`
-- `runtime.overview()`
-- `runtime.status()`
-- `runtime.switchSpeechBackend(to:)`
-- `runtime.reloadModels()`
-- `runtime.unloadModels()`
-- `runtime.request(id:)`
-- `runtime.updates(for:)`
-
-For text normalization, the server stays on the public `TextForSpeech` model surface through the runtime normalizer rather than inventing a parallel server-only schema:
-
-- `runtime.normalizer.profiles.active()`
-- `runtime.normalizer.profiles.stored(id:)`
-- `runtime.normalizer.profiles.list()`
-- `runtime.normalizer.profiles.effective(id:)`
-- `runtime.normalizer.persistence.load()`
-- `runtime.normalizer.persistence.save()`
-- `runtime.normalizer.profiles.create(id:name:replacements:)`
-- `runtime.normalizer.profiles.store(_:)`
-- `runtime.normalizer.profiles.use(_:)`
-- `runtime.normalizer.profiles.delete(id:)`
-- `runtime.normalizer.profiles.reset()`
-- `runtime.normalizer.profiles.add(...)`
-- `runtime.normalizer.profiles.replace(...)`
-- `runtime.normalizer.profiles.removeReplacement(...)`
-
-The server also consumes the public summary and event types that those calls vend, including `SpeakSwiftly.RequestHandle`, `SpeakSwiftly.RequestEvent`, `SpeakSwiftly.StatusEvent`, `SpeakSwiftly.ProfileSummary`, `SpeakSwiftly.ActiveRequest`, `SpeakSwiftly.QueuedRequest`, `SpeakSwiftly.PlaybackStateSnapshot`, `SpeakSwiftly.RuntimeOverview`, `SpeakSwiftly.Vibe`, and `SpeakSwiftly.Configuration`.
-
-That alignment means the remaining translation layer is intentionally transport-local: snake_case HTTP and MCP payload shaping, retained job snapshots, and SSE framing. Queue, playback, and runtime-refresh state now come from the atomic runtime overview instead of server-local fallback reconstruction. The server is not reaching through the library boundary to construct raw worker protocol messages or private runtime state directly.
-
-For generation requests, the server also supports one server-owned default voice profile. HTTP and MCP callers may omit `profile_name` for live speech, retained audio, and retained batch requests when the server has `app.defaultVoiceProfileName` or `APP_DEFAULT_VOICE_PROFILE_NAME` configured. When neither the request nor the server configuration provides a voice profile, the server rejects the request with a descriptive validation error instead of silently guessing.
-
-Across the HTTP, MCP, tool-catalog, and embedded control surfaces, the server now publishes the normalized backend identifiers `qwen3`, `chatterbox_turbo`, and `marvis`. Compatibility input using the older `qwen3_custom_voice` backend name is still accepted on transport-facing runtime-control requests and is normalized to `qwen3` before persistence or response shaping.
-
-That narrowness also informs platform policy. The package should prefer maintainable Apple-platform architecture for the current macOS and near-future iOS use cases over speculative cross-platform compromises.
-
-## Setup
-
-This package resolves its SwiftPM dependencies from GitHub source control in [`Package.swift`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/Package.swift) and locks the resolved revisions in [`Package.resolved`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/Package.resolved). `SpeakSwiftly` uses a normal semantic-version requirement here, and this package currently follows it with an up-to-next-major constraint starting at `3.0.6`. The server's direct `TextForSpeech` dependency now tracks `0.17.0`, matching the current upstream `SpeakSwiftly` graph.
-
-Build the package with SwiftPM through Xcode's selected toolchain:
+Build the package with Xcode's selected Swift toolchain:
 
 ```bash
 xcrun swift build
 ```
 
-Run the test suite:
-
-```bash
-xcrun swift test
-```
-
-The repository intentionally documents `xcrun swift ...` as the default path because the standalone Swiftly-selected Swift 6.3 toolchain in this environment currently reproduces a transitive `_NumericsShims` module-loading failure that does not appear under Xcode's matching Swift toolchain.
-
-The repository also now carries a minimal [`.spi.yml`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/.spi.yml) so Swift Package Index can build and host documentation for the `SpeakSwiftlyServer` library target once the package is indexed. The follow-on DocC content plan lives in [`docs/maintainers/docc-spi-hosting-plan.md`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/docs/maintainers/docc-spi-hosting-plan.md).
-
-## Usage
-
-Run the server locally:
+Run the shared server executable locally:
 
 ```bash
 xcrun swift run SpeakSwiftlyServerTool
 ```
 
-The package now uses distinct default localhost ports by entrypoint:
-
-- direct executable startup defaults to `127.0.0.1:7338`
-- LaunchAgent installs default to `127.0.0.1:7337`
-- embedded app-owned sessions default to `127.0.0.1:7339`
-
-All three entrypaths also support the same explicit runtime-profile-root override through `SPEAKSWIFTLY_PROFILE_ROOT`. Embedded app hosts can set that through `EmbeddedServer.Options(runtimeProfileRootURL:)`, foreground `serve` runs can set it through `--profile-root`, and LaunchAgent installs already stage it into the installed property list.
-
-The package now ships one operator-facing executable product with both the foreground server entrypoint and the LaunchAgent maintenance surface:
+Check the current operator surface:
 
 ```bash
 xcrun swift run SpeakSwiftlyServerTool help
+xcrun swift run SpeakSwiftlyServerTool healthcheck
 ```
 
-Running the tool without subcommands defaults to `serve`, and the same binary also exposes `launch-agent` subcommands for install, promotion, inspection, and maintenance work.
+For contributor setup, validation, release workflow, and live end-to-end coverage, use [CONTRIBUTING.md](./CONTRIBUTING.md).
 
-The most common local operator path is:
+## Usage
 
-1. `xcrun swift run SpeakSwiftlyServerTool help`
-2. `xcrun swift run SpeakSwiftlyServerTool launch-agent print-plist`
-3. `xcrun swift run SpeakSwiftlyServerTool launch-agent promote-live --config-file ./server.yaml`
-4. `xcrun swift run SpeakSwiftlyServerTool healthcheck`
-
-To render the current per-user LaunchAgent property list without installing it:
+Run the server directly in the foreground:
 
 ```bash
-xcrun swift run SpeakSwiftlyServerTool launch-agent print-plist
+xcrun swift run SpeakSwiftlyServerTool serve
 ```
 
-To start the server directly in the foreground with an app- or operator-owned runtime profile root:
-
-```bash
-xcrun swift run SpeakSwiftlyServerTool serve \
-  --profile-root ./runtime/profiles
-```
-
-To install or refresh the current user's LaunchAgent with a config file:
+Install or refresh the per-user LaunchAgent with a config file:
 
 ```bash
 xcrun swift run SpeakSwiftlyServerTool launch-agent install \
   --config-file ./server.yaml
 ```
 
-That command writes a user-owned property list into `~/Library/LaunchAgents`, points `ProgramArguments` at the staged release artifact under `.release-artifacts/current/SpeakSwiftlyServerTool serve`, and uses `launchctl bootstrap` / `bootout` against the current `gui/<uid>` domain. That default keeps the live service on the repo's staged release build instead of whichever debug or transient executable happened to invoke the command. The install output now also prints the exact staged executable path and modification time that the LaunchAgent is being asked to activate. If your tool binary lives somewhere other than the staged release path, pass `--tool-executable-path /absolute/path/to/SpeakSwiftlyServerTool` explicitly.
-
-To promote the currently checked-out code into the live LaunchAgent-backed service in one supported step:
+Promote the current checkout into the live LaunchAgent-backed service:
 
 ```bash
 xcrun swift run SpeakSwiftlyServerTool launch-agent promote-live \
   --config-file ./server.yaml
 ```
 
-That command rebuilds the release executable from the current repository checkout, stages the executable and the sibling `SpeakSwiftly` metallib into `.release-artifacts/current`, refreshes the staged executable's ad-hoc code signature explicitly, and then reruns the LaunchAgent install path. Use `install` when the staged artifact is already the thing you want launchd to boot. Use `promote-live` when the intent is "make the live service run the current source checkout now" without a separate release tag flow.
-
-To inspect or remove the installed LaunchAgent:
+Inspect or remove the installed LaunchAgent:
 
 ```bash
 xcrun swift run SpeakSwiftlyServerTool launch-agent status
 xcrun swift run SpeakSwiftlyServerTool launch-agent uninstall
 ```
 
-To verify the live service end to end without ad hoc `curl` or hand-built JSON-RPC:
+The package uses distinct default localhost ports by entrypoint:
 
-```bash
-xcrun swift run SpeakSwiftlyServerTool healthcheck
-```
+- direct executable startup defaults to `127.0.0.1:7338`
+- LaunchAgent installs default to `127.0.0.1:7337`
+- embedded app-owned sessions default to `127.0.0.1:7339`
 
-That command probes `GET /healthz`, reads `GET /runtime/host`, and sends a real MCP `initialize` request to `/mcp`. It prints one concise summary that distinguishes "the process is up" from "both HTTP and MCP are actually healthy."
-
-### App-Managed Install Contract
-
-The current app-managed install contract is explicit and centered on one per-user layout instead of ad hoc paths:
-
-- server support root: `~/Library/Application Support/SpeakSwiftlyServer`
-- server config file: `~/Library/Application Support/SpeakSwiftlyServer/server.yaml`
-- runtime base directory: `~/Library/Application Support/SpeakSwiftlyServer/runtime`
-- runtime profile root: `~/Library/Application Support/SpeakSwiftlyServer/runtime/profiles`
-- runtime configuration file: `~/Library/Application Support/SpeakSwiftlyServer/runtime/configuration.json`
-- logs directory: `~/Library/Logs/SpeakSwiftlyServer`
-- stdout log: `~/Library/Logs/SpeakSwiftlyServer/stdout.log`
-- stderr log: `~/Library/Logs/SpeakSwiftlyServer/stderr.log`
-- reserved cache root: `~/Library/Caches/SpeakSwiftlyServer`
-
-That runtime profile root is now the default LaunchAgent-owned `SPEAKSWIFTLY_PROFILE_ROOT`, which means the standalone server no longer has to share the generic default `SpeakSwiftly` per-user profile store unless an operator intentionally points it somewhere else.
-
-The package exposes that same contract directly to app code through [`ServerInstallLayout`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/Sources/SpeakSwiftlyServer/AppManagedInstallLayout.swift), so the app can inspect or reuse the owned paths without re-deriving them by hand:
-
-```swift
-import SpeakSwiftlyServer
-
-let layout = ServerInstallLayout.defaultForCurrentUser()
-print(layout.standardErrorLogURL.path)
-print(layout.runtimeProfileRootURL.path)
-```
-
-## Codex Plugin
-
-This repository is also packaged as a repo-local Codex plugin through [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json). The plugin points at the checked-in [`.mcp.json`](./.mcp.json) connection for the local `speak_swiftly` MCP server and the tracked [skills](./skills/) bundle that teaches Codex how to use the surface intentionally. When the plugin is installed through a Codex marketplace, Codex installs the plugin into its plugin cache and loads that installed copy from there, so the plugin surface is the normal Codex-side MCP wiring path. Users should not need to add a second handwritten global MCP entry just to reach the local server.
-
-The first plugin pass currently ships five focused skills:
-
-- [`speak-swiftly-mcp`](./skills/speak-swiftly-mcp/SKILL.md) for broad MCP orientation and workflow selection
-- [`speak-swiftly-launchagent-setup`](./skills/speak-swiftly-launchagent-setup/SKILL.md) for installing, refreshing, validating, and removing the per-user LaunchAgent-backed service
-- [`speak-swiftly-runtime-operator`](./skills/speak-swiftly-runtime-operator/SKILL.md) for runtime state, playback, queue, and request control
-- [`speak-swiftly-voice-workflows`](./skills/speak-swiftly-voice-workflows/SKILL.md) for voice profiles, live speech, and retained artifacts
-- [`speak-swiftly-text-profiles`](./skills/speak-swiftly-text-profiles/SKILL.md) for normalization styles, stored profiles, and replacement editing
-
-The repo-local marketplace advertisement lives in [`.agents/plugins/marketplace.json`](./.agents/plugins/marketplace.json). That entry intentionally points at the repository root so this checkout itself can be discovered and installed as one local plugin instead of forcing a second nested plugin copy inside the repo.
-
-The package also now exposes [`ServerInstalledLogs`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/Sources/SpeakSwiftlyServer/AppManagedInstallLayout.swift), which lets the app read the owned stdout and stderr files as plain text, line arrays, or decodable JSON-line payloads:
-
-```swift
-import SpeakSwiftlyServer
-
-let logs = try ServerInstalledLogs.read()
-let stderrText = logs.stderr.text
-let stderrLines = logs.stderr.lines
-
-struct RuntimeLog: Decodable, Sendable {
-    let event: String
-    let ok: Bool?
-}
-
-let runtimeEvents = try logs.stderr.decodeJSONLines(as: RuntimeLog.self)
-```
-
-That API is intentionally file-backed. The app can call one package function and get useful in-process formats without scraping Console, tailing files manually, or hardcoding LaunchAgent defaults in a second place.
+The full transport contract lives in [API.md](./API.md).
 
 ## Embedding
 
-`SpeakSwiftlyServer` now exposes a small app-facing embedding surface for SwiftUI and other Apple-platform app code:
-
-- [`ServerState.swift`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/Sources/SpeakSwiftlyServer/Host/ServerState.swift) now defines `EmbeddedServer`, the supported public `@Observable` model that app code owns directly.
-- [`HostStateModels.swift`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/Sources/SpeakSwiftlyServer/Host/HostStateModels.swift) plus the transport-facing model families in [`ServerModels.swift`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/Sources/SpeakSwiftlyServer/Host/ServerModels.swift), [`ProfileModels.swift`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/Sources/SpeakSwiftlyServer/Host/ProfileModels.swift), [`QueueStatusModels.swift`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/Sources/SpeakSwiftlyServer/Host/QueueStatusModels.swift), and [`JobEventModels.swift`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/Sources/SpeakSwiftlyServer/Host/JobEventModels.swift) are the public read-only value models that back that observable state.
-
-That public surface is intentionally small. `ServerHost` remains internal so app code does not couple itself to transport orchestration, async stream plumbing, or other backend ownership details.
-
-Behind that small public API, the embedded path now uses one outer `ServiceGroup` owned by the
-embedded server model. That outer group owns the package-level host lifecycle, optional config watching,
-optional MCP readiness and drain, and the wrapped Hummingbird application as sibling long-running
-services. Hummingbird still owns its own internal application `ServiceGroup`, but app code should
-keep treating `EmbeddedServer` itself as the lifecycle boundary.
-
-From app code, `EmbeddedServer` exposes app-facing control points for the cached voice-profile list, the effective default voice profile, runtime model lifecycle, and playback actions:
-
-- `listVoiceProfiles()` and `refreshVoiceProfiles()`
-- `setDefaultVoiceProfileName(_:)` and `clearDefaultVoiceProfileName()`
-- `switchSpeechBackend(to:)`, `reloadModels()`, and `unloadModels()`
-- `pausePlayback()`, `resumePlayback()`, `clearPlaybackQueue()`, and `cancelPlaybackRequest(_:)`
-
-Those default-profile actions mutate the host-owned effective default that HTTP and MCP speech-generation requests use when `profile_name` is omitted. That app-managed default starts from configuration, can be changed live by the embedded app, and is persisted in the server runtime configuration so it survives process restart. Clearing the app-managed default removes the persisted override and falls back to the configured `app.defaultVoiceProfileName` when one exists.
-
-The runtime control actions apply the refreshed host snapshot back onto `EmbeddedServer` before they return, so app code gets one coherent post-action picture of the current backend, worker stage, queues, playback state, and transport health instead of needing to stitch together several follow-up reads.
-
-Start an embedded server from app code like this:
+The supported public embedding surface is `EmbeddedServer`, defined in [Sources/SpeakSwiftlyServer/Host/ServerState.swift](./Sources/SpeakSwiftlyServer/Host/ServerState.swift). App code owns that one observable object directly, calls `liftoff()`, binds UI to its observable properties, and uses the same object for runtime and playback control actions.
 
 ```swift
 import SpeakSwiftlyServer
@@ -311,25 +124,9 @@ struct ExampleApp: App {
         }
     }
 }
-
-struct ContentView: View {
-    let server: EmbeddedServer
-
-    var body: some View {
-        Text(server.overview.workerMode)
-    }
-}
 ```
 
-If you do not pass `EmbeddedServer.Options(port:)`, the embedded host defaults to `127.0.0.1:7339`. Passing `options.port` applies that same value to the shared transport default and the concrete HTTP listener, so app code can claim an app-specific localhost port without mutating global environment state first.
-
-If you pass `EmbeddedServer.Options(runtimeProfileRootURL:)`, that same root is forwarded into both the server-owned runtime configuration store and the underlying `SpeakSwiftly` startup path. That gives an app one explicit persistence root for runtime configuration, text-profile persistence, generated artifacts, and other runtime-owned profile data. For sandboxed macOS apps, Apple documents that `applicationSupportDirectory` already resolves inside the app container; for shared storage across the app and extensions or helpers, pass an App Group container URL instead.
-
-If a subview needs bindings into mutable session-backed state, use SwiftUI's `@Bindable` support for `@Observable` models instead of `@ObservedObject`. Apple documents that `@Observable` types are tracked by the properties a view reads directly, and that binding support should come through `@Bindable` when a view needs writable bindings:
-
-- [Observation](https://developer.apple.com/documentation/observation)
-- [Managing model data in your app](https://developer.apple.com/documentation/swiftui/managing-model-data-in-your-app)
-- [Migrating from the observable object protocol to the observable macro](https://developer.apple.com/documentation/swiftui/migrating-from-the-observable-object-protocol-to-the-observable-macro)
+If you do not pass `EmbeddedServer.Options(port:)`, the embedded host defaults to `127.0.0.1:7339`. If you pass `EmbeddedServer.Options(runtimeProfileRootURL:)`, that root is used for the runtime-owned persistence path as well as the server's runtime configuration store.
 
 ## Configuration
 
@@ -355,7 +152,7 @@ The shared server supports these environment variables:
 - `APP_MCP_TITLE`
 - `SPEAKSWIFTLY_PROFILE_ROOT`
 
-If `APP_CONFIG_FILE` points at a YAML file, the server loads it through [apple/swift-configuration](https://github.com/apple/swift-configuration) with environment variables taking precedence over YAML and YAML taking precedence over built-in defaults. The expected YAML shape mirrors the nested config reader keys:
+If `APP_CONFIG_FILE` points at a YAML file, the server loads it through [swift-configuration](https://github.com/apple/swift-configuration), with environment variables taking precedence over YAML and YAML taking precedence over built-in defaults.
 
 ```yaml
 app:
@@ -379,62 +176,56 @@ app:
     title: SpeakSwiftly
 ```
 
-Top-level transport settings and HTTP-specific overrides intentionally compose this way:
+The app-managed install layout is centered on one per-user location under `~/Library/Application Support/SpeakSwiftlyServer`, with logs in `~/Library/Logs/SpeakSwiftlyServer`. The package exposes that layout directly through [AppManagedInstallLayout.swift](./Sources/SpeakSwiftlyServer/AppManagedInstallLayout.swift).
 
-- `APP_HOST`, `APP_PORT`, and `APP_SSE_HEARTBEAT_SECONDS` define the shared transport defaults.
-- `APP_HTTP_HOST`, `APP_HTTP_PORT`, and `APP_HTTP_SSE_HEARTBEAT_SECONDS` override those defaults only for the HTTP surface.
-- If you do not set an `APP_HTTP_*` value, the HTTP listener inherits the corresponding top-level `APP_*` value.
-- The direct executable, LaunchAgent runtime, and embedded session each start from different built-in default ports before those environment or YAML overrides are applied.
+## Codex Plugin
 
-`SPEAKSWIFTLY_PROFILE_ROOT` is the startup-time persistence-root override. Point it at the runtime profile root directory you want the server to own, not at a broader support directory. When it is set, the server runtime configuration store and the underlying `SpeakSwiftly` persistence paths both use that same root. This value is a startup ownership choice, not a live-reloadable YAML setting.
+This repository is also packaged as a repo-local Codex plugin through [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json). The plugin points at the checked-in [`.mcp.json`](./.mcp.json) connection for the local `speak_swiftly` MCP server and the tracked [skills](./skills/) bundle that teaches Codex how to use the surface intentionally.
 
-When `APP_CONFIG_FILE` is set, the server watches that YAML file for changes, but only the host-safe subset reloads live today. Bind addresses, ports, HTTP enablement, MCP enablement, MCP path, and MCP server metadata still require a process restart.
+The first plugin pass ships focused skills for:
 
-The full transport contract now lives in [API.md](API.md), including:
-
-- the complete HTTP route inventory
-- accepted-request semantics and SSE behavior
-- text-profile, playback, and runtime control notes
-- the MCP tool, resource, prompt, and subscription catalog
-- transport-status semantics for the shared Hummingbird host
-
-If you are integrating against the server rather than just running it locally, use [API.md](API.md) as the source of truth.
-
-## Contributing
-
-Use [CONTRIBUTING.md](CONTRIBUTING.md) for the maintainer workflow, validation path, live end-to-end coverage, release flow, and monorepo handoff rules.
-
-The maintainer release contract is now intentionally split by checkout context: use `scripts/repo-maintenance/release-prepare.sh` from a feature branch or worktree when the job is "push this release candidate, open or update the PR, and queue auto-merge," then use `scripts/repo-maintenance/release-publish.sh` from local `main` after the PR merges when the job is "cut the actual tag and GitHub release." If local `main` is ahead of `origin/main`, that still counts as branch-side release-candidate work for this contract: get those commits onto a PR path first, then fast-forward `main` and publish from the synced release branch. The current details live in [docs/maintainers/release-workflow.md](docs/maintainers/release-workflow.md).
+- broad MCP orientation
+- LaunchAgent setup and maintenance
+- runtime, playback, and queue control
+- voice workflows
+- text-profile workflows
 
 ## Development
 
-The shared runtime entrypoint lives in [`Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.swift`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.swift) inside the `SpeakSwiftlyServer` module, with a thin executable wrapper in [`Sources/SpeakSwiftlyServerTool/SpeakSwiftlyServerToolMain.swift`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/Sources/SpeakSwiftlyServerTool/SpeakSwiftlyServerToolMain.swift) for the unified `SpeakSwiftlyServerTool` executable target.
+The contributor and maintainer workflow lives in [CONTRIBUTING.md](./CONTRIBUTING.md).
 
-The design stays deliberately direct. The service talks to the public `SpeakSwiftly.Runtime` surface, its public text normalizer, and its public event and summary types instead of reaching through the library boundary to construct raw worker requests itself.
+Use that guide for:
 
-For the maintainer workflow, source split, and release path, use [CONTRIBUTING.md](CONTRIBUTING.md), [docs/maintainers/source-layout.md](docs/maintainers/source-layout.md), and [docs/maintainers/release-workflow.md](docs/maintainers/release-workflow.md).
+- local setup and runtime expectations
+- validation commands
+- live end-to-end coverage
+- pull request and release workflow
+- monorepo and submodule handoff rules
 
-## Repository Layout
+## Repo Structure
 
-- `Sources/SpeakSwiftlyServer/` contains the reusable `SpeakSwiftlyServer` library target with the HTTP, MCP, host, config, and LaunchAgent support code.
-- `Sources/SpeakSwiftlyServerTool/` contains the unified `SpeakSwiftlyServerTool` executable wrapper and command entrypoint.
-- `Tests/` contains the package test suite, including the opt-in end-to-end coverage paths and the dedicated CLI tests.
-- `docs/` holds repo-local supporting documentation.
-- `docs/maintainers/source-layout.md` summarizes the current source split so follow-on cleanup work can land in the right file family instead of regrowing monoliths.
+```text
+.
+├── Sources/
+│   ├── SpeakSwiftlyServer/
+│   └── SpeakSwiftlyServerTool/
+├── Tests/
+├── docs/
+├── API.md
+├── CONTRIBUTING.md
+├── Package.swift
+└── README.md
+```
 
-## Verification
+- `Sources/SpeakSwiftlyServer/` contains the reusable library target.
+- `Sources/SpeakSwiftlyServerTool/` contains the unified executable wrapper.
+- `Tests/` contains unit, integration, and opt-in live E2E coverage.
+- `docs/` contains maintainer-facing supporting documentation.
 
-Use [CONTRIBUTING.md](CONTRIBUTING.md) for:
+## Release Notes
 
-- the maintainer validation path
-- direct tool smoke-test commands
-- opt-in live end-to-end coverage
-- release verification and artifact staging notes
-
-## Roadmap
-
-Planned work is tracked in [`ROADMAP.md`](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/ROADMAP.md).
+Tagged release notes live in [GitHub Releases](https://github.com/gaelic-ghost/SpeakSwiftlyServer/releases) and the repo keeps matching maintainer-facing release notes and checklists under [docs/maintainers](./docs/maintainers/).
 
 ## License
 
-This repository is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). See [LICENSE](https://github.com/gaelic-ghost/SpeakSwiftlyServer/blob/main/LICENSE).
+See [LICENSE](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Check the current operator surface:
 
 ```bash
 xcrun swift run SpeakSwiftlyServerTool help
-xcrun swift run SpeakSwiftlyServerTool healthcheck
+xcrun swift run SpeakSwiftlyServerTool healthcheck --base-url http://127.0.0.1:7338
 ```
 
 For contributor setup, validation, release workflow, and live end-to-end coverage, use [CONTRIBUTING.md](./CONTRIBUTING.md).
@@ -67,6 +67,8 @@ xcrun swift run SpeakSwiftlyServerTool serve
 ```
 
 Install or refresh the per-user LaunchAgent with a config file:
+
+This command expects the staged tool artifact to already exist at `.release-artifacts/current/SpeakSwiftlyServerTool`. On a clean checkout, build and stage the release artifact first, or pass `--tool-executable-path /absolute/path/to/SpeakSwiftlyServerTool` explicitly.
 
 ```bash
 xcrun swift run SpeakSwiftlyServerTool launch-agent install \


### PR DESCRIPTION
## Summary
- moved maintainer workflow content out of `README.md` into a new canonical `CONTRIBUTING.md`
- rewrote `README.md` to keep the product, operator, embedding, and release-facing story only
- aligned both docs to their respective maintenance schemas and kept repo-specific workflow guidance grounded in the current checkout

## Testing
- Not run (not requested)