### PR TITLE
runtime: bridge profile-root override for SpeakSwiftly 3.2.0

### DIFF
--- a/API.md
+++ b/API.md
@@ -39,7 +39,7 @@ Only the host-safe subset reloads live today:
 
 Changes to bind addresses, ports, HTTP enablement, MCP enablement, MCP path, or MCP server metadata are detected and reported, but they still require a process restart before they can take effect.
 
-`SPEAKSWIFTLY_PROFILE_ROOT` is also a startup-only setting. It points at the runtime profile root directory the server should own, and the server threads that same root through both its own runtime-configuration persistence and the underlying `SpeakSwiftly` profile and artifact persistence. Because that setting changes filesystem ownership rather than hot runtime state, it is intentionally not part of the live-reloaded YAML surface.
+`SPEAKSWIFTLY_PROFILE_ROOT` is also a startup-only setting. On the `SpeakSwiftlyServer` side, it still refers to the server-owned profile-store root. During startup, the server bridges that value into the broader persistence root expected by the current pinned `SpeakSwiftly` runtime so the launched runtime can derive `profiles/`, `configuration.json`, and `text-profiles.json` consistently. Because that setting changes filesystem ownership rather than hot runtime state, it is intentionally not part of the live-reloaded YAML surface.
 
 ## HTTP Surface
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ struct ExampleApp: App {
 }
 ```
 
-If you do not pass `EmbeddedServer.Options(port:)`, the embedded host defaults to `127.0.0.1:7339`. If you pass `EmbeddedServer.Options(runtimeProfileRootURL:)`, that root is used for the runtime-owned persistence path as well as the server's runtime configuration store.
+If you do not pass `EmbeddedServer.Options(port:)`, the embedded host defaults to `127.0.0.1:7339`. If you pass `EmbeddedServer.Options(runtimeProfileRootURL:)`, the server treats that as its profile-store root and bridges it at startup into the broader persistence root expected by the current pinned `SpeakSwiftly` runtime, while keeping the server's own runtime-configuration snapshot aligned with the same on-disk state.
 
 ## Configuration
 

--- a/Sources/SpeakSwiftlyServer/Host/SpeakSwiftlyRuntimeLauncher.swift
+++ b/Sources/SpeakSwiftlyServer/Host/SpeakSwiftlyRuntimeLauncher.swift
@@ -14,10 +14,38 @@ actor SpeakSwiftlyRuntimeLauncher {
         "SPEAKSWIFTLY_PROFILE_ROOT",
     ]
 
-    private static func environmentOverrides(from environment: [String: String]) -> [String: String?] {
+    static func environmentOverrides(from environment: [String: String]) -> [String: String?] {
         bridgedEnvironmentKeys.reduce(into: [String: String?]()) { result, key in
-            result[key] = environment[key]
+            switch key {
+                case "SPEAKSWIFTLY_PROFILE_ROOT":
+                    result[key] = bridgedSpeakSwiftlyProfileRoot(environment[key])
+                default:
+                    result[key] = environment[key]
+            }
         }
+    }
+
+    static func bridgedSpeakSwiftlyProfileRoot(_ path: String?) -> String? {
+        guard let path else {
+            return nil
+        }
+
+        let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPath.isEmpty else {
+            return nil
+        }
+
+        let standardizedURL = URL(fileURLWithPath: trimmedPath, isDirectory: true)
+            .standardizedFileURL
+
+        // SpeakSwiftlyServer still models this override as the profile-store root for its own
+        // runtime-configuration snapshots and CLI surface, while the pinned SpeakSwiftly runtime
+        // now interprets the same env var as the broader persistence root that contains profiles/.
+        guard standardizedURL.lastPathComponent == "profiles" else {
+            return standardizedURL.path
+        }
+
+        return standardizedURL.deletingLastPathComponent().path
     }
 
     func launch<T: Sendable>(

--- a/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/Embedding-The-Server.md
+++ b/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/Embedding-The-Server.md
@@ -65,6 +65,6 @@ When you need the whole current picture at once, use ``HostStateSnapshot`` as th
 
 Use the embedded session when an app owns the process and wants direct observable state. Use the standalone executable and the HTTP or MCP surfaces when another process, a LaunchAgent, or an external operator should own runtime startup and shutdown.
 
-If the app needs explicit ownership of where the runtime persists profiles, generated artifacts, and staged runtime configuration, pass `runtimeProfileRootURL` on the embedded session options. That same root is forwarded into both the server's own runtime-configuration store and the underlying `SpeakSwiftly` startup path so the embedded app does not have to manage those two persistence layers separately.
+If the app needs explicit ownership of where the runtime persists profiles, generated artifacts, and staged runtime configuration, pass `runtimeProfileRootURL` on the embedded session options. `SpeakSwiftlyServer` keeps that value as the profile-store root on its side and bridges it into the broader persistence root expected by the current pinned `SpeakSwiftly` startup path so the embedded app does not have to manage those two persistence layers separately.
 
 For the transport inventory and command-line surface, see <doc:Operator-Surfaces>.

--- a/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/First-Embedded-Session.md
+++ b/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/First-Embedded-Session.md
@@ -32,7 +32,7 @@ try await server.liftoff()
 
 `EmbeddedServer` owns the host lifecycle. Internally it now coordinates host startup, optional config watching, optional MCP readiness, and HTTP serving through one service-owned lifecycle group, but app code should still treat the server object itself as the lifecycle boundary. Keep that object alive for as long as you want the shared server running in-process. If you do not pass `Options(port:)`, the embedded host defaults to `127.0.0.1:7339`.
 
-If you pass `runtimeProfileRootURL`, the embedded host uses that same root for both its own persisted runtime configuration and the underlying `SpeakSwiftly` profile and artifact persistence. Use that when the app wants an explicit app-owned or App Group-owned runtime root instead of relying on the default Application Support lookup.
+If you pass `runtimeProfileRootURL`, the embedded host uses that explicit profile-store root for its own persisted runtime configuration bookkeeping and bridges it into the broader persistence root expected by the current pinned `SpeakSwiftly` runtime. Use that when the app wants an explicit app-owned or App Group-owned runtime root instead of relying on the default Application Support lookup.
 
 ## Read The App-Facing State
 

--- a/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/LaunchAgent-Workflow.md
+++ b/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/LaunchAgent-Workflow.md
@@ -29,7 +29,7 @@ That gives you the exact LaunchAgent payload the package currently wants to stag
 - the stdout and stderr log files
 - the `SPEAKSWIFTLY_PROFILE_ROOT` environment override for the standalone server
 
-That profile-root override is the LaunchAgent-owned runtime persistence root. It is the directory the installed background service uses for its persisted runtime configuration and the underlying `SpeakSwiftly` profile and artifact persistence, so operators do not have to manage those two filesystem surfaces independently.
+That profile-root override is the LaunchAgent-owned profile-store root on the `SpeakSwiftlyServer` side. The startup bridge converts it into the broader persistence root expected by the current pinned `SpeakSwiftly` runtime so the installed background service can keep one on-disk state tree without nesting `profiles/profiles/`.
 
 ## Install Or Refresh The Background Service
 

--- a/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/Using-The-Command-Line-Tool.md
+++ b/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/Using-The-Command-Line-Tool.md
@@ -47,6 +47,7 @@ xcrun swift run SpeakSwiftlyServerTool serve \
 ```
 
 That flag feeds the same `SPEAKSWIFTLY_PROFILE_ROOT` startup override the LaunchAgent and embedded-app paths use, so the foreground server can point its runtime configuration, text-profile persistence, and generated artifacts at one explicit root.
+Inside `SpeakSwiftlyServer`, that value still names the profile-store root. The startup bridge translates it into the broader persistence root expected by the current pinned `SpeakSwiftly` runtime so the launched worker does not accidentally nest `profiles/profiles/`.
 
 ### LaunchAgent Maintenance
 

--- a/Tests/SpeakSwiftlyServerTests/ConfigTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/ConfigTests.swift
@@ -353,3 +353,21 @@ import Testing
     #expect(snapshot.persistedConfigurationExists == true)
     #expect(snapshot.persistedConfigurationState == "loaded")
 }
+
+@Test func `runtime launcher bridges a profiles directory override onto the broader SpeakSwiftly runtime root`() {
+    let profileRootURL = URL(fileURLWithPath: "/tmp/speakswiftly-runtime/profiles", isDirectory: true)
+
+    #expect(
+        SpeakSwiftlyRuntimeLauncher.bridgedSpeakSwiftlyProfileRoot(profileRootURL.path)
+            == profileRootURL.deletingLastPathComponent().path,
+    )
+}
+
+@Test func `runtime launcher leaves non-profiles override paths unchanged`() {
+    let runtimeRootURL = URL(fileURLWithPath: "/tmp/SpeakSwiftlyRuntime", isDirectory: true)
+
+    #expect(
+        SpeakSwiftlyRuntimeLauncher.bridgedSpeakSwiftlyProfileRoot(runtimeRootURL.path)
+            == runtimeRootURL.path,
+    )
+}


### PR DESCRIPTION
## Release Prepare

- prepares release candidate `v4.2.3`
- leaves release artifact staging, final tag creation, and GitHub release publication for `scripts/repo-maintenance/release-publish.sh` after this pull request lands on `main`

## Publish Follow-Up

After this pull request merges, switch to `main` locally and run:

```bash
scripts/repo-maintenance/release-publish.sh --version v4.2.3 --skip-live-service-refresh
```
