### PR TITLE
release: prepare v4.2.4

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "61b32e97ab221c22ddbb4db9ef28a117a245922f732d71f969962d1404dafdb4",
+  "originHash" : "c8dc83b69a3bc59c82a31d1e0e2af6c9e58b734d5c7b685dbf218f017ae95f1c",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/mlx-audio-swift.git",
       "state" : {
-        "revision" : "a40ac9fb1ce8f4ead5f8d913ef1f15fb80e69847",
-        "version" : "69.2.0"
+        "revision" : "dfb55adee9437e973b98b9dbd00caa30d48b3809",
+        "version" : "0.7.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/SpeakSwiftly.git",
       "state" : {
-        "revision" : "7c72e79e0e7b4fa501ced3564d2f4cece8ec1a1c",
-        "version" : "3.2.0"
+        "revision" : "8582877a1310df6856bb3263fc64505642161397",
+        "version" : "3.2.3"
       }
     },
     {
@@ -321,8 +321,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/TextForSpeech.git",
       "state" : {
-        "revision" : "0a1e5adca30cfe520171419218372506cd70115a",
-        "version" : "0.18.0"
+        "revision" : "78f935b6da04f923854fd5bc14394deb10c132c4",
+        "version" : "0.18.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
         .package(
             url: "https://github.com/gaelic-ghost/SpeakSwiftly.git",
-            from: "3.2.0",
+            from: "3.2.3",
         ),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "2.30.6"),
         .package(url: "https://github.com/gaelic-ghost/TextForSpeech.git", from: "0.17.0"),

--- a/docs/maintainers/speakswiftly-api-coverage-matrix.md
+++ b/docs/maintainers/speakswiftly-api-coverage-matrix.md
@@ -10,7 +10,7 @@ It answers three concrete questions:
 2. Which public capabilities are intentionally adapted instead of mirrored exactly?
 3. Which transport is the right client contract for each capability: HTTP, MCP, both, or neither?
 
-Current baseline checked against the `SpeakSwiftly 3.2.0` package state resolved by this repository on `2026-04-18`. The root package now follows `SpeakSwiftly` with an up-to-next-major semantic-version requirement starting at `3.2.0`.
+Current baseline checked against the `SpeakSwiftly 3.2.3` package state resolved by this repository on `2026-04-21`. The root package now follows `SpeakSwiftly` with an up-to-next-major semantic-version requirement starting at `3.2.3`.
 
 ## Summary
 


### PR DESCRIPTION
## Release Prepare

- prepares release candidate `v4.2.4`
- leaves release artifact staging, final tag creation, and GitHub release publication for `scripts/repo-maintenance/release-publish.sh` after this pull request lands on `main`

## Publish Follow-Up

After this pull request merges, switch to `main` locally and run:

```bash
scripts/repo-maintenance/release-publish.sh --version v4.2.4 --skip-live-service-refresh
```
