### PR TITLE
build: fix post-merge formatting drift

### DIFF
--- a/Sources/SpeakSwiftlyServer/HTTP/HTTPTextProfileRoutes.swift
+++ b/Sources/SpeakSwiftlyServer/HTTP/HTTPTextProfileRoutes.swift
@@ -45,7 +45,7 @@ func registerHTTPTextProfileRoutes(
         let payload = try await request.decode(as: CreateTextProfileRequestPayload.self, context: context)
         let profile = try await host.createTextProfile(
             name: payload.name,
-            replacements: try (payload.replacements ?? []).map { try $0.model() },
+            replacements: (payload.replacements ?? []).map { try $0.model() },
         )
         return .init(profile: profile)
     }

--- a/Sources/SpeakSwiftlyServer/Host/ServerRuntimeAdapter.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerRuntimeAdapter.swift
@@ -221,7 +221,7 @@ actor ServerRuntimeAdapter: ServerRuntimeProtocol {
     }
 
     func activeTextProfile() async -> SpeakSwiftly.TextProfileDetails {
-        transportDetails(await runtime.normalizer.profiles.getActive())
+        await transportDetails(runtime.normalizer.profiles.getActive())
     }
 
     func baseTextProfile() async -> TextForSpeech.Profile {
@@ -238,18 +238,19 @@ actor ServerRuntimeAdapter: ServerRuntimeProtocol {
     }
 
     func textProfiles() async -> [SpeakSwiftly.TextProfileSummary] {
-        await runtime.normalizer.profiles.list()
+        await runtime.normalizer
+            .profiles
+            .list()
             .map(transportSummary)
     }
 
     func effectiveTextProfile(id profileID: String?) async -> SpeakSwiftly.TextProfileDetails {
         if let profileID,
-           let details = try? await runtime.normalizer.profiles.get(id: profileID)
-        {
+           let details = try? await runtime.normalizer.profiles.get(id: profileID) {
             return transportDetails(details)
         }
 
-        return transportDetails(await runtime.normalizer.profiles.getEffective())
+        return await transportDetails(runtime.normalizer.profiles.getEffective())
     }
 
     func loadTextProfiles() async throws {
@@ -261,16 +262,16 @@ actor ServerRuntimeAdapter: ServerRuntimeProtocol {
     }
 
     func createTextProfile(named name: String) async throws -> SpeakSwiftly.TextProfileDetails {
-        transportDetails(try await runtime.normalizer.profiles.create(name: name))
+        try await transportDetails(runtime.normalizer.profiles.create(name: name))
     }
 
     func renameTextProfile(id profileID: String, to name: String) async throws -> SpeakSwiftly.TextProfileDetails {
-        transportDetails(try await runtime.normalizer.profiles.rename(profile: profileID, to: name))
+        try await transportDetails(runtime.normalizer.profiles.rename(profile: profileID, to: name))
     }
 
     func setActiveTextProfile(id profileID: String) async throws -> SpeakSwiftly.TextProfileDetails {
         try await runtime.normalizer.profiles.setActive(id: profileID)
-        return transportDetails(await runtime.normalizer.profiles.getActive())
+        return await transportDetails(runtime.normalizer.profiles.getActive())
     }
 
     func removeTextProfile(id profileID: String) async throws {
@@ -283,44 +284,44 @@ actor ServerRuntimeAdapter: ServerRuntimeProtocol {
 
     func resetTextProfile(id profileID: String) async throws -> SpeakSwiftly.TextProfileDetails {
         try await runtime.normalizer.profiles.reset(id: profileID)
-        return transportDetails(try await runtime.normalizer.profiles.get(id: profileID))
+        return try await transportDetails(runtime.normalizer.profiles.get(id: profileID))
     }
 
     func addTextReplacement(_ replacement: TextForSpeech.Replacement) async throws -> SpeakSwiftly.TextProfileDetails {
-        transportDetails(try await runtime.normalizer.profiles.addReplacement(replacement))
+        try await transportDetails(runtime.normalizer.profiles.addReplacement(replacement))
     }
 
     func addTextReplacement(
         _ replacement: TextForSpeech.Replacement,
         toStoredTextProfileID profileID: String,
     ) async throws -> SpeakSwiftly.TextProfileDetails {
-        transportDetails(try await runtime.normalizer.profiles.addReplacement(replacement, toProfile: profileID))
+        try await transportDetails(runtime.normalizer.profiles.addReplacement(replacement, toProfile: profileID))
     }
 
     func replaceTextReplacement(_ replacement: TextForSpeech.Replacement) async throws -> SpeakSwiftly.TextProfileDetails {
-        transportDetails(try await runtime.normalizer.profiles.patchReplacement(replacement))
+        try await transportDetails(runtime.normalizer.profiles.patchReplacement(replacement))
     }
 
     func replaceTextReplacement(
         _ replacement: TextForSpeech.Replacement,
         inStoredTextProfileID profileID: String,
     ) async throws -> SpeakSwiftly.TextProfileDetails {
-        transportDetails(try await runtime.normalizer.profiles.patchReplacement(replacement, inProfile: profileID))
+        try await transportDetails(runtime.normalizer.profiles.patchReplacement(replacement, inProfile: profileID))
     }
 
     func removeTextReplacement(id replacementID: String) async throws -> SpeakSwiftly.TextProfileDetails {
-        transportDetails(try await runtime.normalizer.profiles.removeReplacement(id: replacementID))
+        try await transportDetails(runtime.normalizer.profiles.removeReplacement(id: replacementID))
     }
 
     func removeTextReplacement(
         id replacementID: String,
         fromStoredTextProfileID profileID: String,
     ) async throws -> SpeakSwiftly.TextProfileDetails {
-        transportDetails(
-            try await runtime.normalizer.profiles.removeReplacement(
-            id: replacementID,
-            fromProfile: profileID,
-        )
+        try await transportDetails(
+            runtime.normalizer.profiles.removeReplacement(
+                id: replacementID,
+                fromProfile: profileID,
+            ),
         )
     }
 
@@ -382,8 +383,8 @@ actor ServerRuntimeAdapter: ServerRuntimeProtocol {
         )
     }
 
-    private func decodeTransportValue<Value: Decodable, Bridge: Encodable>(
-        _ bridge: Bridge,
+    private func decodeTransportValue<Value: Decodable>(
+        _ bridge: some Encodable,
         as type: Value.Type,
     ) -> Value {
         do {

--- a/Tests/SpeakSwiftlyServerTests/MockRuntime+TextProfiles.swift
+++ b/Tests/SpeakSwiftlyServerTests/MockRuntime+TextProfiles.swift
@@ -39,8 +39,7 @@ extension MockRuntime {
 
     func effectiveTextProfile(id profileID: String?) async -> SpeakSwiftly.TextProfileDetails {
         if let profileID,
-           let details = try? textRuntime.profiles.get(id: profileID)
-        {
+           let details = try? textRuntime.profiles.get(id: profileID) {
             return transportDetails(details)
         }
 
@@ -56,11 +55,11 @@ extension MockRuntime {
     }
 
     func createTextProfile(named name: String) async throws -> SpeakSwiftly.TextProfileDetails {
-        transportDetails(try textRuntime.profiles.create(name: name))
+        try transportDetails(textRuntime.profiles.create(name: name))
     }
 
     func renameTextProfile(id profileID: String, to name: String) async throws -> SpeakSwiftly.TextProfileDetails {
-        transportDetails(try textRuntime.profiles.rename(profile: profileID, to: name))
+        try transportDetails(textRuntime.profiles.rename(profile: profileID, to: name))
     }
 
     func setActiveTextProfile(id profileID: String) async throws -> SpeakSwiftly.TextProfileDetails {
@@ -78,40 +77,40 @@ extension MockRuntime {
 
     func resetTextProfile(id profileID: String) async throws -> SpeakSwiftly.TextProfileDetails {
         try textRuntime.profiles.reset(id: profileID)
-        return transportDetails(try textRuntime.profiles.get(id: profileID))
+        return try transportDetails(textRuntime.profiles.get(id: profileID))
     }
 
     func addTextReplacement(_ replacement: TextForSpeech.Replacement) async throws -> SpeakSwiftly.TextProfileDetails {
-        transportDetails(try textRuntime.profiles.addReplacement(replacement))
+        try transportDetails(textRuntime.profiles.addReplacement(replacement))
     }
 
     func addTextReplacement(
         _ replacement: TextForSpeech.Replacement,
         toStoredTextProfileID profileID: String,
     ) async throws -> SpeakSwiftly.TextProfileDetails {
-        transportDetails(try textRuntime.profiles.addReplacement(replacement, toProfile: profileID))
+        try transportDetails(textRuntime.profiles.addReplacement(replacement, toProfile: profileID))
     }
 
     func replaceTextReplacement(_ replacement: TextForSpeech.Replacement) async throws -> SpeakSwiftly.TextProfileDetails {
-        transportDetails(try textRuntime.profiles.patchReplacement(replacement))
+        try transportDetails(textRuntime.profiles.patchReplacement(replacement))
     }
 
     func replaceTextReplacement(
         _ replacement: TextForSpeech.Replacement,
         inStoredTextProfileID profileID: String,
     ) async throws -> SpeakSwiftly.TextProfileDetails {
-        transportDetails(try textRuntime.profiles.patchReplacement(replacement, inProfile: profileID))
+        try transportDetails(textRuntime.profiles.patchReplacement(replacement, inProfile: profileID))
     }
 
     func removeTextReplacement(id replacementID: String) async throws -> SpeakSwiftly.TextProfileDetails {
-        transportDetails(try textRuntime.profiles.removeReplacement(id: replacementID))
+        try transportDetails(textRuntime.profiles.removeReplacement(id: replacementID))
     }
 
     func removeTextReplacement(
         id replacementID: String,
         fromStoredTextProfileID profileID: String,
     ) async throws -> SpeakSwiftly.TextProfileDetails {
-        transportDetails(try textRuntime.profiles.removeReplacement(id: replacementID, fromProfile: profileID))
+        try transportDetails(textRuntime.profiles.removeReplacement(id: replacementID, fromProfile: profileID))
     }
 
     private func transportSummary(
@@ -119,12 +118,12 @@ extension MockRuntime {
     ) -> SpeakSwiftly.TextProfileSummary {
         requireFixture("mock text-profile summary bridge") {
             try fixtureDecode(
-            TextProfileSummaryFixture(
-                id: summary.id,
-                name: summary.name,
-                replacementCount: summary.replacementCount,
-            ),
-            as: SpeakSwiftly.TextProfileSummary.self,
+                TextProfileSummaryFixture(
+                    id: summary.id,
+                    name: summary.name,
+                    replacementCount: summary.replacementCount,
+                ),
+                as: SpeakSwiftly.TextProfileSummary.self,
             )
         }
     }
@@ -134,16 +133,16 @@ extension MockRuntime {
     ) -> SpeakSwiftly.TextProfileDetails {
         requireFixture("mock text-profile details bridge") {
             try fixtureDecode(
-            TextProfileDetailsFixture(
-                profileID: details.profileID,
-                summary: TextProfileSummaryFixture(
-                    id: details.summary.id,
-                    name: details.summary.name,
-                    replacementCount: details.summary.replacementCount,
+                TextProfileDetailsFixture(
+                    profileID: details.profileID,
+                    summary: TextProfileSummaryFixture(
+                        id: details.summary.id,
+                        name: details.summary.name,
+                        replacementCount: details.summary.replacementCount,
+                    ),
+                    replacements: details.replacements,
                 ),
-                replacements: details.replacements,
-            ),
-            as: SpeakSwiftly.TextProfileDetails.self,
+                as: SpeakSwiftly.TextProfileDetails.self,
             )
         }
     }


### PR DESCRIPTION
## Summary
- apply repo SwiftFormat fixes to the text profile alignment follow-up
- keep the already-merged API alignment intact without behavioral changes
- unblock repo-maintenance validation on main

## Verification
- bash scripts/repo-maintenance/validate-all.sh