### PR TITLE
release: prepare v4.2.6

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b8144a5078ba26e9c2e16c71ad759b72a3ec2a1bf2eb7098284d9534319ba9b1",
+  "originHash" : "743707a737759f280cefdd070cadb56570f2529539de12176fd5d263558ee1b4",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/SpeakSwiftly.git",
       "state" : {
-        "revision" : "603de1a9b78140f4bb20a01ec53436b02141ce34",
-        "version" : "3.2.4"
+        "revision" : "1806a9b89e9ed232c3ee5d75593ed3fb90fb34d1",
+        "version" : "3.2.5"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "743707a737759f280cefdd070cadb56570f2529539de12176fd5d263558ee1b4",
+  "originHash" : "99936693df8774c3bb22a0e93149cbe4e3b4b4fe84bd6c7945307316d267a571",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/SpeakSwiftly.git",
       "state" : {
-        "revision" : "1806a9b89e9ed232c3ee5d75593ed3fb90fb34d1",
-        "version" : "3.2.5"
+        "revision" : "a870a2472c00240af62932f72a0a36b59a37987d",
+        "version" : "3.2.6"
       }
     },
     {
@@ -321,8 +321,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/TextForSpeech.git",
       "state" : {
-        "revision" : "b9640e2dd11054764aecd6117f98ad83db17d914",
-        "version" : "0.18.5"
+        "revision" : "ef6afaf4fd07deede82d534fbfcc588f9d6258b0",
+        "version" : "0.18.6"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
         .package(
             url: "https://github.com/gaelic-ghost/SpeakSwiftly.git",
-            from: "3.2.4",
+            from: "3.2.5",
         ),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "2.30.6"),
         .package(url: "https://github.com/gaelic-ghost/TextForSpeech.git", from: "0.17.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
         .package(
             url: "https://github.com/gaelic-ghost/SpeakSwiftly.git",
-            from: "3.2.5",
+            from: "3.2.6",
         ),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "2.30.6"),
         .package(url: "https://github.com/gaelic-ghost/TextForSpeech.git", from: "0.17.0"),

--- a/Sources/SpeakSwiftlyServer/Host/QueueStatusModels.swift
+++ b/Sources/SpeakSwiftlyServer/Host/QueueStatusModels.swift
@@ -17,7 +17,7 @@ public struct ActiveRequestSnapshot: Codable, Sendable, Equatable {
     init(summary: SpeakSwiftly.ActiveRequest) {
         id = summary.id
         op = canonicalOperationName(summary.op)
-        profileName = summary.profileName
+        profileName = summary.voiceProfile
     }
 
     init(id: String, op: String, profileName: String?) {
@@ -44,7 +44,7 @@ public struct QueuedRequestSnapshot: Codable, Sendable, Equatable {
     init(summary: SpeakSwiftly.QueuedRequest) {
         id = summary.id
         op = canonicalOperationName(summary.op)
-        profileName = summary.profileName
+        profileName = summary.voiceProfile
         queuePosition = summary.queuePosition
     }
 

--- a/Sources/SpeakSwiftlyServer/Host/ServerModels.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerModels.swift
@@ -159,9 +159,11 @@ struct BatchItemRequestPayload: Decodable {
         try .init(
             artifactID: artifactID,
             text: text,
-            textProfileID: textProfileID,
-            textContext: normalizationContext(),
-            sourceFormat: sourceFormatModel(),
+            textProfile: textProfileID,
+            inputTextContext: makeInputTextContext(
+                normalizationContext: normalizationContext(),
+                sourceFormat: sourceFormatModel(),
+            ),
         )
     }
 

--- a/Sources/SpeakSwiftlyServer/Host/ServerRuntimeAdapter.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerRuntimeAdapter.swift
@@ -34,10 +34,12 @@ actor ServerRuntimeAdapter: ServerRuntimeProtocol {
     ) async -> RuntimeRequestHandle {
         let handle = await runtime.generate.speech(
             text: text,
-            with: profileName,
-            textProfileID: textProfileID,
-            textContext: normalizationContext,
-            sourceFormat: sourceFormat,
+            voiceProfile: profileName,
+            textProfile: textProfileID,
+            inputTextContext: makeInputTextContext(
+                normalizationContext: normalizationContext,
+                sourceFormat: sourceFormat,
+            ),
         )
         return .init(id: handle.id, operation: "generate_speech", profileName: profileName, events: handle.events)
     }
@@ -51,10 +53,12 @@ actor ServerRuntimeAdapter: ServerRuntimeProtocol {
     ) async -> RuntimeRequestHandle {
         let handle = await runtime.generate.audio(
             text: text,
-            with: profileName,
-            textProfileID: textProfileID,
-            textContext: normalizationContext,
-            sourceFormat: sourceFormat,
+            voiceProfile: profileName,
+            textProfile: textProfileID,
+            inputTextContext: makeInputTextContext(
+                normalizationContext: normalizationContext,
+                sourceFormat: sourceFormat,
+            ),
         )
         return .init(id: handle.id, operation: "generate_audio_file", profileName: profileName, events: handle.events)
     }
@@ -63,7 +67,7 @@ actor ServerRuntimeAdapter: ServerRuntimeProtocol {
         _ items: [SpeakSwiftly.BatchItem],
         with profileName: String,
     ) async -> RuntimeRequestHandle {
-        let handle = await runtime.generate.batch(items, with: profileName)
+        let handle = await runtime.generate.batch(items, voiceProfile: profileName)
         return .init(id: handle.id, operation: "generate_batch", profileName: profileName, events: handle.events)
     }
 

--- a/Sources/SpeakSwiftlyServer/Host/ServerRuntimeProtocol.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerRuntimeProtocol.swift
@@ -4,6 +4,20 @@ import TextForSpeech
 
 public typealias SpeechNormalizationContext = TextForSpeech.Context
 
+func makeInputTextContext(
+    normalizationContext: SpeechNormalizationContext?,
+    sourceFormat: TextForSpeech.SourceFormat?,
+) -> SpeakSwiftly.InputTextContext? {
+    guard normalizationContext != nil || sourceFormat != nil else {
+        return nil
+    }
+
+    return SpeakSwiftly.InputTextContext(
+        context: normalizationContext,
+        sourceFormat: sourceFormat,
+    )
+}
+
 struct RuntimeRequestHandle {
     let id: String
     let operation: String
@@ -27,7 +41,7 @@ struct RuntimeRequestHandle {
     init(_ handle: SpeakSwiftly.RequestHandle) {
         id = handle.id
         operation = canonicalOperationName(handle.operation)
-        profileName = handle.profileName
+        profileName = handle.voiceProfile
         events = handle.events
     }
 }

--- a/Tests/SpeakSwiftlyServerTests/MockRuntime+ProfilesAndArtifacts.swift
+++ b/Tests/SpeakSwiftlyServerTests/MockRuntime+ProfilesAndArtifacts.swift
@@ -188,17 +188,17 @@ extension MockRuntime {
                 jobKind: current.jobKind.rawValue,
                 createdAt: current.createdAt,
                 updatedAt: Date(),
-                profileName: current.profileName,
-                textProfileID: current.textProfileID,
+                voiceProfile: current.voiceProfile,
+                textProfile: current.textProfile,
                 speechBackend: current.speechBackend.rawValue,
                 state: "expired",
                 items: current.items.map {
                     GenerationJobItemFixture(
                         artifactID: $0.artifactID,
                         text: $0.text,
-                        textProfileID: $0.textProfileID,
-                        textContext: $0.textContext,
-                        sourceFormat: $0.sourceFormat,
+                        textProfile: $0.textProfile,
+                        inputTextContext: $0.inputTextContext,
+                        requestContext: $0.requestContext,
                     )
                 },
                 artifacts: current.artifacts.map {
@@ -208,8 +208,10 @@ extension MockRuntime {
                         createdAt: $0.createdAt,
                         filePath: $0.filePath,
                         sampleRate: $0.sampleRate,
-                        profileName: $0.profileName,
-                        textProfileID: $0.textProfileID,
+                        voiceProfile: $0.voiceProfile,
+                        textProfile: $0.textProfile,
+                        inputTextContext: $0.inputTextContext,
+                        requestContext: $0.requestContext,
                     )
                 },
                 failure: current.failure.map { .init(code: $0.code, message: $0.message) },

--- a/Tests/SpeakSwiftlyServerTests/MockRuntime+SpeechGeneration.swift
+++ b/Tests/SpeakSwiftlyServerTests/MockRuntime+SpeechGeneration.swift
@@ -67,8 +67,12 @@ extension MockRuntime {
             try makeGeneratedFile(
                 artifactID: artifactID,
                 createdAt: createdAt,
-                profileName: profileName,
-                textProfileID: textProfileID,
+                voiceProfile: profileName,
+                textProfile: textProfileID,
+                inputTextContext: makeInputTextContext(
+                    normalizationContext: normalizationContext,
+                    sourceFormat: sourceFormat,
+                ),
                 sampleRate: 24000,
                 filePath: "/tmp/\(artifactID).wav",
             )
@@ -78,9 +82,12 @@ extension MockRuntime {
             GenerationJobItemFixture(
                 artifactID: artifactID,
                 text: text,
-                textProfileID: textProfileID,
-                textContext: normalizationContext,
-                sourceFormat: sourceFormat,
+                textProfile: textProfileID,
+                inputTextContext: makeInputTextContext(
+                    normalizationContext: normalizationContext,
+                    sourceFormat: sourceFormat,
+                ),
+                requestContext: nil,
             ),
         ]
         let artifacts = [
@@ -90,8 +97,13 @@ extension MockRuntime {
                 createdAt: createdAt,
                 filePath: generatedFile.filePath,
                 sampleRate: generatedFile.sampleRate,
-                profileName: profileName,
-                textProfileID: textProfileID,
+                voiceProfile: profileName,
+                textProfile: textProfileID,
+                inputTextContext: makeInputTextContext(
+                    normalizationContext: normalizationContext,
+                    sourceFormat: sourceFormat,
+                ),
+                requestContext: nil,
             ),
         ]
         generationJobs.append(
@@ -101,8 +113,8 @@ extension MockRuntime {
                     jobKind: "file",
                     createdAt: createdAt,
                     updatedAt: createdAt,
-                    profileName: profileName,
-                    textProfileID: textProfileID,
+                    voiceProfile: profileName,
+                    textProfile: textProfileID,
                     speechBackend: "qwen3",
                     state: "completed",
                     items: items,
@@ -133,8 +145,9 @@ extension MockRuntime {
                 try makeGeneratedFile(
                     artifactID: item.artifactID ?? "\(requestID)-artifact-\(index + 1)",
                     createdAt: createdAt,
-                    profileName: profileName,
-                    textProfileID: item.textProfileID,
+                    voiceProfile: profileName,
+                    textProfile: item.textProfile,
+                    inputTextContext: item.inputTextContext,
                     sampleRate: 24000,
                     filePath: "/tmp/\(item.artifactID ?? "\(requestID)-artifact-\(index + 1)").wav",
                 )
@@ -145,16 +158,16 @@ extension MockRuntime {
             GenerationJobItemFixture(
                 artifactID: item.artifactID ?? "\(requestID)-artifact-\(index + 1)",
                 text: item.text,
-                textProfileID: item.textProfileID,
-                textContext: item.textContext,
-                sourceFormat: item.sourceFormat,
+                textProfile: item.textProfile,
+                inputTextContext: item.inputTextContext,
+                requestContext: item.requestContext,
             )
         }
         let generatedBatch = requireFixture("generated batch '\(requestID)'") {
             try makeGeneratedBatch(
                 batchID: requestID,
-                profileName: profileName,
-                textProfileID: items.first?.textProfileID,
+                voiceProfile: profileName,
+                textProfile: items.first?.textProfile,
                 speechBackend: "qwen3",
                 state: "completed",
                 items: batchItems,
@@ -162,8 +175,10 @@ extension MockRuntime {
                     GeneratedFileFixture(
                         artifactID: $0.artifactID,
                         createdAt: $0.createdAt,
-                        profileName: $0.profileName,
-                        textProfileID: $0.textProfileID,
+                        voiceProfile: $0.voiceProfile,
+                        textProfile: $0.textProfile,
+                        inputTextContext: $0.inputTextContext,
+                        requestContext: $0.requestContext,
                         sampleRate: $0.sampleRate,
                         filePath: $0.filePath,
                     )
@@ -185,8 +200,8 @@ extension MockRuntime {
                     jobKind: "batch",
                     createdAt: createdAt,
                     updatedAt: createdAt,
-                    profileName: profileName,
-                    textProfileID: items.first?.textProfileID,
+                    voiceProfile: profileName,
+                    textProfile: items.first?.textProfile,
                     speechBackend: "qwen3",
                     state: "completed",
                     items: batchItems,
@@ -197,8 +212,10 @@ extension MockRuntime {
                             createdAt: $0.createdAt,
                             filePath: $0.filePath,
                             sampleRate: $0.sampleRate,
-                            profileName: $0.profileName,
-                            textProfileID: $0.textProfileID,
+                            voiceProfile: $0.voiceProfile,
+                            textProfile: $0.textProfile,
+                            inputTextContext: $0.inputTextContext,
+                            requestContext: $0.requestContext,
                         )
                     },
                     startedAt: generatedBatch.startedAt,

--- a/Tests/SpeakSwiftlyServerTests/MockRuntime+TestControl.swift
+++ b/Tests/SpeakSwiftlyServerTests/MockRuntime+TestControl.swift
@@ -111,7 +111,7 @@ extension MockRuntime {
     }
 
     func activeSummary(for request: MockRequest) -> SpeakSwiftly.ActiveRequest {
-        .init(id: request.id, op: request.operation, profileName: request.profileName)
+        .init(id: request.id, op: request.operation, voiceProfile: request.profileName, requestContext: nil)
     }
 
     func queuedSummaries() -> [SpeakSwiftly.QueuedRequest] {
@@ -119,7 +119,8 @@ extension MockRuntime {
             .init(
                 id: queued.request.id,
                 op: queued.request.operation,
-                profileName: queued.request.profileName,
+                voiceProfile: queued.request.profileName,
+                requestContext: nil,
                 queuePosition: offset + 1,
             )
         }

--- a/Tests/SpeakSwiftlyServerTests/SpeakSwiftlyServerTestFixtures.swift
+++ b/Tests/SpeakSwiftlyServerTests/SpeakSwiftlyServerTestFixtures.swift
@@ -82,16 +82,20 @@ func sampleProfile() -> SpeakSwiftly.ProfileSummary {
 struct GeneratedFileFixture: Codable {
     let artifactID: String
     let createdAt: Date
-    let profileName: String
-    let textProfileID: String?
+    let voiceProfile: String
+    let textProfile: String?
+    let inputTextContext: SpeakSwiftly.InputTextContext?
+    let requestContext: SpeakSwiftly.RequestContext?
     let sampleRate: Int
     let filePath: String
 
     enum CodingKeys: String, CodingKey {
         case artifactID = "artifact_id"
         case createdAt = "created_at"
-        case profileName = "profile_name"
-        case textProfileID = "text_profile_id"
+        case voiceProfile = "voice_profile"
+        case textProfile = "text_profile"
+        case inputTextContext = "input_text_context"
+        case requestContext = "request_context"
         case sampleRate = "sample_rate"
         case filePath = "file_path"
     }
@@ -105,8 +109,10 @@ struct GenerationArtifactFixture: Codable {
     let createdAt: Date
     let filePath: String
     let sampleRate: Int
-    let profileName: String
-    let textProfileID: String?
+    let voiceProfile: String
+    let textProfile: String?
+    let inputTextContext: SpeakSwiftly.InputTextContext?
+    let requestContext: SpeakSwiftly.RequestContext?
 
     enum CodingKeys: String, CodingKey {
         case artifactID = "artifact_id"
@@ -114,8 +120,10 @@ struct GenerationArtifactFixture: Codable {
         case createdAt = "created_at"
         case filePath = "file_path"
         case sampleRate = "sample_rate"
-        case profileName = "profile_name"
-        case textProfileID = "text_profile_id"
+        case voiceProfile = "voice_profile"
+        case textProfile = "text_profile"
+        case inputTextContext = "input_text_context"
+        case requestContext = "request_context"
     }
 }
 
@@ -124,16 +132,16 @@ struct GenerationArtifactFixture: Codable {
 struct GenerationJobItemFixture: Codable {
     let artifactID: String
     let text: String
-    let textProfileID: String?
-    let textContext: TextForSpeech.Context?
-    let sourceFormat: TextForSpeech.SourceFormat?
+    let textProfile: String?
+    let inputTextContext: SpeakSwiftly.InputTextContext?
+    let requestContext: SpeakSwiftly.RequestContext?
 
     enum CodingKeys: String, CodingKey {
         case artifactID = "artifact_id"
         case text
-        case textProfileID = "text_profile_id"
-        case textContext = "text_context"
-        case sourceFormat = "source_format"
+        case textProfile = "text_profile"
+        case inputTextContext = "input_text_context"
+        case requestContext = "request_context"
     }
 }
 
@@ -151,8 +159,8 @@ struct GenerationJobFixture: Codable {
     let jobKind: String
     let createdAt: Date
     let updatedAt: Date
-    let profileName: String
-    let textProfileID: String?
+    let voiceProfile: String
+    let textProfile: String?
     let speechBackend: String
     let state: String
     let items: [GenerationJobItemFixture]
@@ -169,8 +177,8 @@ struct GenerationJobFixture: Codable {
         case jobKind = "job_kind"
         case createdAt = "created_at"
         case updatedAt = "updated_at"
-        case profileName = "profile_name"
-        case textProfileID = "text_profile_id"
+        case voiceProfile = "voice_profile"
+        case textProfile = "text_profile"
         case speechBackend = "speech_backend"
         case state
         case items
@@ -188,8 +196,8 @@ struct GenerationJobFixture: Codable {
 
 struct GeneratedBatchFixture: Codable {
     let batchID: String
-    let profileName: String
-    let textProfileID: String?
+    let voiceProfile: String
+    let textProfile: String?
     let speechBackend: String
     let state: String
     let items: [GenerationJobItemFixture]
@@ -205,8 +213,8 @@ struct GeneratedBatchFixture: Codable {
 
     enum CodingKeys: String, CodingKey {
         case batchID = "batch_id"
-        case profileName = "profile_name"
-        case textProfileID = "text_profile_id"
+        case voiceProfile = "voice_profile"
+        case textProfile = "text_profile"
         case speechBackend = "speech_backend"
         case state
         case items
@@ -242,8 +250,10 @@ func requireFixture<T>(
 func makeGeneratedFile(
     artifactID: String,
     createdAt: Date,
-    profileName: String,
-    textProfileID: String?,
+    voiceProfile: String,
+    textProfile: String?,
+    inputTextContext: SpeakSwiftly.InputTextContext? = nil,
+    requestContext: SpeakSwiftly.RequestContext? = nil,
     sampleRate: Int,
     filePath: String,
 ) throws -> SpeakSwiftly.GeneratedFile {
@@ -251,8 +261,10 @@ func makeGeneratedFile(
         GeneratedFileFixture(
             artifactID: artifactID,
             createdAt: createdAt,
-            profileName: profileName,
-            textProfileID: textProfileID,
+            voiceProfile: voiceProfile,
+            textProfile: textProfile,
+            inputTextContext: inputTextContext,
+            requestContext: requestContext,
             sampleRate: sampleRate,
             filePath: filePath,
         ),
@@ -265,8 +277,8 @@ func makeGenerationJob(
     jobKind: String,
     createdAt: Date,
     updatedAt: Date,
-    profileName: String,
-    textProfileID: String?,
+    voiceProfile: String,
+    textProfile: String?,
     speechBackend: String,
     state: String,
     items: [GenerationJobItemFixture],
@@ -284,8 +296,8 @@ func makeGenerationJob(
             jobKind: jobKind,
             createdAt: createdAt,
             updatedAt: updatedAt,
-            profileName: profileName,
-            textProfileID: textProfileID,
+            voiceProfile: voiceProfile,
+            textProfile: textProfile,
             speechBackend: speechBackend,
             state: state,
             items: items,
@@ -303,8 +315,8 @@ func makeGenerationJob(
 
 func makeGeneratedBatch(
     batchID: String,
-    profileName: String,
-    textProfileID: String?,
+    voiceProfile: String,
+    textProfile: String?,
     speechBackend: String,
     state: String,
     items: [GenerationJobItemFixture],
@@ -321,8 +333,8 @@ func makeGeneratedBatch(
     try fixtureDecode(
         GeneratedBatchFixture(
             batchID: batchID,
-            profileName: profileName,
-            textProfileID: textProfileID,
+            voiceProfile: voiceProfile,
+            textProfile: textProfile,
             speechBackend: speechBackend,
             state: state,
             items: items,

--- a/docs/releases/v4.2.6-release-checklist.md
+++ b/docs/releases/v4.2.6-release-checklist.md
@@ -1,0 +1,49 @@
+# `v4.2.6` Release Checklist
+
+## Purpose
+
+This checklist is the maintainer-facing candidate path for `v4.2.6`.
+
+Use it when the release scope is the `SpeakSwiftly 3.2.5` dependency refresh plus the matching server compatibility pass for the renamed generation, queue, and retained-artifact request fields.
+
+For the standing branch-versus-main release contract, keep using [release-workflow.md](../maintainers/release-workflow.md). This document is only the candidate-specific checklist and release-shape note for `v4.2.6`.
+
+## Proposed Release Number
+
+Target the next release as `v4.2.6`.
+
+That patch bump matches the current change shape:
+
+- no intentional break to the published HTTP, MCP, or embedded-server contract
+- dependency refresh to `SpeakSwiftly 3.2.5`
+- compatibility alignment across the server runtime adapter, queue snapshots, and retained-artifact fixtures
+
+## Pre-Tag Checklist
+
+- keep the worktree clean before release preparation or publish
+- confirm the package-development lane passes:
+
+```bash
+xcrun swift build
+```
+
+```bash
+xcrun swift test
+```
+
+## Suggested Release Notes Shape
+
+Center the release notes on three points:
+
+- the `SpeakSwiftly 3.2.5` dependency refresh
+- the server runtime adapter moving onto the current `voiceProfile` and `inputTextContext` generation API
+- the queue and retained-artifact test fixtures now matching the latest upstream snapshot field names
+
+## Publish Reminder
+
+If this candidate moves forward, use the split release workflow rather than tagging directly from a feature branch:
+
+1. run `scripts/repo-maintenance/release-prepare.sh --version v4.2.6` from the feature branch or release candidate worktree
+2. let the PR merge back to `main`
+3. fast-forward local `main`
+4. run `scripts/repo-maintenance/release-publish.sh --version v4.2.6`

--- a/docs/releases/v4.2.6-release-checklist.md
+++ b/docs/releases/v4.2.6-release-checklist.md
@@ -4,7 +4,7 @@
 
 This checklist is the maintainer-facing candidate path for `v4.2.6`.
 
-Use it when the release scope is the `SpeakSwiftly 3.2.5` dependency refresh plus the matching server compatibility pass for the renamed generation, queue, and retained-artifact request fields.
+Use it when the release scope is the `SpeakSwiftly 3.2.6` dependency refresh plus the matching server compatibility pass for the renamed generation, queue, and retained-artifact request fields that landed across the latest bug-fix line.
 
 For the standing branch-versus-main release contract, keep using [release-workflow.md](../maintainers/release-workflow.md). This document is only the candidate-specific checklist and release-shape note for `v4.2.6`.
 
@@ -15,7 +15,7 @@ Target the next release as `v4.2.6`.
 That patch bump matches the current change shape:
 
 - no intentional break to the published HTTP, MCP, or embedded-server contract
-- dependency refresh to `SpeakSwiftly 3.2.5`
+- dependency refresh to `SpeakSwiftly 3.2.6`
 - compatibility alignment across the server runtime adapter, queue snapshots, and retained-artifact fixtures
 
 ## Pre-Tag Checklist
@@ -35,8 +35,8 @@ xcrun swift test
 
 Center the release notes on three points:
 
-- the `SpeakSwiftly 3.2.5` dependency refresh
-- the server runtime adapter moving onto the current `voiceProfile` and `inputTextContext` generation API
+- the `SpeakSwiftly 3.2.6` dependency refresh
+- the server runtime adapter staying aligned with the current `voiceProfile` and `inputTextContext` generation API
 - the queue and retained-artifact test fixtures now matching the latest upstream snapshot field names
 
 ## Publish Reminder

--- a/docs/releases/v4.2.6-release-notes.md
+++ b/docs/releases/v4.2.6-release-notes.md
@@ -1,0 +1,26 @@
+# v4.2.6 Release Notes
+
+## What changed
+
+- refreshed the resolved `SpeakSwiftly` dependency to [`3.2.5`](https://github.com/gaelic-ghost/SpeakSwiftly/releases/tag/v3.2.5)
+- aligned the server runtime adapter with the current `SpeakSwiftly` generation API, including the `voiceProfile` and `inputTextContext` request-shaping changes
+- updated the server test fixtures and mock runtime snapshots to match the current upstream queue and retained-artifact models
+
+## Breaking changes
+
+- none
+
+## Migration or upgrade notes
+
+- no operator workflow changes are required for this patch
+- downstream consumers should treat this as a compatibility refresh for the current `SpeakSwiftly` request and snapshot surface
+
+## Verification performed
+
+```bash
+xcrun swift build
+```
+
+```bash
+xcrun swift test
+```

--- a/docs/releases/v4.2.6-release-notes.md
+++ b/docs/releases/v4.2.6-release-notes.md
@@ -2,9 +2,9 @@
 
 ## What changed
 
-- refreshed the resolved `SpeakSwiftly` dependency to [`3.2.5`](https://github.com/gaelic-ghost/SpeakSwiftly/releases/tag/v3.2.5)
-- aligned the server runtime adapter with the current `SpeakSwiftly` generation API, including the `voiceProfile` and `inputTextContext` request-shaping changes
-- updated the server test fixtures and mock runtime snapshots to match the current upstream queue and retained-artifact models
+- refreshed the resolved `SpeakSwiftly` dependency to [`3.2.6`](https://github.com/gaelic-ghost/SpeakSwiftly/releases/tag/v3.2.6)
+- aligned the server runtime adapter with the current `SpeakSwiftly` generation API and snapshot names across the `3.2.5` and `3.2.6` bug-fix line
+- updated the server test fixtures and mock runtime snapshots to match the current upstream queue and retained-artifact models while staying compatible with the newer Qwen playback fixes
 
 ## Breaking changes
 
@@ -13,7 +13,7 @@
 ## Migration or upgrade notes
 
 - no operator workflow changes are required for this patch
-- downstream consumers should treat this as a compatibility refresh for the current `SpeakSwiftly` request and snapshot surface
+- downstream consumers should treat this as a compatibility refresh for the current `SpeakSwiftly` request, snapshot, and playback bug-fix surface
 
 ## Verification performed
 


### PR DESCRIPTION
## Release Prepare

- prepares release candidate `v4.2.6`
- leaves release artifact staging, final tag creation, and GitHub release publication for `scripts/repo-maintenance/release-publish.sh` after this pull request lands on `main`

## Publish Follow-Up

After this pull request merges, switch to `main` locally and run:

```bash
scripts/repo-maintenance/release-publish.sh --version v4.2.6 --skip-live-service-refresh
```
