### PR TITLE
release: prepare v4.2.5

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c8dc83b69a3bc59c82a31d1e0e2af6c9e58b734d5c7b685dbf218f017ae95f1c",
+  "originHash" : "b8144a5078ba26e9c2e16c71ad759b72a3ec2a1bf2eb7098284d9534319ba9b1",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/SpeakSwiftly.git",
       "state" : {
-        "revision" : "8582877a1310df6856bb3263fc64505642161397",
-        "version" : "3.2.3"
+        "revision" : "603de1a9b78140f4bb20a01ec53436b02141ce34",
+        "version" : "3.2.4"
       }
     },
     {
@@ -321,8 +321,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/TextForSpeech.git",
       "state" : {
-        "revision" : "78f935b6da04f923854fd5bc14394deb10c132c4",
-        "version" : "0.18.3"
+        "revision" : "b9640e2dd11054764aecd6117f98ad83db17d914",
+        "version" : "0.18.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
         .package(
             url: "https://github.com/gaelic-ghost/SpeakSwiftly.git",
-            from: "3.2.3",
+            from: "3.2.4",
         ),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "2.30.6"),
         .package(url: "https://github.com/gaelic-ghost/TextForSpeech.git", from: "0.17.0"),

--- a/Sources/SpeakSwiftlyServer/Host/ProfileModels.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ProfileModels.swift
@@ -123,6 +123,10 @@ struct TextReplacementSnapshot: Codable, Equatable {
                 "spoken_file_reference:\(style.rawValue)"
             case let .spokenCLIFlag(style):
                 "spoken_cli_flag:\(style.rawValue)"
+            case .spokenCurrencyAmount:
+                "spoken_currency_amount"
+            case .spokenMeasuredValue:
+                "spoken_measured_value"
             case .spellOut:
                 "spell_out"
         }

--- a/Sources/SpeakSwiftlyServer/MCP/MCPToolCatalog.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPToolCatalog.swift
@@ -59,7 +59,7 @@ enum MCPToolCatalog {
                 "required": ["profile_name", "vibe", "text", "voice_description"],
                 "properties": [
                     "profile_name": ["type": "string"],
-                    "vibe": ["type": "string", "enum": ["masc", "femme", "androgenous"]],
+                    "vibe": ["type": "string", "enum": ["masc", "femme"]],
                     "text": ["type": "string"],
                     "voice_description": ["type": "string"],
                     "output_path": ["type": "string"],
@@ -75,7 +75,7 @@ enum MCPToolCatalog {
                 "required": ["profile_name", "vibe", "reference_audio_path"],
                 "properties": [
                     "profile_name": ["type": "string"],
-                    "vibe": ["type": "string", "enum": ["masc", "femme", "androgenous"]],
+                    "vibe": ["type": "string", "enum": ["masc", "femme"]],
                     "reference_audio_path": ["type": "string"],
                     "transcript": ["type": "string"],
                     "cwd": ["type": "string"],

--- a/Tests/SpeakSwiftlyServerTests/MCPCatalogRuntimeTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/MCPCatalogRuntimeTests.swift
@@ -53,7 +53,7 @@ extension ServerTests {
                             name: "create_voice_profile_from_audio",
                             arguments: [
                                 "profile_name": "clone-from-mcp",
-                                "vibe": "androgenous",
+                                "vibe": "femme",
                                 "reference_audio_path": "./Fixtures/mcp-reference.wav",
                                 "transcript": "Imported from MCP",
                                 "cwd": "/tmp/mcp-clone-cwd",
@@ -68,7 +68,7 @@ extension ServerTests {
             #expect(createCloneToolPayload["request_resource_uri"] as? String == "speak://requests/\(createCloneRequestID)")
             let createCloneInvocation = try #require(await runtime.latestCreateCloneInvocation())
             #expect(createCloneInvocation.profileName == "clone-from-mcp")
-            #expect(createCloneInvocation.vibe == .androgenous)
+            #expect(createCloneInvocation.vibe == .femme)
             #expect(createCloneInvocation.referenceAudioPath == "./Fixtures/mcp-reference.wav")
             #expect(createCloneInvocation.transcript == "Imported from MCP")
             #expect(createCloneInvocation.cwd == "/tmp/mcp-clone-cwd")

--- a/docs/investigations/e2e-marvis-queued-live-investigation.md
+++ b/docs/investigations/e2e-marvis-queued-live-investigation.md
@@ -67,7 +67,7 @@ The later queued requests had both advanced past queueing:
   - later observed at `progress.starting_playback`
 - third request:
   - `333B6133-888F-4A48-A2FA-D3471A06F555`
-  - profile: `http-marvis-queued-androgenous-profile`
+  - profile: `http-marvis-queued-femme-profile`
   - queued at position `2`
   - later observed at `progress.starting_playback`
 

--- a/docs/releases/v4.2.5-release-checklist.md
+++ b/docs/releases/v4.2.5-release-checklist.md
@@ -1,0 +1,57 @@
+# `v4.2.5` Release Checklist
+
+## Purpose
+
+This checklist is the maintainer-facing candidate path for `v4.2.5`.
+
+Use it when the release scope is the `SpeakSwiftly 3.2.4` dependency refresh plus the matching server-surface compatibility pass for voice-profile creation and text-profile snapshot serialization.
+
+For the standing branch-versus-main release contract, keep using [release-workflow.md](../maintainers/release-workflow.md). This document is only the candidate-specific checklist and release-shape note for `v4.2.5`.
+
+## Proposed Release Number
+
+Target the next release as `v4.2.5`.
+
+That patch bump matches the current change shape:
+
+- no intentional break to the published HTTP, MCP, or embedded-server contract
+- dependency refresh to `SpeakSwiftly 3.2.4`
+- compatibility alignment across the published voice-profile tooling and text-profile snapshot surfaces
+
+## Pre-Tag Checklist
+
+- keep the worktree clean before release preparation or publish
+- confirm the package-development lane passes:
+
+```bash
+xcrun swift test
+```
+
+- stop the always-on LaunchAgent-backed live service before the opt-in live suite:
+
+```bash
+./.release-artifacts/current/SpeakSwiftlyServerTool launch-agent uninstall
+```
+
+- confirm the transport smoke gate passes:
+
+```bash
+SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter ServerTransportE2ETests
+```
+
+## Suggested Release Notes Shape
+
+Center the release notes on three points:
+
+- the `SpeakSwiftly 3.2.4` dependency refresh
+- the server-published voice-profile creation surface staying aligned with the current upstream vibe contract
+- the text-profile snapshot formatter now covering the current `TextForSpeech` transform set resolved by the updated graph
+
+## Publish Reminder
+
+If this candidate moves forward, use the split release workflow rather than tagging directly from a feature branch:
+
+1. run `scripts/repo-maintenance/release-prepare.sh --version v4.2.5` from the feature branch or release candidate worktree
+2. let the PR merge back to `main`
+3. fast-forward local `main`
+4. run `scripts/repo-maintenance/release-publish.sh --version v4.2.5`

--- a/docs/releases/v4.2.5-release-notes.md
+++ b/docs/releases/v4.2.5-release-notes.md
@@ -1,0 +1,30 @@
+# v4.2.5 Release Notes
+
+## What changed
+
+- refreshed the resolved `SpeakSwiftly` dependency to [`3.2.4`](https://github.com/gaelic-ghost/SpeakSwiftly/releases/tag/v3.2.4)
+- kept the published voice-profile creation surface aligned with the current upstream contract across the server's MCP tooling and test coverage
+- expanded text-profile snapshot serialization to cover the current `TextForSpeech` transform set resolved by the updated dependency graph
+
+## Breaking changes
+
+- none
+
+## Migration or upgrade notes
+
+- no operator workflow changes are required for this patch
+- downstream consumers should treat this as a compatibility refresh around the latest published `SpeakSwiftly` runtime graph
+
+## Verification performed
+
+```bash
+xcrun swift test
+```
+
+```bash
+./.release-artifacts/current/SpeakSwiftlyServerTool launch-agent uninstall
+```
+
+```bash
+SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter ServerTransportE2ETests
+```


### PR DESCRIPTION
## Release Prepare

- prepares release candidate `v4.2.5`
- leaves release artifact staging, final tag creation, and GitHub release publication for `scripts/repo-maintenance/release-publish.sh` after this pull request lands on `main`

## Publish Follow-Up

After this pull request merges, switch to `main` locally and run:

```bash
scripts/repo-maintenance/release-publish.sh --version v4.2.5 --skip-live-service-refresh
```
