### PR TITLE
release: prepare v4.2.2

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "speak-swiftly-server",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Repo-local Codex plugin for the SpeakSwiftlyServer MCP surface, focused operator skills, and shared local MCP configuration.",
   "author": {
     "name": "Gale",
@@ -32,11 +32,11 @@
     ],
     "websiteURL": "https://github.com/gaelic-ghost/SpeakSwiftlyServer",
     "defaultPrompt": [
-      "Use SpeakSwiftly to read this reply aloud.",
-      "Set up SpeakSwiftly on this machine as a background service.",
-      "Help me install or validate the SpeakSwiftly LaunchAgent service.",
-      "Inspect the local SpeakSwiftly runtime and queue state.",
-      "Create or edit a SpeakSwiftly text profile."
+      "Use Speak Swiftly to read this reply aloud.",
+      "Set up Speak Swiftly on this machine as a background service.",
+      "Help me install or validate the Speak Swiftly LaunchAgent service.",
+      "Inspect the local Speak Swiftly runtime and queue state.",
+      "Create or edit a Speak Swiftly text profile."
     ]
   }
 }

--- a/docs/releases/v4.2.2-release-checklist.md
+++ b/docs/releases/v4.2.2-release-checklist.md
@@ -1,0 +1,45 @@
+# `v4.2.2` Release Checklist
+
+## Purpose
+
+This checklist is the maintainer-facing candidate path for `v4.2.2`.
+
+Use it when the release scope is the Speak Swiftly skills-surface audit follow-through: fix stale skill references, align the bundled agent metadata with the current naming, and ship the missing LaunchAgent skill manifest.
+
+For the standing branch-versus-main release contract, keep using [release-workflow.md](../maintainers/release-workflow.md). This document is only the candidate-specific checklist and release-shape note for `v4.2.2`.
+
+## Proposed Release Number
+
+Target the next release as `v4.2.2`.
+
+That patch bump matches the current change shape:
+
+- no public HTTP, MCP, embedding, or runtime protocol break
+- bundled skill and plugin metadata alignment against the current API and naming
+- release-safe plugin patch bump from `2.1.2` to `2.1.3`
+
+## Pre-Tag Checklist
+
+- keep the worktree clean before release preparation or publish
+- confirm the authoritative maintainer validation path passes:
+
+```bash
+sh scripts/repo-maintenance/validate-all.sh
+```
+
+## Suggested Release Notes Shape
+
+Center the release notes on three points:
+
+- the MCP skill source-of-truth reference fix
+- the prompt-aware skill guidance updates across runtime, voice, and text-profile workflows
+- the consistent "Speak Swiftly" agent metadata plus the newly added LaunchAgent agent manifest
+
+## Publish Reminder
+
+If this candidate moves forward, use the split release workflow rather than tagging directly from a feature branch:
+
+1. run `scripts/repo-maintenance/release-prepare.sh --version v4.2.2` from the feature branch or release candidate worktree
+2. let the PR merge back to `main`
+3. fast-forward local `main`
+4. run `scripts/repo-maintenance/release-publish.sh --version v4.2.2 --skip-live-service-refresh`

--- a/docs/releases/v4.2.2-release-notes.md
+++ b/docs/releases/v4.2.2-release-notes.md
@@ -1,0 +1,22 @@
+# v4.2.2 Release Notes
+
+## What changed
+
+- refreshed the checked-in Speak Swiftly skill bundle so the MCP orientation skill now points at the real prompt catalog source file
+- expanded the runtime, voice, and text-profile skills to acknowledge the current prompt-backed authoring and playback-guidance surface instead of describing only the older tool-and-resource flow
+- aligned the checked-in agent metadata with the current "Speak Swiftly" naming and added the missing LaunchAgent skill agent manifest so the whole bundled skill surface now exposes consistent metadata
+
+## Breaking changes
+
+- none
+
+## Migration or upgrade notes
+
+- if you install the repo-local plugin, refresh to plugin bundle version `2.1.3` so the LaunchAgent skill and renamed agent metadata come along with the updated skill docs
+- when orienting on the MCP surface, treat `Sources/SpeakSwiftlyServer/MCP/MCPPrompts.swift` as the source of truth for prompt coverage
+
+## Verification performed
+
+```bash
+sh scripts/repo-maintenance/validate-all.sh
+```

--- a/skills/speak-swiftly-launchagent-setup/agents/openai.yaml
+++ b/skills/speak-swiftly-launchagent-setup/agents/openai.yaml
@@ -1,0 +1,15 @@
+interface:
+  display_name: "Speak Swiftly LaunchAgent"
+  short_description: "Set up and validate the Speak Swiftly background service."
+  default_prompt: "Use $speak-swiftly-launchagent-setup to install, inspect, refresh, or troubleshoot the local Speak Swiftly LaunchAgent service."
+
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "speak_swiftly"
+      description: "Local SpeakSwiftlyServer MCP surface used after the LaunchAgent-backed service is healthy."
+      transport: "streamable_http"
+      url: "http://127.0.0.1:7337/mcp"
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/speak-swiftly-mcp/SKILL.md
+++ b/skills/speak-swiftly-mcp/SKILL.md
@@ -14,7 +14,7 @@ Use this skill as the first orientation pass when the request is about the Speak
 - For a "what can this surface do?" question, use [API.md](../../API.md) first, then the current source-of-truth catalog files:
   - [MCPToolCatalog.swift](../../Sources/SpeakSwiftlyServer/MCP/MCPToolCatalog.swift)
   - [MCPResources.swift](../../Sources/SpeakSwiftlyServer/MCP/MCPResources.swift)
-  - [MCPPromptCatalog.swift](../../Sources/SpeakSwiftlyServer/MCP/MCPPromptCatalog.swift)
+  - [MCPPrompts.swift](../../Sources/SpeakSwiftlyServer/MCP/MCPPrompts.swift)
 
 ## Workflow Split
 
@@ -28,6 +28,7 @@ Use this skill as the first orientation pass when the request is about the Speak
 ## General Operating Rules
 
 - Prefer resources for orientation and verification, then use tools for mutations.
+- When the user needs help deciding which action family fits best, use the `choose_surface_action` prompt instead of improvising from memory.
 - When a tool returns `request_id`, follow it with `speak://requests/{request_id}` or `get_runtime_overview` instead of guessing whether the work finished.
 - Distinguish generation backlog from playback backlog. A request can be done generating and still be queued for playback.
 - Do not silently substitute a different voice profile when the requested profile is missing unless the user explicitly asks for fallback behavior.

--- a/skills/speak-swiftly-mcp/agents/openai.yaml
+++ b/skills/speak-swiftly-mcp/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
-  display_name: "SpeakSwiftly MCP"
-  short_description: "Orient Codex on the SpeakSwiftly MCP surface."
-  default_prompt: "Use $speak-swiftly-mcp to inspect the local SpeakSwiftly MCP surface and choose the right workflow."
+  display_name: "Speak Swiftly MCP"
+  short_description: "Orient Codex on the Speak Swiftly MCP surface."
+  default_prompt: "Use $speak-swiftly-mcp to inspect the local Speak Swiftly MCP surface and choose the right workflow."
 
 dependencies:
   tools:

--- a/skills/speak-swiftly-runtime-operator/SKILL.md
+++ b/skills/speak-swiftly-runtime-operator/SKILL.md
@@ -18,6 +18,7 @@ Use this skill for operator-style runtime work on the local `speak_swiftly` MCP 
 
 - Use `list_generation_queue` for "what is still generating?"
 - Use `list_playback_queue` for "what is waiting to be heard?"
+- Read `speak://playback/guide` when the user wants help choosing the least destructive queue or playback action.
 - Use `speak://requests/{request_id}` after any accepted request or cancellation so the user can see the retained state directly.
 - When multiple similar requests exist, confirm the exact `request_id` from the resource before cancelling anything.
 
@@ -33,5 +34,6 @@ Use this skill for operator-style runtime work on the local `speak_swiftly` MCP 
 ## Verification
 
 - After any mutation, read `get_runtime_overview` again so the response is grounded in the post-change state.
+- Use `draft_queue_playback_notice` when the user wants a short spoken-safe acknowledgement for accepted queued playback work.
 - When a control path fails, cite the actual runtime or request snapshot instead of paraphrasing vaguely.
 - The playback and queue workflow guidance embedded in [MCPResources.swift](../../Sources/SpeakSwiftlyServer/MCP/MCPResources.swift) is the best repo-local explanation of intended operator flow.

--- a/skills/speak-swiftly-runtime-operator/agents/openai.yaml
+++ b/skills/speak-swiftly-runtime-operator/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
-  display_name: "SpeakSwiftly Runtime"
+  display_name: "Speak Swiftly Runtime"
   short_description: "Operate runtime, queue, playback, and requests."
-  default_prompt: "Use $speak-swiftly-runtime-operator to inspect the local SpeakSwiftly runtime and control playback or queued work."
+  default_prompt: "Use $speak-swiftly-runtime-operator to inspect the local Speak Swiftly runtime and control playback or queued work."
 
 dependencies:
   tools:

--- a/skills/speak-swiftly-text-profiles/SKILL.md
+++ b/skills/speak-swiftly-text-profiles/SKILL.md
@@ -26,6 +26,7 @@ Use this skill for text-normalization work on the local `speak_swiftly` MCP surf
 ## Replacement Editing
 
 - Use `add_text_replacement`, `replace_text_replacement`, and `remove_text_replacement` for targeted rule edits.
+- Use the `draft_text_profile` and `draft_text_replacement` prompts when the user is still designing the normalization policy instead of applying a settled edit immediately.
 - Prefer `whole_token` for identifiers and acronyms, and `exact_phrase` for multi-word substitutions.
 - Be deliberate about whether a rule should run before or after built-in normalization.
 - Restrict `formats` when the user only wants the rule to affect source code, CLI output, or another narrow content kind.

--- a/skills/speak-swiftly-text-profiles/agents/openai.yaml
+++ b/skills/speak-swiftly-text-profiles/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
-  display_name: "SpeakSwiftly Text Profiles"
+  display_name: "Speak Swiftly Text Profiles"
   short_description: "Shape text normalization before speech generation."
-  default_prompt: "Use $speak-swiftly-text-profiles to inspect or edit SpeakSwiftly text normalization rules."
+  default_prompt: "Use $speak-swiftly-text-profiles to inspect or edit Speak Swiftly text normalization rules."
 
 dependencies:
   tools:

--- a/skills/speak-swiftly-voice-workflows/SKILL.md
+++ b/skills/speak-swiftly-voice-workflows/SKILL.md
@@ -11,7 +11,7 @@ Use this skill for voice selection, voice creation, and speech-generation work o
 
 - Read `list_voice_profiles` or `speak://voices` before creating, renaming, rerolling, deleting, or choosing a profile.
 - Use `speak://voices/{profile_name}` when the user is working on one specific stored voice.
-- If the user wants help designing a voice rather than executing immediately, prefer the prompt and guide flow documented in [MCPResources.swift](../../Sources/SpeakSwiftlyServer/MCP/MCPResources.swift).
+- If the user wants help designing a voice rather than executing immediately, prefer the `draft_profile_voice_description`, `draft_profile_source_text`, and `draft_voice_design_instruction` prompts plus the guide flow documented in [MCPResources.swift](../../Sources/SpeakSwiftlyServer/MCP/MCPResources.swift).
 
 ## Creation And Editing
 

--- a/skills/speak-swiftly-voice-workflows/agents/openai.yaml
+++ b/skills/speak-swiftly-voice-workflows/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
-  display_name: "SpeakSwiftly Voices"
+  display_name: "Speak Swiftly Voices"
   short_description: "Create voices and generate spoken output."
-  default_prompt: "Use $speak-swiftly-voice-workflows to create or choose a SpeakSwiftly voice profile and generate speech."
+  default_prompt: "Use $speak-swiftly-voice-workflows to create or choose a Speak Swiftly voice profile and generate speech."
 
 dependencies:
   tools:


### PR DESCRIPTION
## Release Prepare

- prepares release candidate `v4.2.2`
- leaves release artifact staging, final tag creation, and GitHub release publication for `scripts/repo-maintenance/release-publish.sh` after this pull request lands on `main`

## Publish Follow-Up

After this pull request merges, switch to `main` locally and run:

```bash
scripts/repo-maintenance/release-publish.sh --version v4.2.2 --skip-live-service-refresh
```
