### PR TITLE
Remove redundant MARK comments and align formatting

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -3,7 +3,7 @@
 # configuration changes later, re-export from the shared SwiftFormat settings
 # and review the diff before importing it back into the app.
 
---rules andOperator,anyObjectProtocol,applicationMain,assertionFailures,blankLineAfterImports,blankLinesAfterGuardStatements,blankLinesAroundMark,blankLinesAtEndOfScope,blankLinesAtStartOfScope,blankLinesBetweenChainedFunctions,blankLinesBetweenImports,blankLinesBetweenScopes,braces,conditionalAssignment,consecutiveBlankLines,consecutiveSpaces,consistentSwitchCaseSpacing,docComments,docCommentsBeforeModifiers,duplicateImports,elseOnSameLine,emptyBraces,emptyExtensions,enumNamespaces,environmentEntry,extensionAccessControl,fileMacro,genericExtensions,headerFileName,hoistAwait,hoistPatternLet,hoistTry,indent,initCoderUnavailable,isEmpty,leadingDelimiters,linebreakAtEndOfFile,linebreaks,markTypes,modifierOrder,noForceTryInTests,noForceUnwrapInTests,noGuardInTests,numberFormatting,opaqueGenericParameters,organizeDeclarations,preferFinalClasses,privateStateVariables,redundantAsync,redundantBackticks,redundantBreak,redundantClosure,redundantEquatable,redundantExtensionACL,redundantFileprivate,redundantGet,redundantInit,redundantInternal,redundantLet,redundantLetError,redundantMemberwiseInit,redundantNilInit,redundantObjc,redundantOptionalBinding,redundantParens,redundantPattern,redundantPublic,redundantRawValues,redundantReturn,redundantSelf,redundantSendable,redundantStaticSelf,redundantSwiftTestingSuite,redundantThrows,redundantType,redundantTypedThrows,redundantVariable,redundantViewBuilder,semicolons,simplifyGenericConstraints,sortDeclarations,sortImports,sortTypealiases,spaceAroundBraces,spaceAroundBrackets,spaceAroundComments,spaceAroundGenerics,spaceAroundOperators,spaceAroundParens,spaceInsideBrackets,spaceInsideComments,spaceInsideGenerics,spaceInsideParens,strongOutlets,strongifiedSelf,swiftTestingTestCaseNames,todos,trailingClosures,trailingCommas,trailingSpace,typeSugar,validateTestCases,void,wrap,wrapArguments,wrapAttributes,wrapLoopBodies,wrapMultilineFunctionChains,wrapSingleLineComments,yodaConditions
+--rules andOperator,anyObjectProtocol,applicationMain,assertionFailures,blankLineAfterImports,blankLinesAfterGuardStatements,blankLinesAroundMark,blankLinesAtEndOfScope,blankLinesAtStartOfScope,blankLinesBetweenChainedFunctions,blankLinesBetweenImports,blankLinesBetweenScopes,braces,conditionalAssignment,consecutiveBlankLines,consecutiveSpaces,consistentSwitchCaseSpacing,docComments,docCommentsBeforeModifiers,duplicateImports,elseOnSameLine,emptyBraces,emptyExtensions,enumNamespaces,environmentEntry,extensionAccessControl,fileMacro,genericExtensions,headerFileName,hoistAwait,hoistPatternLet,hoistTry,indent,initCoderUnavailable,isEmpty,leadingDelimiters,linebreakAtEndOfFile,linebreaks,modifierOrder,noForceTryInTests,noForceUnwrapInTests,noGuardInTests,numberFormatting,opaqueGenericParameters,organizeDeclarations,preferFinalClasses,privateStateVariables,redundantAsync,redundantBackticks,redundantBreak,redundantClosure,redundantEquatable,redundantExtensionACL,redundantFileprivate,redundantGet,redundantInit,redundantInternal,redundantLet,redundantLetError,redundantMemberwiseInit,redundantNilInit,redundantObjc,redundantOptionalBinding,redundantParens,redundantPattern,redundantPublic,redundantRawValues,redundantReturn,redundantSelf,redundantSendable,redundantStaticSelf,redundantSwiftTestingSuite,redundantThrows,redundantType,redundantTypedThrows,redundantVariable,redundantViewBuilder,semicolons,simplifyGenericConstraints,sortDeclarations,sortImports,sortTypealiases,spaceAroundBraces,spaceAroundBrackets,spaceAroundComments,spaceAroundGenerics,spaceAroundOperators,spaceAroundParens,spaceInsideBrackets,spaceInsideComments,spaceInsideGenerics,spaceInsideParens,strongOutlets,strongifiedSelf,swiftTestingTestCaseNames,todos,trailingClosures,trailingCommas,trailingSpace,typeSugar,validateTestCases,void,wrap,wrapArguments,wrapAttributes,wrapLoopBodies,wrapMultilineFunctionChains,wrapSingleLineComments,yodaConditions
 
 --acronyms ID,URL,UUID
 --allow-partial-wrapping true
@@ -27,11 +27,9 @@
 --equatable-macro none
 --exponent-case lowercase
 --extension-acl on-extension
---extension-mark "MARK: - %t + %c"
 --file-macro "#file"
 --func-attributes preserve
 --group-blank-lines true
---grouped-extension "MARK: %c"
 --guard-else auto
 --header ignore
 --hex-grouping 4,8
@@ -49,9 +47,7 @@
 --mark-class-threshold 40
 --mark-enum-threshold 40
 --mark-extension-threshold 40
---mark-extensions if-not-empty
 --mark-struct-threshold 40
---mark-types if-not-empty
 --max-width none
 --operator-func spaced
 --organization-mode type
@@ -80,7 +76,6 @@
 --type-blank-lines remove
 --type-body-marks preserve
 --type-delimiter space-after
---type-mark "MARK: - %t"
 --class-threshold 40
 --enum-threshold 40
 --extension-threshold 40

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,11 @@ The maintainer validation entrypoint is:
 sh scripts/repo-maintenance/validate-all.sh
 ```
 
+That validation path now includes the default package lane (`xcrun swift build` and
+`xcrun swift test`) before the repo-owned DocC, formatting, and lint checks, so maintainers
+do not need a separate "ordinary SwiftPM lane" command chain just to get the standard package
+signal.
+
 Direct formatter and linter commands are:
 
 ```bash

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d87d6dce8becfa09d1be778e801291c9014fdabbb4c0cf17061908d1730ba8de",
+  "originHash" : "ce688d96906062697faa2cf1a03882dbb67bb9b4cc3dab50564e352d104e2da2",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/mlx-audio-swift.git",
       "state" : {
-        "revision" : "ce483e503595c2e01a11efaa6716ffd1ebc496c1",
-        "version" : "69.1.5"
+        "revision" : "a40ac9fb1ce8f4ead5f8d913ef1f15fb80e69847",
+        "version" : "69.2.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/SpeakSwiftly.git",
       "state" : {
-        "revision" : "56b5c054263331b4018c2dba59aac57cf64a6e44",
-        "version" : "3.0.8"
+        "revision" : "f1f6daf92e9a8913f7fd076997ed93045f81f753",
+        "version" : "3.1.0"
       }
     },
     {
@@ -321,8 +321,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/TextForSpeech.git",
       "state" : {
-        "revision" : "556646677a3403771123fc498c9d6e2b6ce4b823",
-        "version" : "0.17.1"
+        "revision" : "8dfe72e9f870532f0f25027b6cf1bec17793bea3",
+        "version" : "0.17.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
         .package(
             url: "https://github.com/gaelic-ghost/SpeakSwiftly.git",
-            from: "3.0.8",
+            from: "3.1.0",
         ),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "2.30.6"),
         .package(url: "https://github.com/gaelic-ghost/TextForSpeech.git", from: "0.17.0"),

--- a/Sources/SpeakSwiftlyServer/AppManagedInstallLayout.swift
+++ b/Sources/SpeakSwiftlyServer/AppManagedInstallLayout.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-// MARK: - ServerInstallLayout
-
 /// App-facing path contract for a per-user SpeakSwiftlyServer install.
 ///
 /// The forthcoming macOS app should treat these paths as the owned install surface for the
@@ -139,15 +137,11 @@ public struct ServerInstallLayout: Codable, Sendable, Equatable {
     }
 }
 
-// MARK: - ServerInstalledLogKind
-
 /// Identifies which retained log file from an installed server snapshot a caller wants to inspect.
 public enum ServerInstalledLogKind: String, Codable, Sendable, Equatable, CaseIterable {
     case stdout
     case stderr
 }
-
-// MARK: - ServerInstalledLogFileSnapshot
 
 /// Captures one retained stdout or stderr file from an installed standalone server.
 public struct ServerInstalledLogFileSnapshot: Codable, Sendable, Equatable {
@@ -171,8 +165,6 @@ public struct ServerInstalledLogFileSnapshot: Codable, Sendable, Equatable {
     }
 }
 
-// MARK: - ServerInstalledLogsSnapshot
-
 /// Bundles the retained stdout and stderr snapshots for one installed server layout.
 public struct ServerInstalledLogsSnapshot: Codable, Sendable, Equatable {
     public let layout: ServerInstallLayout
@@ -189,8 +181,6 @@ public struct ServerInstalledLogsSnapshot: Codable, Sendable, Equatable {
         }
     }
 }
-
-// MARK: - ServerInstalledLogs
 
 /// Reads retained stdout and stderr files from an app-managed standalone server install.
 public enum ServerInstalledLogs {

--- a/Sources/SpeakSwiftlyServer/Config/AppConfig.swift
+++ b/Sources/SpeakSwiftlyServer/Config/AppConfig.swift
@@ -1,8 +1,6 @@
 import Configuration
 import Foundation
 
-// MARK: - App Config
-
 struct AppConfig {
     let server: ServerConfiguration
     let http: HTTPConfig
@@ -27,8 +25,6 @@ struct AppConfig {
         )
         mcp = try MCPConfig(config: config.scoped(to: "mcp"))
     }
-
-    // MARK: - Loading
 
     static func load(
         environment: [String: String] = ProcessInfo.processInfo.environment,

--- a/Sources/SpeakSwiftlyServer/Config/AppRuntimeDefaults.swift
+++ b/Sources/SpeakSwiftlyServer/Config/AppRuntimeDefaults.swift
@@ -1,8 +1,6 @@
 import Configuration
 import Foundation
 
-// MARK: - Runtime Default Profiles
-
 enum AppRuntimeDefaultProfile: String {
     case standaloneExecutable = "standalone-executable"
     case launchAgent = "launch-agent"

--- a/Sources/SpeakSwiftlyServer/Config/ConfigStore.swift
+++ b/Sources/SpeakSwiftlyServer/Config/ConfigStore.swift
@@ -3,8 +3,6 @@ import Foundation
 import ServiceLifecycle
 import SystemPackage
 
-// MARK: - Config Store
-
 struct ConfigStore {
     enum Update {
         case reloaded(AppConfig)

--- a/Sources/SpeakSwiftlyServer/EmbeddedLifecycleServices.swift
+++ b/Sources/SpeakSwiftlyServer/EmbeddedLifecycleServices.swift
@@ -2,13 +2,9 @@ import AsyncAlgorithms
 import Foundation
 import ServiceLifecycle
 
-// MARK: - EmbeddedLifecycleReadinessError
-
 private struct EmbeddedLifecycleReadinessError: Error {
     let message: String
 }
-
-// MARK: - EmbeddedLifecycleReadinessGate
 
 actor EmbeddedLifecycleReadinessGate {
     private enum State {
@@ -64,8 +60,6 @@ actor EmbeddedLifecycleReadinessGate {
     }
 }
 
-// MARK: - EmbeddedLifecycleShutdownBarrier
-
 actor EmbeddedLifecycleShutdownBarrier {
     private let targetCount: Int
     private var completedCount = 0
@@ -107,8 +101,6 @@ actor EmbeddedLifecycleShutdownBarrier {
     }
 }
 
-// MARK: - HostLifecycleService
-
 struct HostLifecycleService: Service {
     let host: ServerHost
     let readinessGate: EmbeddedLifecycleReadinessGate
@@ -128,8 +120,6 @@ struct HostLifecycleService: Service {
         await host.shutdown()
     }
 }
-
-// MARK: - HostPruneService
 
 struct HostPruneService: Service {
     let host: ServerHost
@@ -155,8 +145,6 @@ struct HostPruneService: Service {
         await shutdownBarrier.markCompleted()
     }
 }
-
-// MARK: - ConfigWatchService
 
 struct ConfigWatchService: Service {
     let configStore: ConfigStore
@@ -187,8 +175,6 @@ struct ConfigWatchService: Service {
     }
 }
 
-// MARK: - MCPLifecycleService
-
 struct MCPLifecycleService: Service {
     let surface: MCPSurface
     let readinessGate: EmbeddedLifecycleReadinessGate
@@ -216,8 +202,6 @@ struct MCPLifecycleService: Service {
         }
     }
 }
-
-// MARK: - EmbeddedApplicationService
 
 struct EmbeddedApplicationService: Service {
     let application: any Service

--- a/Sources/SpeakSwiftlyServer/EmbeddedServerSession.swift
+++ b/Sources/SpeakSwiftlyServer/EmbeddedServerSession.swift
@@ -2,14 +2,10 @@ import Foundation
 import Hummingbird
 import ServiceLifecycle
 
-// MARK: - EmbeddedServerLifecycleHooks
-
 struct EmbeddedServerLifecycleHooks {
     let requestStop: @Sendable () async -> Void
     let waitUntilStopped: @Sendable () async throws -> Void
 }
-
-// MARK: - EmbeddedServerStopCoordinator
 
 actor EmbeddedServerStopCoordinator {
     private var didRequestStop = false

--- a/Sources/SpeakSwiftlyServer/HTTP/HTTPConfig.swift
+++ b/Sources/SpeakSwiftlyServer/HTTP/HTTPConfig.swift
@@ -1,8 +1,6 @@
 import Configuration
 import Foundation
 
-// MARK: - HTTP Config
-
 struct HTTPConfig {
     let enabled: Bool
     let host: String

--- a/Sources/SpeakSwiftlyServer/HTTP/HTTPGenerationRoutes.swift
+++ b/Sources/SpeakSwiftlyServer/HTTP/HTTPGenerationRoutes.swift
@@ -1,7 +1,5 @@
 import Hummingbird
 
-// MARK: - Generation Routes
-
 func registerHTTPGenerationRoutes(
     on router: Router<BasicRequestContext>,
     host: ServerHost,

--- a/Sources/SpeakSwiftlyServer/HTTP/HTTPPlaybackRoutes.swift
+++ b/Sources/SpeakSwiftlyServer/HTTP/HTTPPlaybackRoutes.swift
@@ -1,7 +1,5 @@
 import Hummingbird
 
-// MARK: - Playback Routes
-
 func registerHTTPPlaybackRoutes(
     on router: Router<BasicRequestContext>,
     host: ServerHost,

--- a/Sources/SpeakSwiftlyServer/HTTP/HTTPRequestRoutes.swift
+++ b/Sources/SpeakSwiftlyServer/HTTP/HTTPRequestRoutes.swift
@@ -1,8 +1,6 @@
 import HTTPTypes
 import Hummingbird
 
-// MARK: - Request Routes
-
 func registerHTTPRequestRoutes(
     on router: Router<BasicRequestContext>,
     host: ServerHost,

--- a/Sources/SpeakSwiftlyServer/HTTP/HTTPRouteSupport.swift
+++ b/Sources/SpeakSwiftlyServer/HTTP/HTTPRouteSupport.swift
@@ -3,8 +3,6 @@ import HTTPTypes
 import Hummingbird
 import NIOCore
 
-// MARK: - Route Support
-
 func buildAcceptedRequestResponse(
     request: Request,
     configuration: HTTPConfig,

--- a/Sources/SpeakSwiftlyServer/HTTP/HTTPRuntimeRoutes.swift
+++ b/Sources/SpeakSwiftlyServer/HTTP/HTTPRuntimeRoutes.swift
@@ -1,7 +1,5 @@
 import Hummingbird
 
-// MARK: - Runtime Routes
-
 func registerHTTPRuntimeRoutes(
     on router: Router<BasicRequestContext>,
     configuration: HTTPConfig,

--- a/Sources/SpeakSwiftlyServer/HTTP/HTTPSpeechRoutes.swift
+++ b/Sources/SpeakSwiftlyServer/HTTP/HTTPSpeechRoutes.swift
@@ -1,7 +1,5 @@
 import Hummingbird
 
-// MARK: - Speech Submission Routes
-
 func registerHTTPSpeechRoutes(
     on router: Router<BasicRequestContext>,
     configuration: HTTPConfig,

--- a/Sources/SpeakSwiftlyServer/HTTP/HTTPSurface.swift
+++ b/Sources/SpeakSwiftlyServer/HTTP/HTTPSurface.swift
@@ -2,8 +2,6 @@ import Foundation
 import Hummingbird
 import ServiceLifecycle
 
-// MARK: - HTTP Surface
-
 func assembleHBApp(
     configuration: HTTPConfig,
     host: ServerHost,
@@ -37,8 +35,6 @@ func assembleHBApp(
 
     return app
 }
-
-// MARK: - Route Registration
 
 private func registerHTTPRoutes(
     on router: Router<BasicRequestContext>,

--- a/Sources/SpeakSwiftlyServer/HTTP/HTTPTextProfileRoutes.swift
+++ b/Sources/SpeakSwiftlyServer/HTTP/HTTPTextProfileRoutes.swift
@@ -1,7 +1,5 @@
 import Hummingbird
 
-// MARK: - Text Profile Routes
-
 func registerHTTPTextProfileRoutes(
     on router: Router<BasicRequestContext>,
     host: ServerHost,

--- a/Sources/SpeakSwiftlyServer/HTTP/HTTPVoiceRoutes.swift
+++ b/Sources/SpeakSwiftlyServer/HTTP/HTTPVoiceRoutes.swift
@@ -1,7 +1,5 @@
 import Hummingbird
 
-// MARK: - Voice Routes
-
 func registerHTTPVoiceRoutes(
     on router: Router<BasicRequestContext>,
     configuration: HTTPConfig,

--- a/Sources/SpeakSwiftlyServer/HealthcheckCommand+Transport.swift
+++ b/Sources/SpeakSwiftlyServer/HealthcheckCommand+Transport.swift
@@ -119,8 +119,6 @@ extension SpeakSwiftlyServerHealthcheck {
     }
 }
 
-// MARK: - Healthcheck Transport Models
-
 struct DecodedHTTPResponse<Response> {
     let statusCode: Int
     let value: Response

--- a/Sources/SpeakSwiftlyServer/Host/HostEvents.swift
+++ b/Sources/SpeakSwiftlyServer/Host/HostEvents.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-// MARK: - ProfileCacheStatusSnapshot
-
 struct ProfileCacheStatusSnapshot: Codable, Equatable {
     let state: String
     let warning: String?
@@ -16,8 +14,6 @@ struct ProfileCacheStatusSnapshot: Codable, Equatable {
     }
 }
 
-// MARK: - TextProfilesStatusSnapshot
-
 struct TextProfilesStatusSnapshot: Codable, Equatable {
     let activeProfileID: String
     let storedProfileCount: Int
@@ -27,8 +23,6 @@ struct TextProfilesStatusSnapshot: Codable, Equatable {
         case storedProfileCount = "stored_profile_count"
     }
 }
-
-// MARK: - RuntimeConfigurationStatusSnapshot
 
 struct RuntimeConfigurationStatusSnapshot: Codable, Equatable {
     let activeRuntimeSpeechBackend: String
@@ -54,16 +48,12 @@ struct RuntimeConfigurationStatusSnapshot: Codable, Equatable {
     }
 }
 
-// MARK: - JobEventUpdate
-
 struct JobEventUpdate: Equatable {
     let jobID: String
     let event: ServerJobEvent
     let historyIndex: Int
     let terminal: Bool
 }
-
-// MARK: - HostEvent
 
 enum HostEvent {
     case transportChanged(TransportStatusSnapshot)

--- a/Sources/SpeakSwiftlyServer/Host/HostStateModels.swift
+++ b/Sources/SpeakSwiftlyServer/Host/HostStateModels.swift
@@ -2,8 +2,6 @@ import Foundation
 import Hummingbird
 import SpeakSwiftly
 
-// MARK: - HostOverviewSnapshot
-
 /// High-level readiness and profile-cache status for the shared host.
 public struct HostOverviewSnapshot: Codable, Sendable, Equatable {
     enum CodingKeys: String, CodingKey {
@@ -52,8 +50,6 @@ public struct HostOverviewSnapshot: Codable, Sendable, Equatable {
     }
 }
 
-// MARK: - QueueStatusSnapshot
-
 /// Active and queued work for one host queue.
 public struct QueueStatusSnapshot: Codable, Sendable, Equatable {
     public let queueType: String
@@ -72,8 +68,6 @@ public struct QueueStatusSnapshot: Codable, Sendable, Equatable {
         case queuedRequests = "queued_requests"
     }
 }
-
-// MARK: - PlaybackStatusSnapshot
 
 /// App-facing playback state reported by the shared runtime.
 public struct PlaybackStatusSnapshot: Codable, Sendable, Equatable {
@@ -119,8 +113,6 @@ public struct PlaybackStatusSnapshot: Codable, Sendable, Equatable {
     }
 }
 
-// MARK: - RuntimeRefreshSnapshot
-
 /// Timing markers for one completed refresh cycle of the host state snapshots.
 public struct RuntimeRefreshSnapshot: Codable, Sendable, Equatable {
     public let sequenceID: Int
@@ -141,8 +133,6 @@ public struct RuntimeRefreshSnapshot: Codable, Sendable, Equatable {
         case completedAt = "completed_at"
     }
 }
-
-// MARK: - CurrentGenerationJobSnapshot
 
 /// Summary of one generation job that is currently active in the runtime.
 public struct CurrentGenerationJobSnapshot: Codable, Sendable, Equatable {
@@ -165,8 +155,6 @@ public struct CurrentGenerationJobSnapshot: Codable, Sendable, Equatable {
     }
 }
 
-// MARK: - TransportStatusSnapshot
-
 /// Status for one published operator transport such as HTTP or MCP.
 public struct TransportStatusSnapshot: Codable, Sendable, Equatable {
     public let name: String
@@ -188,8 +176,6 @@ public struct TransportStatusSnapshot: Codable, Sendable, Equatable {
     }
 }
 
-// MARK: - RecentErrorSnapshot
-
 /// One retained host or transport error suitable for operator display.
 public struct RecentErrorSnapshot: Codable, Sendable, Equatable {
     public let occurredAt: String
@@ -204,8 +190,6 @@ public struct RecentErrorSnapshot: Codable, Sendable, Equatable {
         case message
     }
 }
-
-// MARK: - RuntimeConfigurationSnapshot
 
 /// The active and next-start runtime configuration state exposed by the host.
 public struct RuntimeConfigurationSnapshot: Codable, ResponseEncodable, Sendable, Equatable {
@@ -243,8 +227,6 @@ public struct RuntimeConfigurationSnapshot: Codable, ResponseEncodable, Sendable
         case persistedConfigurationWillAffectNextRuntimeStart = "persisted_configuration_will_affect_next_runtime_start"
     }
 }
-
-// MARK: - HostStateSnapshot
 
 /// Aggregate snapshot of the host state that bundles overview, queues, runtime, transport, and error data.
 public struct HostStateSnapshot: Codable, Sendable, Equatable {

--- a/Sources/SpeakSwiftlyServer/Host/JobEventModels.swift
+++ b/Sources/SpeakSwiftlyServer/Host/JobEventModels.swift
@@ -2,8 +2,6 @@ import Foundation
 import Hummingbird
 import SpeakSwiftly
 
-// MARK: - ServerWorkerStatusEvent
-
 /// Worker readiness or mode change emitted on the shared job event stream.
 struct ServerWorkerStatusEvent: Encodable, Equatable {
     let event = "worker_status"
@@ -16,8 +14,6 @@ struct ServerWorkerStatusEvent: Encodable, Equatable {
         case workerMode = "worker_mode"
     }
 }
-
-// MARK: - ServerQueuedEvent
 
 /// Queue-placement event emitted when a request cannot start immediately.
 struct ServerQueuedEvent: Encodable, Equatable {
@@ -34,8 +30,6 @@ struct ServerQueuedEvent: Encodable, Equatable {
     }
 }
 
-// MARK: - ServerStartedEvent
-
 /// Start event emitted when a queued request begins execution.
 struct ServerStartedEvent: Encodable, Equatable {
     let id: String
@@ -43,16 +37,12 @@ struct ServerStartedEvent: Encodable, Equatable {
     let op: String
 }
 
-// MARK: - ServerProgressEvent
-
 /// Progress event emitted while a request advances through runtime stages.
 struct ServerProgressEvent: Encodable, Equatable {
     let id: String
     let event = "progress"
     let stage: String
 }
-
-// MARK: - ServerSuccessEvent
 
 /// Success-shaped event payload used for acknowledgements and completions.
 struct ServerSuccessEvent: Encodable, Equatable {
@@ -105,8 +95,6 @@ struct ServerSuccessEvent: Encodable, Equatable {
     let cancelledRequestID: String?
 }
 
-// MARK: - ServerFailureEvent
-
 /// Failure-shaped event payload emitted when a request cannot complete successfully.
 struct ServerFailureEvent: Encodable, Equatable {
     let id: String
@@ -114,8 +102,6 @@ struct ServerFailureEvent: Encodable, Equatable {
     let code: String
     let message: String
 }
-
-// MARK: - ServerJobEvent
 
 /// Union event type for one job's lifecycle on the shared event stream.
 enum ServerJobEvent: Equatable, Encodable {
@@ -176,8 +162,6 @@ enum ServerJobEvent: Equatable, Encodable {
         }
     }
 }
-
-// MARK: - JobSnapshot
 
 /// Snapshot of one retained request lifecycle, including latest and terminal events.
 struct JobSnapshot: ResponseEncodable {

--- a/Sources/SpeakSwiftlyServer/Host/ProfileModels.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ProfileModels.swift
@@ -3,8 +3,6 @@ import Hummingbird
 import SpeakSwiftly
 import TextForSpeech
 
-// MARK: - ProfileSnapshot
-
 /// Summary of one cached voice profile known to the shared runtime.
 public struct ProfileSnapshot: Codable, Sendable, Equatable {
     public let profileName: String
@@ -44,13 +42,9 @@ public struct ProfileSnapshot: Codable, Sendable, Equatable {
     }
 }
 
-// MARK: - ProfileListResponse
-
 struct ProfileListResponse: ResponseEncodable {
     let profiles: [ProfileSnapshot]
 }
-
-// MARK: - RenameVoiceProfileRequestPayload
 
 struct RenameVoiceProfileRequestPayload: Decodable {
     let newProfileName: String
@@ -59,8 +53,6 @@ struct RenameVoiceProfileRequestPayload: Decodable {
         case newProfileName = "new_profile_name"
     }
 }
-
-// MARK: - TextReplacementSnapshot
 
 /// One text-normalization replacement rule exposed through the server surfaces.
 struct TextReplacementSnapshot: Codable, Equatable {
@@ -203,8 +195,6 @@ struct TextReplacementSnapshot: Codable, Equatable {
     }
 }
 
-// MARK: - TextProfileSnapshot
-
 /// One text profile and its replacement rules as exposed by the server.
 struct TextProfileSnapshot: Codable, Equatable {
     let id: String
@@ -226,8 +216,6 @@ struct TextProfileSnapshot: Codable, Equatable {
     }
 }
 
-// MARK: - TextProfileStyleSnapshot
-
 struct TextProfileStyleSnapshot: Codable, Equatable {
     let builtInStyle: String
 
@@ -239,8 +227,6 @@ struct TextProfileStyleSnapshot: Codable, Equatable {
         builtInStyle = style.rawValue
     }
 }
-
-// MARK: - TextProfilesSnapshot
 
 struct TextProfilesSnapshot: ResponseEncodable, Equatable {
     let builtInStyle: String
@@ -258,8 +244,6 @@ struct TextProfilesSnapshot: ResponseEncodable, Equatable {
     }
 }
 
-// MARK: - TextProfileListResponse
-
 struct TextProfileListResponse: ResponseEncodable {
     let textProfiles: TextProfilesSnapshot
 
@@ -268,13 +252,9 @@ struct TextProfileListResponse: ResponseEncodable {
     }
 }
 
-// MARK: - TextProfileResponse
-
 struct TextProfileResponse: ResponseEncodable {
     let profile: TextProfileSnapshot
 }
-
-// MARK: - TextProfileStyleResponse
 
 struct TextProfileStyleResponse: ResponseEncodable {
     let textProfileStyle: TextProfileStyleSnapshot
@@ -284,33 +264,23 @@ struct TextProfileStyleResponse: ResponseEncodable {
     }
 }
 
-// MARK: - CreateTextProfileRequestPayload
-
 struct CreateTextProfileRequestPayload: Decodable {
     let id: String
     let name: String
     let replacements: [TextReplacementSnapshot]
 }
 
-// MARK: - StoreTextProfileRequestPayload
-
 struct StoreTextProfileRequestPayload: Decodable {
     let profile: TextProfileSnapshot
 }
-
-// MARK: - UseTextProfileRequestPayload
 
 struct UseTextProfileRequestPayload: Decodable {
     let profile: TextProfileSnapshot
 }
 
-// MARK: - TextReplacementRequestPayload
-
 struct TextReplacementRequestPayload: Decodable {
     let replacement: TextReplacementSnapshot
 }
-
-// MARK: - SetTextProfileStyleRequestPayload
 
 struct SetTextProfileStyleRequestPayload: Decodable {
     let builtInStyle: String

--- a/Sources/SpeakSwiftlyServer/Host/QueueStatusModels.swift
+++ b/Sources/SpeakSwiftlyServer/Host/QueueStatusModels.swift
@@ -2,8 +2,6 @@ import Foundation
 import Hummingbird
 import SpeakSwiftly
 
-// MARK: - ActiveRequestSnapshot
-
 /// The active request currently running in a host queue.
 public struct ActiveRequestSnapshot: Codable, Sendable, Equatable {
     public let id: String
@@ -28,8 +26,6 @@ public struct ActiveRequestSnapshot: Codable, Sendable, Equatable {
         self.profileName = profileName
     }
 }
-
-// MARK: - QueuedRequestSnapshot
 
 /// A queued request waiting for work in a host queue.
 public struct QueuedRequestSnapshot: Codable, Sendable, Equatable {
@@ -60,8 +56,6 @@ public struct QueuedRequestSnapshot: Codable, Sendable, Equatable {
     }
 }
 
-// MARK: - QueueSnapshotResponse
-
 struct QueueSnapshotResponse: ResponseEncodable {
     let queueType: String
     let activeRequest: ActiveRequestSnapshot?
@@ -75,8 +69,6 @@ struct QueueSnapshotResponse: ResponseEncodable {
         case queue
     }
 }
-
-// MARK: - PlaybackStateSnapshot
 
 /// Transport-facing playback state snapshot used by HTTP and MCP control surfaces.
 struct PlaybackStateSnapshot: Codable, Equatable {
@@ -106,8 +98,6 @@ struct PlaybackStateSnapshot: Codable, Equatable {
     }
 }
 
-// MARK: - PlaybackStateResponse
-
 struct PlaybackStateResponse: ResponseEncodable {
     let playback: PlaybackStateSnapshot
 }
@@ -123,8 +113,6 @@ extension PlaybackStateSnapshot {
     }
 }
 
-// MARK: - QueueClearedResponse
-
 struct QueueClearedResponse: ResponseEncodable {
     let clearedCount: Int
 
@@ -133,8 +121,6 @@ struct QueueClearedResponse: ResponseEncodable {
     }
 }
 
-// MARK: - QueueCancellationResponse
-
 struct QueueCancellationResponse: ResponseEncodable {
     let cancelledRequestID: String
 
@@ -142,8 +128,6 @@ struct QueueCancellationResponse: ResponseEncodable {
         case cancelledRequestID = "cancelled_request_id"
     }
 }
-
-// MARK: - HealthSnapshot
 
 struct HealthSnapshot: ResponseEncodable {
     let status: String
@@ -166,8 +150,6 @@ struct HealthSnapshot: ResponseEncodable {
         case startupError = "startup_error"
     }
 }
-
-// MARK: - ReadinessSnapshot
 
 struct ReadinessSnapshot: ResponseEncodable {
     let status: String
@@ -194,8 +176,6 @@ struct ReadinessSnapshot: ResponseEncodable {
         case lastProfileRefreshAt = "last_profile_refresh_at"
     }
 }
-
-// MARK: - StatusSnapshot
 
 struct StatusSnapshot: ResponseEncodable {
     enum CodingKeys: String, CodingKey {

--- a/Sources/SpeakSwiftlyServer/Host/RuntimeConfigurationStore.swift
+++ b/Sources/SpeakSwiftlyServer/Host/RuntimeConfigurationStore.swift
@@ -1,8 +1,6 @@
 import Foundation
 import SpeakSwiftly
 
-// MARK: - RuntimeConfigurationStore
-
 struct RuntimeConfigurationStore {
     private final class FileSystem: @unchecked Sendable {
         private let fileManager: FileManager
@@ -294,8 +292,6 @@ private extension RuntimeConfigurationStore {
         }
     }
 }
-
-// MARK: - RuntimeConfigurationStoreError
 
 struct RuntimeConfigurationStoreError: LocalizedError {
     let message: String

--- a/Sources/SpeakSwiftlyServer/Host/ServerConfiguration.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerConfiguration.swift
@@ -1,8 +1,6 @@
 import Configuration
 import Foundation
 
-// MARK: - ServerConfiguration
-
 struct ServerConfiguration {
     let name: String
     let environment: String
@@ -117,8 +115,6 @@ struct ServerConfiguration {
         return value
     }
 }
-
-// MARK: - ServerConfigurationError
 
 struct ServerConfigurationError: Error, CustomStringConvertible {
     let message: String

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+ControlSupport.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+ControlSupport.swift
@@ -1,8 +1,6 @@
 import Foundation
 import SpeakSwiftly
 
-// MARK: - Host Control Support
-
 extension ServerHost {
     // MARK: - Playback Control Helpers
 

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+EventSupport.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+EventSupport.swift
@@ -2,8 +2,6 @@ import Foundation
 import Hummingbird
 import SpeakSwiftly
 
-// MARK: - Host Event Support
-
 extension ServerHost {
     // MARK: - Transport and Error Tracking
 

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+JobSubmission.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+JobSubmission.swift
@@ -3,8 +3,6 @@ import Hummingbird
 import SpeakSwiftly
 import TextForSpeech
 
-// MARK: - Job Submission
-
 extension ServerHost {
     func queueSpeechLive(
         text: String,

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+JobTracking.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+JobTracking.swift
@@ -3,8 +3,6 @@ import Hummingbird
 import SpeakSwiftly
 import TextForSpeech
 
-// MARK: - Job Tracking
-
 extension ServerHost {
     func jobSnapshot(id: String) throws -> JobSnapshot {
         pruneCompletedJobs()

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+Lifecycle.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+Lifecycle.swift
@@ -1,8 +1,6 @@
 import AsyncAlgorithms
 import Foundation
 
-// MARK: - Host Lifecycle Surface
-
 extension ServerHost {
     // MARK: - Runtime Lifecycle
 

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+ProfileQueries.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+ProfileQueries.swift
@@ -3,8 +3,6 @@ import Hummingbird
 import SpeakSwiftly
 import TextForSpeech
 
-// MARK: - Profile Query Surface
-
 extension ServerHost {
     // MARK: - Voice Profile Queries
 

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+Queries.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+Queries.swift
@@ -3,8 +3,6 @@ import Hummingbird
 import SpeakSwiftly
 import TextForSpeech
 
-// MARK: - Query Surface
-
 extension ServerHost {
     // MARK: - Public Query Surface
 

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+State.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+State.swift
@@ -1,8 +1,6 @@
 import Foundation
 import SpeakSwiftly
 
-// MARK: - Host State Flow
-
 extension ServerHost {
     // MARK: - Publish Flow
 

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost.swift
@@ -4,8 +4,6 @@ import Hummingbird
 import SpeakSwiftly
 import TextForSpeech
 
-// MARK: - Server Host
-
 actor ServerHost {
     enum PublishMode {
         case immediate

--- a/Sources/SpeakSwiftlyServer/Host/ServerModels.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerModels.swift
@@ -3,8 +3,6 @@ import Hummingbird
 import SpeakSwiftly
 import TextForSpeech
 
-// MARK: - Speech Backend Surface Helpers
-
 func exposedSpeechBackendIdentifiers() -> [String] {
     SpeakSwiftly.SpeechBackend.allCases.map(\.rawValue)
 }
@@ -49,8 +47,6 @@ func makeSpeechSourceFormat(_ rawValue: String?) throws -> TextForSpeech.SourceF
     try rawValue.flatMap { try resolveSourceFormat($0, fieldName: "source_format") }
 }
 
-// MARK: - SpeakRequestPayload
-
 struct SpeakRequestPayload: Decodable {
     enum CodingKeys: String, CodingKey {
         case text
@@ -86,8 +82,6 @@ struct SpeakRequestPayload: Decodable {
     }
 }
 
-// MARK: - CreateProfileRequestPayload
-
 struct CreateProfileRequestPayload: Decodable {
     let profileName: String
     let vibe: String
@@ -110,8 +104,6 @@ struct CreateProfileRequestPayload: Decodable {
     }
 }
 
-// MARK: - CreateCloneRequestPayload
-
 struct CreateCloneRequestPayload: Decodable {
     let profileName: String
     let vibe: String
@@ -132,8 +124,6 @@ struct CreateCloneRequestPayload: Decodable {
     }
 }
 
-// MARK: - GenerateBatchRequestPayload
-
 struct GenerateBatchRequestPayload: Decodable {
     let profileName: String?
     let items: [BatchItemRequestPayload]
@@ -143,8 +133,6 @@ struct GenerateBatchRequestPayload: Decodable {
         case items
     }
 }
-
-// MARK: - BatchItemRequestPayload
 
 struct BatchItemRequestPayload: Decodable {
     enum CodingKeys: String, CodingKey {
@@ -191,8 +179,6 @@ struct BatchItemRequestPayload: Decodable {
     }
 }
 
-// MARK: - RuntimeConfigurationUpdatePayload
-
 struct RuntimeConfigurationUpdatePayload: Decodable {
     let speechBackend: String
 
@@ -204,8 +190,6 @@ struct RuntimeConfigurationUpdatePayload: Decodable {
         try resolveSpeechBackend(speechBackend, fieldName: "speech_backend")
     }
 }
-
-// MARK: - RequestAcceptedResponse
 
 struct RequestAcceptedResponse: ResponseEncodable {
     let requestID: String
@@ -219,19 +203,13 @@ struct RequestAcceptedResponse: ResponseEncodable {
     }
 }
 
-// MARK: - RequestListResponse
-
 struct RequestListResponse: ResponseEncodable {
     let requests: [JobSnapshot]
 }
 
-// MARK: - RuntimeStatusResponse
-
 struct RuntimeStatusResponse: ResponseEncodable {
     let status: SpeakSwiftly.StatusEvent
 }
-
-// MARK: - RuntimeBackendResponse
 
 struct RuntimeBackendResponse: ResponseEncodable {
     let speechBackend: String
@@ -241,16 +219,12 @@ struct RuntimeBackendResponse: ResponseEncodable {
     }
 }
 
-// MARK: - TimestampFormatter
-
 enum TimestampFormatter {
     static func string(from date: Date) -> String {
         let formatter = ISO8601DateFormatter()
         return formatter.string(from: date)
     }
 }
-
-// MARK: - NormalizationFormat
 
 enum NormalizationFormat {
     case text(TextForSpeech.TextFormat)

--- a/Sources/SpeakSwiftlyServer/Host/ServerRuntimeAdapter.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerRuntimeAdapter.swift
@@ -2,8 +2,6 @@ import Foundation
 import SpeakSwiftly
 import TextForSpeech
 
-// MARK: - Runtime Adapter
-
 actor ServerRuntimeAdapter: ServerRuntimeProtocol {
     private let runtime: SpeakSwiftly.Runtime
 

--- a/Sources/SpeakSwiftlyServer/Host/ServerRuntimeProtocol.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerRuntimeProtocol.swift
@@ -4,8 +4,6 @@ import TextForSpeech
 
 typealias SpeechNormalizationContext = TextForSpeech.Context
 
-// MARK: - RuntimeRequestHandle
-
 struct RuntimeRequestHandle {
     let id: String
     let operation: String
@@ -34,8 +32,6 @@ struct RuntimeRequestHandle {
     }
 }
 
-// MARK: - Operation Naming
-
 func canonicalOperationName(_ operation: String) -> String {
     switch operation {
         case "queue_speech_live":
@@ -56,8 +52,6 @@ func canonicalOperationName(_ operation: String) -> String {
             operation
     }
 }
-
-// MARK: - ServerRuntimeProtocol
 
 protocol ServerRuntimeProtocol: Actor {
     func start() async

--- a/Sources/SpeakSwiftlyServer/Host/ServerState.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerState.swift
@@ -2,8 +2,6 @@ import Foundation
 import Observation
 import SpeakSwiftly
 
-// MARK: - Embedded Server
-
 /// Main-actor observable app model for an embedded SpeakSwiftly server session.
 ///
 /// `EmbeddedServer` is the consumer-facing type an app should own directly. It exposes the current

--- a/Sources/SpeakSwiftlyServer/Host/SpeakSwiftlyRuntimeLauncher.swift
+++ b/Sources/SpeakSwiftlyServer/Host/SpeakSwiftlyRuntimeLauncher.swift
@@ -1,8 +1,6 @@
 import Foundation
 import SpeakSwiftly
 
-// MARK: - SpeakSwiftly Runtime Launcher
-
 /// Bridges package-owned startup environment overrides into `SpeakSwiftly.liftoff(...)`.
 ///
 /// `SpeakSwiftly` currently resolves its profile-root override from the process environment during

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentCommands.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentCommands.swift
@@ -2,8 +2,6 @@ import Foundation
 
 let speakSwiftlyServerToolName = "SpeakSwiftlyServerTool"
 
-// MARK: - ServeOptions
-
 package struct ServeOptions {
     let runtimeProfileRootPath: String?
 
@@ -35,8 +33,6 @@ package struct ServeOptions {
         )
     }
 }
-
-// MARK: - SpeakSwiftlyServerToolCommand
 
 /// Top-level parsed command for the `SpeakSwiftlyServerTool` executable.
 package enum SpeakSwiftlyServerToolCommand {
@@ -77,8 +73,6 @@ package enum SpeakSwiftlyServerToolCommand {
 
       Without arguments, \(speakSwiftlyServerToolName) defaults to `serve`.
     """
-
-    // MARK: - Parsing
 
     /// Parses command-line arguments into the tool's top-level command model.
     package static func parse(
@@ -131,8 +125,6 @@ package enum SpeakSwiftlyServerToolCommand {
         }
     }
 
-    // MARK: - Running
-
     /// Runs the parsed command against the standalone runtime or LaunchAgent workflow.
     package func run() async throws {
         switch self {
@@ -150,8 +142,6 @@ package enum SpeakSwiftlyServerToolCommand {
     }
 }
 
-// MARK: - SpeakSwiftlyServerToolCommandError
-
 /// Human-friendly parse or usage error for the top-level executable command surface.
 package struct SpeakSwiftlyServerToolCommandError: Error, CustomStringConvertible {
     package let message: String
@@ -162,8 +152,6 @@ package struct SpeakSwiftlyServerToolCommandError: Error, CustomStringConvertibl
 
     package var description: String { message }
 }
-
-// MARK: - LaunchAgentCommand
 
 /// Parsed subcommand for LaunchAgent install, uninstall, status, and property-list rendering.
 package struct LaunchAgentCommand {
@@ -176,8 +164,6 @@ package struct LaunchAgentCommand {
     }
 
     let action: Action
-
-    // MARK: - Parsing
 
     /// Parses the `launch-agent` subcommand surface.
     static func parse(arguments: [String], currentDirectoryPath: String, currentExecutablePath: String) throws -> LaunchAgentCommand {
@@ -217,8 +203,6 @@ package struct LaunchAgentCommand {
         }
     }
 
-    // MARK: - Running
-
     /// Executes the requested LaunchAgent management action.
     func run() throws {
         switch action {
@@ -246,8 +230,6 @@ package struct LaunchAgentCommand {
         }
     }
 }
-
-// MARK: - LaunchAgentCommandError
 
 /// Human-friendly parse or execution error for the LaunchAgent command surface.
 package typealias LaunchAgentCommandError = SpeakSwiftlyServerToolCommandError

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentOptions.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentOptions.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-// MARK: - Launch Agent Options
-
 struct LaunchAgentOptions {
     let label: String
     let toolExecutablePath: String
@@ -61,8 +59,6 @@ struct LaunchAgentOptions {
         self.launchctlPath = launchctlPath
         self.userDomain = userDomain
     }
-
-    // MARK: - Parsing
 
     static func parse(
         arguments: [String],

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentPromotion.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentPromotion.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-// MARK: - LaunchAgentPromoteOptions
-
 struct LaunchAgentPromoteOptions {
     let installOptions: LaunchAgentOptions
     let repositoryRootPath: String
@@ -55,15 +53,11 @@ struct LaunchAgentPromoteOptions {
     }
 }
 
-// MARK: - ReleaseArtifactPromotionResult
-
 private struct ReleaseArtifactPromotionResult {
     let builtExecutablePath: String
     let stagedExecutablePath: String
     let stagedMetallibPath: String
 }
-
-// MARK: - ReleaseArtifactPromoter
 
 private enum ReleaseArtifactPromoter {
     private struct SpeakSwiftlyPublishedRuntimeMetadata: Decodable {

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentRuntime.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentRuntime.swift
@@ -6,8 +6,6 @@ import Foundation
 let launchAgentGraceIntervalMicroseconds: useconds_t = 100_000
 let launchAgentBootstrapRetryCount = 10
 
-// MARK: - LaunchAgentStatusOptions
-
 struct LaunchAgentStatusOptions {
     let label: String
     let plistPath: String
@@ -123,8 +121,6 @@ struct LaunchAgentStatusOptions {
     }
 }
 
-// MARK: - LaunchAgentDefaults
-
 enum LaunchAgentDefaults {
     static let label = "com.gaelic-ghost.speak-swiftly-server"
     static let defaultProfile: AppRuntimeDefaultProfile = .launchAgent
@@ -151,15 +147,11 @@ enum LaunchAgentDefaults {
     }
 }
 
-// MARK: - LaunchctlResult
-
 struct LaunchctlResult {
     let exitCode: Int32
     let standardOutput: String
     let standardError: String
 }
-
-// MARK: - ProcessExecutionResult
 
 struct ProcessExecutionResult {
     let exitCode: Int32

--- a/Sources/SpeakSwiftlyServer/MCP/MCPConfig.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPConfig.swift
@@ -1,8 +1,6 @@
 import Configuration
 import Foundation
 
-// MARK: - MCP Config
-
 struct MCPConfig {
     let enabled: Bool
     let path: String

--- a/Sources/SpeakSwiftlyServer/MCP/MCPHTTPBridge.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPHTTPBridge.swift
@@ -4,8 +4,6 @@ import Hummingbird
 import MCP
 import NIOCore
 
-// MARK: - HTTP Bridge
-
 enum MCPHTTPBridge {
     static func makeHTTPRequest(from request: Request) async throws -> MCP.HTTPRequest {
         let bodyBuffer = try await request.body.collect(upTo: 10 * 1024 * 1024)

--- a/Sources/SpeakSwiftlyServer/MCP/MCPModels.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPModels.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-// MARK: - MCP Models
-
 struct MCPAcceptedRequestResult: Codable {
     let requestID: String
     let requestResourceURI: String

--- a/Sources/SpeakSwiftlyServer/MCP/MCPPrompts.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPPrompts.swift
@@ -1,8 +1,6 @@
 import Foundation
 import MCP
 
-// MARK: - MCPPromptCatalog
-
 enum MCPPromptCatalog {
     static let promptNames = Set([
         "draft_profile_voice_description",

--- a/Sources/SpeakSwiftlyServer/MCP/MCPResources.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPResources.swift
@@ -1,8 +1,6 @@
 import Foundation
 import MCP
 
-// MARK: - MCPResourceCatalog
-
 enum MCPResourceCatalog {
     static let resourceURIs = Set([
         "speak://runtime/overview",

--- a/Sources/SpeakSwiftlyServer/MCP/MCPSession.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPSession.swift
@@ -1,7 +1,5 @@
 import MCP
 
-// MARK: - Session
-
 actor MCPSession {
     private let host: ServerHost
     private let transport: StatefulHTTPServerTransport

--- a/Sources/SpeakSwiftlyServer/MCP/MCPSessionRegistry.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPSessionRegistry.swift
@@ -2,8 +2,6 @@ import Foundation
 import HTTPTypes
 import MCP
 
-// MARK: - MCPSessionRegistry
-
 actor MCPSessionRegistry {
     let path: String
 

--- a/Sources/SpeakSwiftlyServer/MCP/MCPSurface.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPSurface.swift
@@ -2,8 +2,6 @@ import Foundation
 import Hummingbird
 import MCP
 
-// MARK: - MCP Surface
-
 struct MCPSurface {
     private let sessions: MCPSessionRegistry
 

--- a/Sources/SpeakSwiftlyServer/MCP/MCPToolCatalog.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPToolCatalog.swift
@@ -1,8 +1,6 @@
 import Foundation
 import MCP
 
-// MARK: - Tool Catalog
-
 enum MCPToolCatalog {
     static let definitions: [Tool] = [
         Tool(

--- a/Sources/SpeakSwiftlyServer/MCP/MCPToolHandlers.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPToolHandlers.swift
@@ -3,8 +3,6 @@ import MCP
 import SpeakSwiftly
 import TextForSpeech
 
-// MARK: - Tool Handlers
-
 extension MCPSurface {
     static func registerToolHandlers(
         on server: Server,

--- a/Sources/SpeakSwiftlyServer/MCP/MCPToolSupport.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPToolSupport.swift
@@ -21,7 +21,7 @@ func acceptedRequestResult(requestID: String, message: String) -> MCPAcceptedReq
 }
 
 func supportedRawValuesDescription<T: RawRepresentable & CaseIterable>(_ type: T.Type) -> String
-where T.AllCases: Collection, T.RawValue == String {
+    where T.AllCases: Collection, T.RawValue == String {
     T.allCases.map(\.rawValue).joined(separator: ", ")
 }
 
@@ -30,7 +30,7 @@ func decodeStringEnum<T: RawRepresentable & CaseIterable>(
     fieldName: String,
     valueType: T.Type,
 ) throws -> T
-where T.AllCases: Collection, T.RawValue == String {
+    where T.AllCases: Collection, T.RawValue == String {
     guard let value = T(rawValue: rawValue) else {
         throw MCPError.invalidParams(
             "Tool argument '\(fieldName)' used unsupported value '\(rawValue)'. Expected one of: \(supportedRawValuesDescription(T.self)).",

--- a/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.swift
+++ b/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-// MARK: - ServerRuntimeEntrypointOptions
-
 package struct ServerRuntimeEntrypointOptions {
     package let runtimeProfileRootPath: String?
 
@@ -14,8 +12,6 @@ package struct ServerRuntimeEntrypointOptions {
         }
     }
 }
-
-// MARK: - ServerRuntimeEntrypoint
 
 /// Starts the standalone SpeakSwiftly server runtime using the package's default embedded bootstrap path.
 package enum ServerRuntimeEntrypoint {

--- a/Tests/SpeakSwiftlyServerE2ETests/E2ETransportSmokeTests.swift
+++ b/Tests/SpeakSwiftlyServerE2ETests/E2ETransportSmokeTests.swift
@@ -20,17 +20,17 @@ extension ServerTransportE2ETests {
         let client = E2EHTTPClient(baseURL: server.baseURL)
         try await waitUntilWorkerReady(using: client, timeout: Self.e2eTimeout, server: server)
 
-        let health = try decode(
+        let health = try await decode(
             E2EHealthSnapshot.self,
-            from: try await client.request(path: "/healthz", method: "GET").data,
+            from: client.request(path: "/healthz", method: "GET").data,
         )
         #expect(health.status == "ok")
         #expect(health.workerMode == "ready")
         #expect(health.workerReady)
 
-        let readiness = try decode(
+        let readiness = try await decode(
             E2EReadinessSnapshot.self,
-            from: try await client.request(path: "/readyz", method: "GET").data,
+            from: client.request(path: "/readyz", method: "GET").data,
         )
         #expect(readiness.workerReady)
 
@@ -44,9 +44,9 @@ extension ServerTransportE2ETests {
         )
         try await ServerE2E.assertProfileIsVisible(using: client, profileName: profileName)
 
-        let status = try decode(
+        let status = try await decode(
             E2EStatusSnapshot.self,
-            from: try await client.request(path: "/runtime/host", method: "GET").data,
+            from: client.request(path: "/runtime/host", method: "GET").data,
         )
         #expect(status.workerMode == "ready")
         #expect(status.cachedProfiles.contains { $0.profileName == profileName })
@@ -65,9 +65,9 @@ extension ServerTransportE2ETests {
         )
         ServerE2E.assertSpeechJobCompleted(terminalSnapshot, expectedJobID: jobID)
 
-        let retainedSnapshot = try decode(
+        let retainedSnapshot = try await decode(
             E2EJobSnapshot.self,
-            from: try await client.request(path: "/requests/\(jobID)", method: "GET").data,
+            from: client.request(path: "/requests/\(jobID)", method: "GET").data,
         )
         #expect(retainedSnapshot.requestID == jobID)
         #expect(retainedSnapshot.status == "completed")
@@ -101,8 +101,8 @@ extension ServerTransportE2ETests {
         )
         try await waitUntilWorkerReady(using: client, timeout: Self.e2eTimeout, server: server)
 
-        let runtimeOverview = try Self.requireObjectPayload(
-            from: try await client.readResourceJSON(uri: "speak://runtime/overview"),
+        let runtimeOverview = try await Self.requireObjectPayload(
+            from: client.readResourceJSON(uri: "speak://runtime/overview"),
         )
         let transports = try requireArray("transports", in: runtimeOverview)
         #expect(transports.contains {
@@ -151,8 +151,8 @@ extension ServerTransportE2ETests {
         let profiles = try await requireProfiles(from: client.callToolJSON(name: "list_voice_profiles", arguments: [:]))
         #expect(profiles.contains { $0.profileName == profileName })
 
-        let profileDetail = try Self.requireObjectPayload(
-            from: try await client.readResourceJSON(uri: "speak://voices/\(profileName)"),
+        let profileDetail = try await Self.requireObjectPayload(
+            from: client.readResourceJSON(uri: "speak://voices/\(profileName)"),
         )
         #expect(profileDetail["profile_name"] as? String == profileName)
 
@@ -174,8 +174,8 @@ extension ServerTransportE2ETests {
         )
         ServerE2E.assertSpeechJobCompleted(speechTerminal, expectedJobID: speechJobID)
 
-        let retainedRequest = try Self.requireObjectPayload(
-            from: try await client.readResourceJSON(uri: "speak://requests/\(speechJobID)"),
+        let retainedRequest = try await Self.requireObjectPayload(
+            from: client.readResourceJSON(uri: "speak://requests/\(speechJobID)"),
         )
         #expect(retainedRequest["request_id"] as? String == speechJobID)
         #expect(retainedRequest["status"] as? String == "completed")

--- a/docs/releases/v4.0.0-rc.1-release-checklist.md
+++ b/docs/releases/v4.0.0-rc.1-release-checklist.md
@@ -22,24 +22,16 @@ That major prerelease bump matches the current change shape:
 ## Pre-Tag Checklist
 
 - keep the worktree clean before release preparation or publish
-- confirm the default package lane still passes:
-
-```bash
-xcrun swift build
-xcrun swift test
-```
-
-- confirm the maintainer validation path passes:
+- confirm the maintainer validation path passes. This now includes the default package lane (`xcrun swift build` and `xcrun swift test`):
 
 ```bash
 sh scripts/repo-maintenance/validate-all.sh
 ```
 
-- run at least a small live end-to-end smoke pass across both transport families:
+- run the current live end-to-end smoke gate:
 
 ```bash
-SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter 'http text profile lifecycle covers stored active effective and persistence flows'
-SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter 'mcp catalog control resources prompts and subscriptions stay live and accurate'
+SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter ServerTransportE2ETests
 ```
 
 - confirm the resolved `SpeakSwiftly` dependency is still current before tagging

--- a/docs/releases/v4.0.0-rc.1-release-notes.md
+++ b/docs/releases/v4.0.0-rc.1-release-notes.md
@@ -23,21 +23,9 @@
 ## Verification performed
 
 ```bash
-xcrun swift build
-```
-
-```bash
-xcrun swift test
-```
-
-```bash
 sh scripts/repo-maintenance/validate-all.sh
 ```
 
 ```bash
-SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter 'http text profile lifecycle covers stored active effective and persistence flows'
-```
-
-```bash
-SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter 'mcp catalog control resources prompts and subscriptions stay live and accurate'
+SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter ServerTransportE2ETests
 ```

--- a/docs/releases/v4.0.0-release-checklist.md
+++ b/docs/releases/v4.0.0-release-checklist.md
@@ -22,25 +22,16 @@ That major bump matches the current change shape:
 ## Pre-Tag Checklist
 
 - keep the worktree clean before release preparation or publish
-- confirm the default package lane still passes:
-
-```bash
-xcrun swift build
-xcrun swift test
-```
-
-- confirm the maintainer validation path passes:
+- confirm the maintainer validation path still passes. This now includes the default package lane (`xcrun swift build` and `xcrun swift test`):
 
 ```bash
 sh scripts/repo-maintenance/validate-all.sh
 ```
 
-- run the full live end-to-end surface in the repo-approved serial shape:
+- run the current live end-to-end smoke gate in the repo-approved one-suite-at-a-time shape:
 
 ```bash
-SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter HTTPWorkflowE2ETests
-SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter MCPWorkflowE2ETests
-SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter ControlE2ETests
+SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter ServerTransportE2ETests
 ```
 
 ## Suggested Release Notes Shape
@@ -50,7 +41,7 @@ Center the release notes on four points:
 - the new `EmbeddedServer` consumer model
 - the breaking embedded-lifecycle and observable-surface flattening
 - the package-surface cleanup that removes accidental public exports
-- the live E2E harness repair and the now-green full serial E2E gate
+- the live E2E harness repair and the now-green transport smoke gate over the shipped HTTP and MCP surfaces
 
 ## Publish Reminder
 

--- a/docs/releases/v4.0.0-release-notes.md
+++ b/docs/releases/v4.0.0-release-notes.md
@@ -5,7 +5,7 @@
 - replaced the older embedded session-plus-state model with a single app-owned `EmbeddedServer` observable surface
 - moved the embedded lifecycle entrypoint and consumer-facing control actions onto that public object so app code can create one server object, call `liftoff()`, and bind SwiftUI directly to its properties
 - tightened the package surface so internal transport payload models and CLI-only helper types are no longer exported from the library product
-- fixed the live E2E competing-process detector so the repo-approved serial HTTP, MCP, and control-suite release gate now runs cleanly end to end
+- fixed the live E2E competing-process detector so the repo-approved `ServerTransportE2ETests` smoke gate now runs cleanly end to end
 
 ## Breaking changes
 
@@ -23,25 +23,9 @@
 ## Verification performed
 
 ```bash
-xcrun swift build
-```
-
-```bash
-xcrun swift test
-```
-
-```bash
 sh scripts/repo-maintenance/validate-all.sh
 ```
 
 ```bash
-SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter HTTPWorkflowE2ETests
-```
-
-```bash
-SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter MCPWorkflowE2ETests
-```
-
-```bash
-SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter ControlE2ETests
+SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter ServerTransportE2ETests
 ```

--- a/scripts/repo-maintenance/validations/35-swift-package.sh
+++ b/scripts/repo-maintenance/validations/35-swift-package.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -eu
+
+SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "$SELF_DIR/../lib/common.sh"
+
+log "Building the package with the Xcode-selected Swift toolchain."
+swiftpm build
+
+log "Running the package test suite with the Xcode-selected Swift toolchain."
+swiftpm test


### PR DESCRIPTION
## Summary
- Removed `// MARK:` clutter and other redundant section dividers across `Sources/SpeakSwiftlyServer/Host`
- Dropped the SwiftFormat type-mark rules so the formatter no longer reintroduces those comments
- Kept the package/test lane and release docs aligned with the current SwiftPM workflow

## Testing
- `xcrun swift test`
- `SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter ServerTransportE2ETests`