### PR TITLE
release: prepare v4.2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The full transport contract lives in [API.md](./API.md).
 
 ## Embedding
 
-The supported public embedding surface is `EmbeddedServer`, defined in [Sources/SpeakSwiftlyServer/Host/ServerState.swift](./Sources/SpeakSwiftlyServer/Host/ServerState.swift). App code owns that one observable object directly, calls `liftoff()`, binds UI to its observable properties, and uses the same object for runtime controls, playback controls, voice-profile actions, and direct live speech submission through `queueLiveSpeech(...)`.
+The supported public embedding surface is `EmbeddedServer`, defined in [Sources/SpeakSwiftlyServer/Host/ServerState.swift](./Sources/SpeakSwiftlyServer/Host/ServerState.swift). App code owns that one observable object directly, calls `liftoff()`, binds UI to its observable properties, and uses the same object for runtime controls, playback controls, voice-profile actions, and direct live speech submission through `queueLiveSpeech(...)`, including the shared `SpeakSwiftly.RequestContext` metadata model when one request needs caller-origin details.
 
 ```swift
 import SpeakSwiftlyServer

--- a/Sources/SpeakSwiftlyServer/EmbeddedServerSession.swift
+++ b/Sources/SpeakSwiftlyServer/EmbeddedServerSession.swift
@@ -53,7 +53,7 @@ func embeddedServerLiveBootstrap(
                 refreshVoiceProfiles: {
                     try await host.refreshVoiceProfiles()
                 },
-                queueLiveSpeech: { text, profileName, textProfileID, normalizationContext, sourceFormat in
+                queueLiveSpeech: { text, profileName, textProfileID, normalizationContext, sourceFormat, requestContext in
                     guard let resolvedProfileName = await host.resolvedRequestedVoiceProfileName(profileName) else {
                         let errorMessage = await host.missingVoiceProfileNameMessage(for: "the live speech request")
                         throw ServerConfigurationError(errorMessage)
@@ -65,6 +65,7 @@ func embeddedServerLiveBootstrap(
                         textProfileID: textProfileID,
                         normalizationContext: normalizationContext,
                         sourceFormat: sourceFormat,
+                        requestContext: requestContext,
                     )
                 },
                 setDefaultVoiceProfileName: { profileName in

--- a/Sources/SpeakSwiftlyServer/HTTP/HTTPSpeechRoutes.swift
+++ b/Sources/SpeakSwiftlyServer/HTTP/HTTPSpeechRoutes.swift
@@ -20,6 +20,7 @@ func registerHTTPSpeechRoutes(
             textProfileID: payload.textProfileID,
             normalizationContext: payload.normalizationContext(),
             sourceFormat: payload.sourceFormatModel(),
+            requestContext: payload.requestContext,
         )
         return try buildAcceptedRequestResponse(request: request, configuration: configuration, requestID: requestID)
     }
@@ -39,6 +40,7 @@ func registerHTTPSpeechRoutes(
             textProfileID: payload.textProfileID,
             normalizationContext: payload.normalizationContext(),
             sourceFormat: payload.sourceFormatModel(),
+            requestContext: payload.requestContext,
         )
         return try buildAcceptedRequestResponse(request: request, configuration: configuration, requestID: requestID)
     }

--- a/Sources/SpeakSwiftlyServer/HTTP/HTTPTextProfileRoutes.swift
+++ b/Sources/SpeakSwiftlyServer/HTTP/HTTPTextProfileRoutes.swift
@@ -1,11 +1,35 @@
 import Hummingbird
+import SpeakSwiftly
+
+private func mapTextProfileRouteError(_ error: any Error) -> any Error {
+    if error is HTTPError {
+        return error
+    }
+
+    if let error = error as? SpeakSwiftly.Error {
+        return HTTPError(
+            .internalServerError,
+            message: error.message,
+        )
+    }
+
+    return HTTPError(
+        .internalServerError,
+        message: "SpeakSwiftlyServer could not complete the text-profile request. Likely cause: \(error.localizedDescription)",
+    )
+}
 
 func registerHTTPTextProfileRoutes(
     on router: Router<BasicRequestContext>,
     host: ServerHost,
 ) {
     router.get("text-profiles") { _, _ -> TextProfileListResponse in
-        await .init(textProfiles: host.textProfilesSnapshot())
+        do {
+            let snapshot = try await host.textProfilesSnapshot()
+            return .init(textProfiles: snapshot)
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.get("text-profiles/style") { _, _ -> TextProfileStyleResponse in
@@ -13,127 +37,211 @@ func registerHTTPTextProfileRoutes(
     }
 
     router.get("text-profiles/base") { _, _ -> TextProfileResponse in
-        await .init(profile: (host.textProfilesSnapshot()).baseProfile)
+        do {
+            let snapshot = try await host.textProfilesSnapshot()
+            return .init(profile: snapshot.baseProfile)
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.get("text-profiles/active") { _, _ -> TextProfileResponse in
-        await .init(profile: (host.textProfilesSnapshot()).activeProfile)
+        do {
+            let snapshot = try await host.textProfilesSnapshot()
+            return .init(profile: snapshot.activeProfile)
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.get("text-profiles/effective") { _, _ -> TextProfileResponse in
-        await .init(profile: host.effectiveTextProfile(nil))
+        do {
+            let profile = try await host.effectiveTextProfile(nil)
+            return .init(profile: profile)
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.get("text-profiles/effective/:profile_id") { _, context -> TextProfileResponse in
         let profileID = try context.parameters.require("profile_id")
-        return await .init(profile: host.effectiveTextProfile(profileID))
+        do {
+            let profile = try await host.effectiveTextProfile(profileID)
+            return .init(profile: profile)
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.get("text-profiles/stored/:profile_id") { _, context -> TextProfileResponse in
         let profileID = try context.parameters.require("profile_id")
-        guard let profile = await host.storedTextProfile(profileID) else {
-            throw HTTPError(
-                .notFound,
-                message: "Text profile '\(profileID)' was not found in the persisted SpeakSwiftly text-profile set.",
-            )
-        }
+        do {
+            guard let profile = try await host.storedTextProfile(profileID) else {
+                throw HTTPError(
+                    .notFound,
+                    message: "Text profile '\(profileID)' was not found in the persisted SpeakSwiftly text-profile set.",
+                )
+            }
 
-        return .init(profile: profile)
+            return .init(profile: profile)
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.post("text-profiles/stored") { request, context -> TextProfileResponse in
-        let payload = try await request.decode(as: CreateTextProfileRequestPayload.self, context: context)
-        let profile = try await host.createTextProfile(
-            name: payload.name,
-            replacements: (payload.replacements ?? []).map { try $0.model() },
-        )
-        return .init(profile: profile)
+        do {
+            let payload = try await request.decode(as: CreateTextProfileRequestPayload.self, context: context)
+            let profile = try await host.createTextProfile(
+                name: payload.name,
+                replacements: (payload.replacements ?? []).map { try $0.model() },
+            )
+            return .init(profile: profile)
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.post("text-profiles/load") { _, _ -> TextProfileListResponse in
-        try await .init(textProfiles: host.loadTextProfiles())
+        do {
+            return try await .init(textProfiles: host.loadTextProfiles())
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.post("text-profiles/save") { _, _ -> TextProfileListResponse in
-        try await .init(textProfiles: host.saveTextProfiles())
+        do {
+            return try await .init(textProfiles: host.saveTextProfiles())
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.put("text-profiles/style") { request, context -> TextProfileListResponse in
-        let payload = try await request.decode(as: SetTextProfileStyleRequestPayload.self, context: context)
-        return try await .init(textProfiles: host.setTextProfileStyle(payload.styleModel()))
+        do {
+            let payload = try await request.decode(as: SetTextProfileStyleRequestPayload.self, context: context)
+            return try await .init(textProfiles: host.setTextProfileStyle(payload.styleModel()))
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.put("text-profiles/stored/:profile_id/name") { request, context -> TextProfileResponse in
-        let profileID = try context.parameters.require("profile_id")
-        let payload = try await request.decode(as: RenameTextProfileRequestPayload.self, context: context)
-        return try await .init(profile: host.renameTextProfile(id: profileID, to: payload.name))
+        do {
+            let profileID = try context.parameters.require("profile_id")
+            let payload = try await request.decode(as: RenameTextProfileRequestPayload.self, context: context)
+            return try await .init(profile: host.renameTextProfile(id: profileID, to: payload.name))
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.put("text-profiles/active") { request, context -> TextProfileResponse in
-        let payload = try await request.decode(as: SetActiveTextProfileRequestPayload.self, context: context)
-        return try await .init(profile: host.setActiveTextProfile(id: payload.profileID))
+        do {
+            let payload = try await request.decode(as: SetActiveTextProfileRequestPayload.self, context: context)
+            return try await .init(profile: host.setActiveTextProfile(id: payload.profileID))
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.post("text-profiles/factory-reset") { _, _ -> TextProfileListResponse in
-        try await .init(textProfiles: host.factoryResetTextProfiles())
+        do {
+            return try await .init(textProfiles: host.factoryResetTextProfiles())
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.post("text-profiles/stored/:profile_id/reset") { _, context -> TextProfileResponse in
-        let profileID = try context.parameters.require("profile_id")
-        return try await .init(profile: host.resetTextProfile(id: profileID))
+        do {
+            let profileID = try context.parameters.require("profile_id")
+            return try await .init(profile: host.resetTextProfile(id: profileID))
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.delete("text-profiles/stored/:profile_id") { _, context -> TextProfileListResponse in
-        let profileID = try context.parameters.require("profile_id")
-        return try await .init(textProfiles: host.removeTextProfile(id: profileID))
+        do {
+            let profileID = try context.parameters.require("profile_id")
+            return try await .init(textProfiles: host.removeTextProfile(id: profileID))
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.post("text-profiles/active/replacements") { request, context -> TextProfileResponse in
-        let payload = try await request.decode(as: TextReplacementRequestPayload.self, context: context)
-        return try await .init(profile: host.addTextReplacement(payload.replacement.model()))
+        do {
+            let payload = try await request.decode(as: TextReplacementRequestPayload.self, context: context)
+            return try await .init(profile: host.addTextReplacement(payload.replacement.model()))
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.post("text-profiles/stored/:profile_id/replacements") { request, context -> TextProfileResponse in
-        let profileID = try context.parameters.require("profile_id")
-        let payload = try await request.decode(as: TextReplacementRequestPayload.self, context: context)
-        return try await .init(profile: host.addTextReplacement(payload.replacement.model(), toStoredTextProfileID: profileID))
+        do {
+            let profileID = try context.parameters.require("profile_id")
+            let payload = try await request.decode(as: TextReplacementRequestPayload.self, context: context)
+            return try await .init(profile: host.addTextReplacement(payload.replacement.model(), toStoredTextProfileID: profileID))
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.put("text-profiles/active/replacements/:replacement_id") { request, context -> TextProfileResponse in
-        let replacementID = try context.parameters.require("replacement_id")
-        let payload = try await request.decode(as: TextReplacementRequestPayload.self, context: context)
-        guard payload.replacement.id == replacementID else {
-            throw HTTPError(
-                .badRequest,
-                message: "Active text replacement route id '\(replacementID)' did not match body replacement id '\(payload.replacement.id)'.",
-            )
-        }
+        do {
+            let replacementID = try context.parameters.require("replacement_id")
+            let payload = try await request.decode(as: TextReplacementRequestPayload.self, context: context)
+            guard payload.replacement.id == replacementID else {
+                throw HTTPError(
+                    .badRequest,
+                    message: "Active text replacement route id '\(replacementID)' did not match body replacement id '\(payload.replacement.id)'.",
+                )
+            }
 
-        return try await .init(profile: host.replaceTextReplacement(payload.replacement.model()))
+            return try await .init(profile: host.replaceTextReplacement(payload.replacement.model()))
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.put("text-profiles/stored/:profile_id/replacements/:replacement_id") { request, context -> TextProfileResponse in
-        let profileID = try context.parameters.require("profile_id")
-        let replacementID = try context.parameters.require("replacement_id")
-        let payload = try await request.decode(as: TextReplacementRequestPayload.self, context: context)
-        guard payload.replacement.id == replacementID else {
-            throw HTTPError(
-                .badRequest,
-                message: "Stored text replacement route id '\(replacementID)' did not match body replacement id '\(payload.replacement.id)'.",
-            )
-        }
+        do {
+            let profileID = try context.parameters.require("profile_id")
+            let replacementID = try context.parameters.require("replacement_id")
+            let payload = try await request.decode(as: TextReplacementRequestPayload.self, context: context)
+            guard payload.replacement.id == replacementID else {
+                throw HTTPError(
+                    .badRequest,
+                    message: "Stored text replacement route id '\(replacementID)' did not match body replacement id '\(payload.replacement.id)'.",
+                )
+            }
 
-        return try await .init(profile: host.replaceTextReplacement(payload.replacement.model(), inStoredTextProfileID: profileID))
+            return try await .init(profile: host.replaceTextReplacement(payload.replacement.model(), inStoredTextProfileID: profileID))
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.delete("text-profiles/active/replacements/:replacement_id") { _, context -> TextProfileResponse in
-        let replacementID = try context.parameters.require("replacement_id")
-        return try await .init(profile: host.removeTextReplacement(id: replacementID))
+        do {
+            let replacementID = try context.parameters.require("replacement_id")
+            return try await .init(profile: host.removeTextReplacement(id: replacementID))
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 
     router.delete("text-profiles/stored/:profile_id/replacements/:replacement_id") { _, context -> TextProfileResponse in
-        let profileID = try context.parameters.require("profile_id")
-        let replacementID = try context.parameters.require("replacement_id")
-        return try await .init(profile: host.removeTextReplacement(id: replacementID, fromStoredTextProfileID: profileID))
+        do {
+            let profileID = try context.parameters.require("profile_id")
+            let replacementID = try context.parameters.require("replacement_id")
+            return try await .init(profile: host.removeTextReplacement(id: replacementID, fromStoredTextProfileID: profileID))
+        } catch {
+            throw mapTextProfileRouteError(error)
+        }
     }
 }

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+EventSupport.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+EventSupport.swift
@@ -88,9 +88,9 @@ extension ServerHost {
         )
     }
 
-    func emitTextProfilesChanged() async {
-        let activeProfile = await runtime.activeTextProfile()
-        let storedProfiles = await runtime.textProfiles()
+    func emitTextProfilesChanged() async throws {
+        let activeProfile = try await runtime.activeTextProfile()
+        let storedProfiles = try await runtime.textProfiles()
         hostEventContinuation.yield(
             .textProfilesChanged(
                 .init(

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+JobSubmission.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+JobSubmission.swift
@@ -10,6 +10,7 @@ extension ServerHost {
         textProfileID: String? = nil,
         normalizationContext: SpeechNormalizationContext? = nil,
         sourceFormat: TextForSpeech.SourceFormat? = nil,
+        requestContext: SpeakSwiftly.RequestContext? = nil,
     ) async throws -> String {
         try ensureWorkerReady()
         let handle = await runtime.queueSpeechLive(
@@ -18,6 +19,7 @@ extension ServerHost {
             textProfileID: textProfileID,
             normalizationContext: normalizationContext,
             sourceFormat: sourceFormat,
+            requestContext: requestContext,
         )
         return await enqueuePublicJob(handle)
     }
@@ -28,6 +30,7 @@ extension ServerHost {
         textProfileID: String? = nil,
         normalizationContext: SpeechNormalizationContext? = nil,
         sourceFormat: TextForSpeech.SourceFormat? = nil,
+        requestContext: SpeakSwiftly.RequestContext? = nil,
     ) async throws -> String {
         try ensureWorkerReady()
         let handle = await runtime.queueSpeechFile(
@@ -36,6 +39,7 @@ extension ServerHost {
             textProfileID: textProfileID,
             normalizationContext: normalizationContext,
             sourceFormat: sourceFormat,
+            requestContext: requestContext,
         )
         return await enqueuePublicJob(handle)
     }

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+JobTracking.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+JobTracking.swift
@@ -106,6 +106,7 @@ extension ServerHost {
                         if handle.operation == "create_voice_profile_from_description"
                             || handle.operation == "create_voice_profile_from_audio"
                             || handle.operation == "update_voice_profile_name"
+                            || handle.operation == "reroll_voice_profile"
                             || handle.operation == "delete_voice_profile" {
                             await finalizeMutationSuccess(
                                 success: success,
@@ -272,6 +273,15 @@ extension ServerHost {
                 return refreshedNames.contains(profileName)
                     && !previousNames.contains(profileName)
                     && refreshedNames.count == previousNames.count
+            case "reroll_voice_profile":
+                guard
+                    let previousProfile = previousProfiles.first(where: { $0.profileName == profileName }),
+                    let refreshedProfile = refreshedProfiles.first(where: { $0.profileName == profileName })
+                else {
+                    return false
+                }
+
+                return refreshedProfile != previousProfile
             case "delete_voice_profile":
                 return !refreshedNames.contains(profileName) && refreshedNames != previousNames
             default:

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+ProfileQueries.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+ProfileQueries.swift
@@ -69,14 +69,18 @@ extension ServerHost {
 
     // MARK: - Text Profile Queries
 
-    func textProfilesSnapshot() async -> TextProfilesSnapshot {
+    func textProfilesSnapshot() async throws -> TextProfilesSnapshot {
         let builtInStyle = await runtime.builtInTextProfileStyle()
-        return await .init(
+        let baseProfile = await runtime.baseTextProfile()
+        let activeProfile = try await runtime.activeTextProfile()
+        let storedProfiles = try await runtime.textProfiles()
+        let effectiveProfile = try await runtime.effectiveTextProfile(id: nil)
+        return .init(
             builtInStyle: builtInStyle.rawValue,
-            baseProfile: .init(profile: runtime.baseTextProfile()),
-            activeProfile: .init(details: runtime.activeTextProfile()),
-            storedProfiles: (runtime.textProfiles()).map(TextProfileSnapshot.init(summary:)),
-            effectiveProfile: .init(details: runtime.effectiveTextProfile(id: nil)),
+            baseProfile: .init(profile: baseProfile),
+            activeProfile: .init(details: activeProfile),
+            storedProfiles: storedProfiles.map(TextProfileSnapshot.init(summary:)),
+            effectiveProfile: .init(details: effectiveProfile),
         )
     }
 
@@ -84,12 +88,14 @@ extension ServerHost {
         await .init(style: runtime.builtInTextProfileStyle())
     }
 
-    func storedTextProfile(_ profileID: String) async -> TextProfileSnapshot? {
-        await runtime.textProfile(id: profileID).map(TextProfileSnapshot.init(details:))
+    func storedTextProfile(_ profileID: String) async throws -> TextProfileSnapshot? {
+        let profile = try await runtime.textProfile(id: profileID)
+        return profile.map(TextProfileSnapshot.init(details:))
     }
 
-    func effectiveTextProfile(_ profileID: String?) async -> TextProfileSnapshot {
-        await .init(details: runtime.effectiveTextProfile(id: profileID))
+    func effectiveTextProfile(_ profileID: String?) async throws -> TextProfileSnapshot {
+        let profile = try await runtime.effectiveTextProfile(id: profileID)
+        return .init(details: profile)
     }
 
     func createTextProfile(
@@ -103,66 +109,66 @@ extension ServerHost {
             }
         }
 
-        let refreshedProfile = await runtime.textProfile(id: profile.profileID) ?? profile
-        await emitTextProfilesChanged()
+        let refreshedProfile = try await runtime.textProfile(id: profile.profileID) ?? profile
+        try await emitTextProfilesChanged()
         await requestPublish(mode: .immediate, refreshRuntimeState: false)
         return .init(details: refreshedProfile)
     }
 
     func loadTextProfiles() async throws -> TextProfilesSnapshot {
         try await runtime.loadTextProfiles()
-        await emitTextProfilesChanged()
+        try await emitTextProfilesChanged()
         await requestPublish(mode: .immediate, refreshRuntimeState: false)
-        return await textProfilesSnapshot()
+        return try await textProfilesSnapshot()
     }
 
     func saveTextProfiles() async throws -> TextProfilesSnapshot {
         try await runtime.saveTextProfiles()
-        await emitTextProfilesChanged()
+        try await emitTextProfilesChanged()
         await requestPublish(mode: .immediate, refreshRuntimeState: false)
-        return await textProfilesSnapshot()
+        return try await textProfilesSnapshot()
     }
 
     func setTextProfileStyle(
         _ style: TextForSpeech.BuiltInProfileStyle,
     ) async throws -> TextProfilesSnapshot {
         _ = try await runtime.setBuiltInTextProfileStyle(style)
-        await emitTextProfilesChanged()
+        try await emitTextProfilesChanged()
         await requestPublish(mode: .immediate, refreshRuntimeState: false)
-        return await textProfilesSnapshot()
+        return try await textProfilesSnapshot()
     }
 
     func renameTextProfile(id profileID: String, to name: String) async throws -> TextProfileSnapshot {
         let profile = try await runtime.renameTextProfile(id: profileID, to: name)
-        await emitTextProfilesChanged()
+        try await emitTextProfilesChanged()
         await requestPublish(mode: .immediate, refreshRuntimeState: false)
         return .init(details: profile)
     }
 
     func setActiveTextProfile(id profileID: String) async throws -> TextProfileSnapshot {
         let profile = try await runtime.setActiveTextProfile(id: profileID)
-        await emitTextProfilesChanged()
+        try await emitTextProfilesChanged()
         await requestPublish(mode: .immediate, refreshRuntimeState: false)
         return .init(details: profile)
     }
 
     func removeTextProfile(id profileID: String) async throws -> TextProfilesSnapshot {
         try await runtime.removeTextProfile(id: profileID)
-        await emitTextProfilesChanged()
+        try await emitTextProfilesChanged()
         await requestPublish(mode: .immediate, refreshRuntimeState: false)
-        return await textProfilesSnapshot()
+        return try await textProfilesSnapshot()
     }
 
     func factoryResetTextProfiles() async throws -> TextProfilesSnapshot {
         try await runtime.factoryResetTextProfiles()
-        await emitTextProfilesChanged()
+        try await emitTextProfilesChanged()
         await requestPublish(mode: .immediate, refreshRuntimeState: false)
-        return await textProfilesSnapshot()
+        return try await textProfilesSnapshot()
     }
 
     func resetTextProfile(id profileID: String) async throws -> TextProfileSnapshot {
         let profile = try await runtime.resetTextProfile(id: profileID)
-        await emitTextProfilesChanged()
+        try await emitTextProfilesChanged()
         await requestPublish(mode: .immediate, refreshRuntimeState: false)
         return .init(details: profile)
     }
@@ -176,7 +182,7 @@ extension ServerHost {
         } else {
             try await runtime.addTextReplacement(replacement)
         }
-        await emitTextProfilesChanged()
+        try await emitTextProfilesChanged()
         await requestPublish(mode: .immediate, refreshRuntimeState: false)
         return .init(details: profile)
     }
@@ -190,7 +196,7 @@ extension ServerHost {
         } else {
             try await runtime.replaceTextReplacement(replacement)
         }
-        await emitTextProfilesChanged()
+        try await emitTextProfilesChanged()
         await requestPublish(mode: .immediate, refreshRuntimeState: false)
         return .init(details: profile)
     }
@@ -204,7 +210,7 @@ extension ServerHost {
         } else {
             try await runtime.removeTextReplacement(id: replacementID)
         }
-        await emitTextProfilesChanged()
+        try await emitTextProfilesChanged()
         await requestPublish(mode: .immediate, refreshRuntimeState: false)
         return .init(details: profile)
     }

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+State.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+State.swift
@@ -121,6 +121,14 @@ extension ServerHost {
         source: String,
     ) {
         if source == "cached_worker_not_ready" {
+            generationQueueStatus = .init(
+                queueType: "generation",
+                activeCount: 0,
+                queuedCount: 0,
+                activeRequest: nil,
+                activeRequests: [],
+                queuedRequests: [],
+            )
             playbackQueueStatus = .init(
                 queueType: "playback",
                 activeCount: 0,

--- a/Sources/SpeakSwiftlyServer/Host/ServerModels.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerModels.swift
@@ -57,6 +57,7 @@ struct SpeakRequestPayload: Decodable {
         case textFormat = "text_format"
         case nestedSourceFormat = "nested_source_format"
         case sourceFormat = "source_format"
+        case requestContext = "request_context"
     }
 
     let text: String
@@ -67,6 +68,7 @@ struct SpeakRequestPayload: Decodable {
     let textFormat: String?
     let nestedSourceFormat: String?
     let sourceFormat: String?
+    let requestContext: SpeakSwiftly.RequestContext?
 
     func normalizationContext() throws -> SpeechNormalizationContext? {
         try makeSpeechNormalizationContext(
@@ -144,6 +146,7 @@ struct BatchItemRequestPayload: Decodable {
         case textFormat = "text_format"
         case nestedSourceFormat = "nested_source_format"
         case sourceFormat = "source_format"
+        case requestContext = "request_context"
     }
 
     let artifactID: String?
@@ -154,6 +157,7 @@ struct BatchItemRequestPayload: Decodable {
     let textFormat: String?
     let nestedSourceFormat: String?
     let sourceFormat: String?
+    let requestContext: SpeakSwiftly.RequestContext?
 
     func model() throws -> SpeakSwiftly.BatchItem {
         try .init(
@@ -164,6 +168,7 @@ struct BatchItemRequestPayload: Decodable {
                 normalizationContext: normalizationContext(),
                 sourceFormat: sourceFormatModel(),
             ),
+            requestContext: requestContext,
         )
     }
 

--- a/Sources/SpeakSwiftlyServer/Host/ServerRuntimeAdapter.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerRuntimeAdapter.swift
@@ -70,6 +70,7 @@ actor ServerRuntimeAdapter: ServerRuntimeProtocol {
         textProfileID: String?,
         normalizationContext: SpeechNormalizationContext?,
         sourceFormat: TextForSpeech.SourceFormat?,
+        requestContext: SpeakSwiftly.RequestContext?,
     ) async -> RuntimeRequestHandle {
         let handle = await runtime.generate.speech(
             text: text,
@@ -79,6 +80,7 @@ actor ServerRuntimeAdapter: ServerRuntimeProtocol {
                 normalizationContext: normalizationContext,
                 sourceFormat: sourceFormat,
             ),
+            requestContext: requestContext,
         )
         return .init(id: handle.id, operation: "generate_speech", profileName: profileName, events: handle.events)
     }
@@ -89,6 +91,7 @@ actor ServerRuntimeAdapter: ServerRuntimeProtocol {
         textProfileID: String?,
         normalizationContext: SpeechNormalizationContext?,
         sourceFormat: TextForSpeech.SourceFormat?,
+        requestContext: SpeakSwiftly.RequestContext?,
     ) async -> RuntimeRequestHandle {
         let handle = await runtime.generate.audio(
             text: text,
@@ -98,6 +101,7 @@ actor ServerRuntimeAdapter: ServerRuntimeProtocol {
                 normalizationContext: normalizationContext,
                 sourceFormat: sourceFormat,
             ),
+            requestContext: requestContext,
         )
         return .init(id: handle.id, operation: "generate_audio_file", profileName: profileName, events: handle.events)
     }

--- a/Sources/SpeakSwiftlyServer/Host/ServerRuntimeAdapter.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerRuntimeAdapter.swift
@@ -2,6 +2,45 @@ import Foundation
 import SpeakSwiftly
 import TextForSpeech
 
+func resolvedAbsoluteFilesystemPath(
+    _ path: String?,
+    cwd: String?,
+    currentDirectoryPath: String = FileManager.default.currentDirectoryPath,
+) -> String? {
+    guard let path else {
+        return nil
+    }
+
+    let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmedPath.isEmpty == false else {
+        return nil
+    }
+
+    if trimmedPath.hasPrefix("/") {
+        return URL(fileURLWithPath: trimmedPath).standardizedFileURL.path
+    }
+
+    let trimmedCWD = cwd?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let resolvedBasePath: String
+    if let trimmedCWD, trimmedCWD.isEmpty == false {
+        if trimmedCWD.hasPrefix("/") {
+            resolvedBasePath = trimmedCWD
+        } else {
+            resolvedBasePath = URL(
+                fileURLWithPath: trimmedCWD,
+                relativeTo: URL(fileURLWithPath: currentDirectoryPath, isDirectory: true),
+            ).standardizedFileURL.path
+        }
+    } else {
+        resolvedBasePath = currentDirectoryPath
+    }
+
+    return URL(
+        fileURLWithPath: trimmedPath,
+        relativeTo: URL(fileURLWithPath: resolvedBasePath, isDirectory: true),
+    ).standardizedFileURL.path
+}
+
 actor ServerRuntimeAdapter: ServerRuntimeProtocol {
     private let runtime: SpeakSwiftly.Runtime
 
@@ -224,8 +263,8 @@ actor ServerRuntimeAdapter: ServerRuntimeProtocol {
         return await runtime.normalizer.style.getActive()
     }
 
-    func activeTextProfile() async -> SpeakSwiftly.TextProfileDetails {
-        await transportDetails(runtime.normalizer.profiles.getActive())
+    func activeTextProfile() async throws -> SpeakSwiftly.TextProfileDetails {
+        try await transportDetails(runtime.normalizer.profiles.getActive())
     }
 
     func baseTextProfile() async -> TextForSpeech.Profile {
@@ -233,28 +272,28 @@ actor ServerRuntimeAdapter: ServerRuntimeProtocol {
         return .builtInBase(style: style)
     }
 
-    func textProfile(id profileID: String) async -> SpeakSwiftly.TextProfileDetails? {
+    func textProfile(id profileID: String) async throws -> SpeakSwiftly.TextProfileDetails? {
         guard let details = try? await runtime.normalizer.profiles.get(id: profileID) else {
             return nil
         }
 
-        return transportDetails(details)
+        return try transportDetails(details)
     }
 
-    func textProfiles() async -> [SpeakSwiftly.TextProfileSummary] {
-        await runtime.normalizer
+    func textProfiles() async throws -> [SpeakSwiftly.TextProfileSummary] {
+        try await runtime.normalizer
             .profiles
             .list()
-            .map(transportSummary)
+            .map { try transportSummary($0) }
     }
 
-    func effectiveTextProfile(id profileID: String?) async -> SpeakSwiftly.TextProfileDetails {
+    func effectiveTextProfile(id profileID: String?) async throws -> SpeakSwiftly.TextProfileDetails {
         if let profileID,
            let details = try? await runtime.normalizer.profiles.get(id: profileID) {
-            return transportDetails(details)
+            return try transportDetails(details)
         }
 
-        return await transportDetails(runtime.normalizer.profiles.getEffective())
+        return try await transportDetails(runtime.normalizer.profiles.getEffective())
     }
 
     func loadTextProfiles() async throws {
@@ -275,7 +314,7 @@ actor ServerRuntimeAdapter: ServerRuntimeProtocol {
 
     func setActiveTextProfile(id profileID: String) async throws -> SpeakSwiftly.TextProfileDetails {
         try await runtime.normalizer.profiles.setActive(id: profileID)
-        return await transportDetails(runtime.normalizer.profiles.getActive())
+        return try await transportDetails(runtime.normalizer.profiles.getActive())
     }
 
     func removeTextProfile(id profileID: String) async throws {
@@ -331,36 +370,10 @@ actor ServerRuntimeAdapter: ServerRuntimeProtocol {
 
     // MARK: - Path Resolution
 
-    private func resolvedAbsoluteFilesystemPath(
-        _ path: String?,
-        cwd: String?,
-    ) -> String? {
-        guard let path else {
-            return nil
-        }
-
-        let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmedPath.isEmpty == false else {
-            return nil
-        }
-
-        if trimmedPath.hasPrefix("/") {
-            return URL(fileURLWithPath: trimmedPath).standardizedFileURL.path
-        }
-
-        let trimmedCWD = cwd?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolvedBasePath =
-            (trimmedCWD?.isEmpty == false ? trimmedCWD : nil)
-                ?? FileManager.default.currentDirectoryPath
-        return URL(fileURLWithPath: trimmedPath, relativeTo: URL(fileURLWithPath: resolvedBasePath, isDirectory: true))
-            .standardizedFileURL
-            .path
-    }
-
     private func transportSummary(
         _ summary: TextForSpeech.Runtime.Profiles.Summary,
-    ) -> SpeakSwiftly.TextProfileSummary {
-        decodeTransportValue(
+    ) throws -> SpeakSwiftly.TextProfileSummary {
+        try decodeTransportValue(
             SummaryBridge(
                 id: summary.id,
                 name: summary.name,
@@ -372,8 +385,8 @@ actor ServerRuntimeAdapter: ServerRuntimeProtocol {
 
     private func transportDetails(
         _ details: TextForSpeech.Runtime.Profiles.Details,
-    ) -> SpeakSwiftly.TextProfileDetails {
-        decodeTransportValue(
+    ) throws -> SpeakSwiftly.TextProfileDetails {
+        try decodeTransportValue(
             DetailsBridge(
                 profileID: details.profileID,
                 summary: SummaryBridge(
@@ -390,12 +403,15 @@ actor ServerRuntimeAdapter: ServerRuntimeProtocol {
     private func decodeTransportValue<Value: Decodable>(
         _ bridge: some Encodable,
         as type: Value.Type,
-    ) -> Value {
+    ) throws -> Value {
         do {
             let data = try JSONEncoder().encode(bridge)
             return try JSONDecoder().decode(Value.self, from: data)
         } catch {
-            preconditionFailure("SpeakSwiftlyServer could not bridge a released SpeakSwiftly text-profile transport value: \(error)")
+            throw SpeakSwiftly.Error(
+                code: .internalError,
+                message: "SpeakSwiftlyServer could not bridge a released SpeakSwiftly text-profile transport value into its stable server payload. Likely cause: \(error.localizedDescription)",
+            )
         }
     }
 }

--- a/Sources/SpeakSwiftlyServer/Host/ServerRuntimeProtocol.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerRuntimeProtocol.swift
@@ -77,6 +77,7 @@ protocol ServerRuntimeProtocol: Actor {
         textProfileID: String?,
         normalizationContext: SpeechNormalizationContext?,
         sourceFormat: TextForSpeech.SourceFormat?,
+        requestContext: SpeakSwiftly.RequestContext?,
     ) async -> RuntimeRequestHandle
     func queueSpeechFile(
         text: String,
@@ -84,6 +85,7 @@ protocol ServerRuntimeProtocol: Actor {
         textProfileID: String?,
         normalizationContext: SpeechNormalizationContext?,
         sourceFormat: TextForSpeech.SourceFormat?,
+        requestContext: SpeakSwiftly.RequestContext?,
     ) async -> RuntimeRequestHandle
     func queueSpeechBatch(
         _ items: [SpeakSwiftly.BatchItem],

--- a/Sources/SpeakSwiftlyServer/Host/ServerRuntimeProtocol.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerRuntimeProtocol.swift
@@ -127,11 +127,11 @@ protocol ServerRuntimeProtocol: Actor {
     func cancelRequest(_ requestID: String) async -> RuntimeRequestHandle
     func builtInTextProfileStyle() async -> TextForSpeech.BuiltInProfileStyle
     func setBuiltInTextProfileStyle(_ style: TextForSpeech.BuiltInProfileStyle) async throws -> TextForSpeech.BuiltInProfileStyle
-    func activeTextProfile() async -> SpeakSwiftly.TextProfileDetails
+    func activeTextProfile() async throws -> SpeakSwiftly.TextProfileDetails
     func baseTextProfile() async -> TextForSpeech.Profile
-    func textProfile(id profileID: String) async -> SpeakSwiftly.TextProfileDetails?
-    func textProfiles() async -> [SpeakSwiftly.TextProfileSummary]
-    func effectiveTextProfile(id profileID: String?) async -> SpeakSwiftly.TextProfileDetails
+    func textProfile(id profileID: String) async throws -> SpeakSwiftly.TextProfileDetails?
+    func textProfiles() async throws -> [SpeakSwiftly.TextProfileSummary]
+    func effectiveTextProfile(id profileID: String?) async throws -> SpeakSwiftly.TextProfileDetails
     func loadTextProfiles() async throws
     func saveTextProfiles() async throws
     func createTextProfile(named name: String) async throws -> SpeakSwiftly.TextProfileDetails

--- a/Sources/SpeakSwiftlyServer/Host/ServerState.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerState.swift
@@ -40,7 +40,7 @@ public final class EmbeddedServer {
                     "EmbeddedServer could not refresh voice profiles because no embedded host action performer is configured yet.",
                 )
             },
-            queueLiveSpeech: { _, _, _, _, _ in
+            queueLiveSpeech: { _, _, _, _, _, _ in
                 throw EmbeddedServerActionError.unavailable(
                     "EmbeddedServer could not queue the live speech request because no embedded host action performer is configured yet.",
                 )
@@ -99,6 +99,7 @@ public final class EmbeddedServer {
             String?,
             SpeechNormalizationContext?,
             TextForSpeech.SourceFormat?,
+            SpeakSwiftly.RequestContext?,
         ) async throws -> String
         let setDefaultVoiceProfileName: @Sendable (String) async throws -> String
         let clearDefaultVoiceProfileName: @Sendable () async throws -> String?
@@ -251,6 +252,7 @@ public final class EmbeddedServer {
         textProfileID: String? = nil,
         normalizationContext: SpeechNormalizationContext? = nil,
         sourceFormat: TextForSpeech.SourceFormat? = nil,
+        requestContext: SpeakSwiftly.RequestContext? = nil,
     ) async throws -> String {
         try await actions.queueLiveSpeech(
             text,
@@ -258,6 +260,7 @@ public final class EmbeddedServer {
             textProfileID,
             normalizationContext,
             sourceFormat,
+            requestContext,
         )
     }
 

--- a/Sources/SpeakSwiftlyServer/MCP/MCPResources.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPResources.swift
@@ -1,5 +1,20 @@
 import Foundation
 import MCP
+import SpeakSwiftly
+
+private func mapTextProfileResourceError(_ error: any Error) -> MCPError {
+    if let error = error as? MCPError {
+        return error
+    }
+
+    if let error = error as? SpeakSwiftly.Error {
+        return .internalError(error.message)
+    }
+
+    return .internalError(
+        "SpeakSwiftlyServer could not complete the text-profile MCP resource request. Likely cause: \(error.localizedDescription)",
+    )
+}
 
 enum MCPResourceCatalog {
     static let resourceURIs = Set([
@@ -105,7 +120,12 @@ extension MCPSurface {
                     )
 
                 case "speak://text-profiles":
-                    return try await resourceResult(uri: params.uri, payload: host.textProfilesSnapshot())
+                    do {
+                        let snapshot = try await host.textProfilesSnapshot()
+                        return try resourceResult(uri: params.uri, payload: snapshot)
+                    } catch {
+                        throw mapTextProfileResourceError(error)
+                    }
 
                 case "speak://text-profiles/style":
                     return try await resourceResult(uri: params.uri, payload: host.textProfileStyleSnapshot())
@@ -133,13 +153,28 @@ extension MCPSurface {
                     )
 
                 case "speak://text-profiles/base":
-                    return try await resourceResult(uri: params.uri, payload: (host.textProfilesSnapshot()).baseProfile)
+                    do {
+                        let snapshot = try await host.textProfilesSnapshot()
+                        return try resourceResult(uri: params.uri, payload: snapshot.baseProfile)
+                    } catch {
+                        throw mapTextProfileResourceError(error)
+                    }
 
                 case "speak://text-profiles/active":
-                    return try await resourceResult(uri: params.uri, payload: (host.textProfilesSnapshot()).activeProfile)
+                    do {
+                        let snapshot = try await host.textProfilesSnapshot()
+                        return try resourceResult(uri: params.uri, payload: snapshot.activeProfile)
+                    } catch {
+                        throw mapTextProfileResourceError(error)
+                    }
 
                 case "speak://text-profiles/effective":
-                    return try await resourceResult(uri: params.uri, payload: host.effectiveTextProfile(nil))
+                    do {
+                        let profile = try await host.effectiveTextProfile(nil)
+                        return try resourceResult(uri: params.uri, payload: profile)
+                    } catch {
+                        throw mapTextProfileResourceError(error)
+                    }
 
                 case "speak://requests":
                     return try await resourceResult(uri: params.uri, payload: host.jobSnapshots())
@@ -165,17 +200,26 @@ extension MCPSurface {
                     }
 
                     if let profileID = storedTextProfileID(from: params.uri) {
-                        guard let profile = await host.storedTextProfile(profileID) else {
-                            throw MCPError.invalidRequest(
-                                "No stored SpeakSwiftly text profile matched that profile id. Read speak://text-profiles first to inspect the current stored profile set.",
-                            )
-                        }
+                        do {
+                            guard let profile = try await host.storedTextProfile(profileID) else {
+                                throw MCPError.invalidRequest(
+                                    "No stored SpeakSwiftly text profile matched that profile id. Read speak://text-profiles first to inspect the current stored profile set.",
+                                )
+                            }
 
-                        return try resourceResult(uri: params.uri, payload: profile)
+                            return try resourceResult(uri: params.uri, payload: profile)
+                        } catch {
+                            throw mapTextProfileResourceError(error)
+                        }
                     }
 
                     if let profileID = effectiveTextProfileID(from: params.uri) {
-                        return try await resourceResult(uri: params.uri, payload: host.effectiveTextProfile(profileID))
+                        do {
+                            let profile = try await host.effectiveTextProfile(profileID)
+                            return try resourceResult(uri: params.uri, payload: profile)
+                        } catch {
+                            throw mapTextProfileResourceError(error)
+                        }
                     }
 
                     if let requestID = requestID(from: params.uri) {

--- a/Sources/SpeakSwiftlyServer/MCP/MCPToolCatalog.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPToolCatalog.swift
@@ -5,7 +5,7 @@ enum MCPToolCatalog {
     static let definitions: [Tool] = [
         Tool(
             name: "generate_speech",
-            description: "Queue live speech playback with a stored SpeakSwiftly voice profile. Use this when the user wants audible output now, and optionally provide profile_name to override the server's configured default voice profile plus text_profile_id and explicit normalization-format arguments when the input should not rely on automatic format detection.",
+            description: "Queue live speech playback with a stored SpeakSwiftly voice profile. Use this when the user wants audible output now, and optionally provide profile_name to override the server's configured default voice profile plus text_profile_id, request_context, and explicit normalization-format arguments when the input should not rely on automatic format detection.",
             inputSchema: [
                 "type": "object",
                 "required": ["text"],
@@ -13,6 +13,7 @@ enum MCPToolCatalog {
                     "text": ["type": "string"],
                     "profile_name": ["type": "string"],
                     "text_profile_id": ["type": "string"],
+                    "request_context": ["type": "object"],
                     "cwd": ["type": "string"],
                     "repo_root": ["type": "string"],
                     "text_format": ["type": "string"],
@@ -23,7 +24,7 @@ enum MCPToolCatalog {
         ),
         Tool(
             name: "generate_audio_file",
-            description: "Queue one retained generated-audio file instead of live playback. Use this when the user wants a saved artifact they can inspect or reuse later, and optionally provide profile_name to override the server's configured default voice profile.",
+            description: "Queue one retained generated-audio file instead of live playback. Use this when the user wants a saved artifact they can inspect or reuse later, and optionally provide profile_name to override the server's configured default voice profile plus request_context when the downstream artifact should retain caller metadata.",
             inputSchema: [
                 "type": "object",
                 "required": ["text"],
@@ -31,6 +32,7 @@ enum MCPToolCatalog {
                     "text": ["type": "string"],
                     "profile_name": ["type": "string"],
                     "text_profile_id": ["type": "string"],
+                    "request_context": ["type": "object"],
                     "cwd": ["type": "string"],
                     "repo_root": ["type": "string"],
                     "text_format": ["type": "string"],
@@ -41,7 +43,7 @@ enum MCPToolCatalog {
         ),
         Tool(
             name: "generate_batch",
-            description: "Queue a retained generated-audio batch from multiple items under one voice profile. Use this when the user wants several output files produced together, and optionally provide profile_name to override the server's configured default voice profile.",
+            description: "Queue a retained generated-audio batch from multiple items under one voice profile. Use this when the user wants several output files produced together, and optionally provide profile_name to override the server's configured default voice profile. Each item may carry its own request_context payload.",
             inputSchema: [
                 "type": "object",
                 "required": ["items"],

--- a/Sources/SpeakSwiftlyServer/MCP/MCPToolHandlers.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPToolHandlers.swift
@@ -80,6 +80,7 @@ extension MCPSurface {
                         textProfileID: optionalString("text_profile_id", in: arguments),
                         normalizationContext: normalizationContext(in: arguments),
                         sourceFormat: sourceFormat(in: arguments),
+                        requestContext: requestContext(in: arguments),
                     )
                     return try acceptedRequestToolResult(
                         requestID: requestID,
@@ -99,6 +100,7 @@ extension MCPSurface {
                         textProfileID: optionalString("text_profile_id", in: arguments),
                         normalizationContext: normalizationContext(in: arguments),
                         sourceFormat: sourceFormat(in: arguments),
+                        requestContext: requestContext(in: arguments),
                     )
                     return try acceptedRequestToolResult(
                         requestID: requestID,

--- a/Sources/SpeakSwiftlyServer/MCP/MCPToolHandlers.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPToolHandlers.swift
@@ -3,6 +3,20 @@ import MCP
 import SpeakSwiftly
 import TextForSpeech
 
+private func mapTextProfileToolError(_ error: any Error) -> MCPError {
+    if let error = error as? MCPError {
+        return error
+    }
+
+    if let error = error as? SpeakSwiftly.Error {
+        return .internalError(error.message)
+    }
+
+    return .internalError(
+        "SpeakSwiftlyServer could not complete the text-profile MCP tool request. Likely cause: \(error.localizedDescription)",
+    )
+}
+
 extension MCPSurface {
     static func registerToolHandlers(
         on server: Server,
@@ -176,94 +190,146 @@ extension MCPSurface {
                     return try await toolResult(host.unloadModels())
 
                 case "get_text_normalizer_snapshot":
-                    return try await toolResult(host.textProfilesSnapshot())
+                    do {
+                        return try await toolResult(host.textProfilesSnapshot())
+                    } catch {
+                        throw mapTextProfileToolError(error)
+                    }
 
                 case "get_text_profile_style":
                     return try await toolResult(host.textProfileStyleSnapshot())
 
                 case "set_text_profile_style":
-                    let result = try await host.setTextProfileStyle(
-                        requiredBuiltInTextProfileStyle("built_in_style", in: arguments),
-                    )
-                    await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                    return try toolResult(result)
+                    do {
+                        let result = try await host.setTextProfileStyle(
+                            requiredBuiltInTextProfileStyle("built_in_style", in: arguments),
+                        )
+                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
+                        return try toolResult(result)
+                    } catch {
+                        throw mapTextProfileToolError(error)
+                    }
 
                 case "create_text_profile":
-                    let result = try await host.createTextProfile(
-                        name: requiredString("name", in: arguments),
-                        replacements: decodeOptionalArgument("replacements", in: arguments, default: [TextReplacementSnapshot]())
-                            .map { try $0.model() },
-                    )
-                    await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                    return try toolResult(result)
+                    do {
+                        let result = try await host.createTextProfile(
+                            name: requiredString("name", in: arguments),
+                            replacements: decodeOptionalArgument("replacements", in: arguments, default: [TextReplacementSnapshot]())
+                                .map { try $0.model() },
+                        )
+                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
+                        return try toolResult(result)
+                    } catch {
+                        throw mapTextProfileToolError(error)
+                    }
 
                 case "load_text_profiles":
-                    let result = try await host.loadTextProfiles()
-                    await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                    return try toolResult(result)
+                    do {
+                        let result = try await host.loadTextProfiles()
+                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
+                        return try toolResult(result)
+                    } catch {
+                        throw mapTextProfileToolError(error)
+                    }
 
                 case "save_text_profiles":
-                    let result = try await host.saveTextProfiles()
-                    await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                    return try toolResult(result)
+                    do {
+                        let result = try await host.saveTextProfiles()
+                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
+                        return try toolResult(result)
+                    } catch {
+                        throw mapTextProfileToolError(error)
+                    }
 
                 case "rename_text_profile":
-                    let result = try await host.renameTextProfile(
-                        id: requiredString("profile_id", in: arguments),
-                        to: requiredString("name", in: arguments),
-                    )
-                    await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                    return try toolResult(result)
+                    do {
+                        let result = try await host.renameTextProfile(
+                            id: requiredString("profile_id", in: arguments),
+                            to: requiredString("name", in: arguments),
+                        )
+                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
+                        return try toolResult(result)
+                    } catch {
+                        throw mapTextProfileToolError(error)
+                    }
 
                 case "delete_text_profile":
-                    let result = try await host.removeTextProfile(id: requiredString("profile_id", in: arguments))
-                    await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                    return try toolResult(result)
+                    do {
+                        let result = try await host.removeTextProfile(id: requiredString("profile_id", in: arguments))
+                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
+                        return try toolResult(result)
+                    } catch {
+                        throw mapTextProfileToolError(error)
+                    }
 
                 case "set_active_text_profile":
-                    let result = try await host.setActiveTextProfile(
-                        id: requiredString("profile_id", in: arguments),
-                    )
-                    await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                    return try toolResult(result)
+                    do {
+                        let result = try await host.setActiveTextProfile(
+                            id: requiredString("profile_id", in: arguments),
+                        )
+                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
+                        return try toolResult(result)
+                    } catch {
+                        throw mapTextProfileToolError(error)
+                    }
 
                 case "factory_reset_text_profiles":
-                    let result = try await host.factoryResetTextProfiles()
-                    await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                    return try toolResult(result)
+                    do {
+                        let result = try await host.factoryResetTextProfiles()
+                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
+                        return try toolResult(result)
+                    } catch {
+                        throw mapTextProfileToolError(error)
+                    }
 
                 case "reset_text_profile":
-                    let result = try await host.resetTextProfile(
-                        id: requiredString("profile_id", in: arguments),
-                    )
-                    await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                    return try toolResult(result)
+                    do {
+                        let result = try await host.resetTextProfile(
+                            id: requiredString("profile_id", in: arguments),
+                        )
+                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
+                        return try toolResult(result)
+                    } catch {
+                        throw mapTextProfileToolError(error)
+                    }
 
                 case "add_text_replacement":
-                    let replacement: TextReplacementSnapshot = try decodeArgument("replacement", in: arguments)
-                    let result = try await host.addTextReplacement(
-                        replacement.model(),
-                        toStoredTextProfileID: optionalString("profile_id", in: arguments),
-                    )
-                    await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                    return try toolResult(result)
+                    do {
+                        let replacement: TextReplacementSnapshot = try decodeArgument("replacement", in: arguments)
+                        let result = try await host.addTextReplacement(
+                            replacement.model(),
+                            toStoredTextProfileID: optionalString("profile_id", in: arguments),
+                        )
+                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
+                        return try toolResult(result)
+                    } catch {
+                        throw mapTextProfileToolError(error)
+                    }
 
                 case "replace_text_replacement":
-                    let replacement: TextReplacementSnapshot = try decodeArgument("replacement", in: arguments)
-                    let result = try await host.replaceTextReplacement(
-                        replacement.model(),
-                        inStoredTextProfileID: optionalString("profile_id", in: arguments),
-                    )
-                    await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                    return try toolResult(result)
+                    do {
+                        let replacement: TextReplacementSnapshot = try decodeArgument("replacement", in: arguments)
+                        let result = try await host.replaceTextReplacement(
+                            replacement.model(),
+                            inStoredTextProfileID: optionalString("profile_id", in: arguments),
+                        )
+                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
+                        return try toolResult(result)
+                    } catch {
+                        throw mapTextProfileToolError(error)
+                    }
 
                 case "remove_text_replacement":
-                    let result = try await host.removeTextReplacement(
-                        id: requiredString("replacement_id", in: arguments),
-                        fromStoredTextProfileID: optionalString("profile_id", in: arguments),
-                    )
-                    await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                    return try toolResult(result)
+                    do {
+                        let result = try await host.removeTextReplacement(
+                            id: requiredString("replacement_id", in: arguments),
+                            fromStoredTextProfileID: optionalString("profile_id", in: arguments),
+                        )
+                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
+                        return try toolResult(result)
+                    } catch {
+                        throw mapTextProfileToolError(error)
+                    }
 
                 case "list_generation_queue":
                     return try await toolResult(host.generationQueueSnapshot())

--- a/Sources/SpeakSwiftlyServer/MCP/MCPToolHandlers.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPToolHandlers.swift
@@ -17,6 +17,42 @@ private func mapTextProfileToolError(_ error: any Error) -> MCPError {
     )
 }
 
+private func acceptedRequestToolResult(
+    requestID: String,
+    message: String,
+) throws -> CallTool.Result {
+    try toolResult(
+        acceptedRequestResult(
+            requestID: requestID,
+            message: message,
+        ),
+    )
+}
+
+private func mappedTextProfileToolResult<T: Encodable>(
+    _ operation: () async throws -> T,
+) async throws -> CallTool.Result {
+    do {
+        return try toolResult(try await operation())
+    } catch {
+        throw mapTextProfileToolError(error)
+    }
+}
+
+private func notifyingTextProfileToolResult<T: Encodable>(
+    on server: Server,
+    subscriptionBroker: MCPSubscriptionBroker,
+    _ operation: () async throws -> T,
+) async throws -> CallTool.Result {
+    do {
+        let result = try await operation()
+        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
+        return try toolResult(result)
+    } catch {
+        throw mapTextProfileToolError(error)
+    }
+}
+
 extension MCPSurface {
     static func registerToolHandlers(
         on server: Server,
@@ -45,11 +81,9 @@ extension MCPSurface {
                         normalizationContext: normalizationContext(in: arguments),
                         sourceFormat: sourceFormat(in: arguments),
                     )
-                    return try toolResult(
-                        acceptedRequestResult(
-                            requestID: requestID,
-                            message: "SpeakSwiftlyServer accepted the live speech request. Read the returned request resource for progress or read speak://runtime/overview to monitor generation, playback, and transport state.",
-                        ),
+                    return try acceptedRequestToolResult(
+                        requestID: requestID,
+                        message: "SpeakSwiftlyServer accepted the live speech request. Read the returned request resource for progress or read speak://runtime/overview to monitor generation, playback, and transport state.",
                     )
 
                 case "generate_audio_file":
@@ -66,11 +100,9 @@ extension MCPSurface {
                         normalizationContext: normalizationContext(in: arguments),
                         sourceFormat: sourceFormat(in: arguments),
                     )
-                    return try toolResult(
-                        acceptedRequestResult(
-                            requestID: requestID,
-                            message: "SpeakSwiftlyServer accepted the retained audio-file generation request. Read the returned request resource for progress, then inspect speak://generation/files or speak://generation/jobs.",
-                        ),
+                    return try acceptedRequestToolResult(
+                        requestID: requestID,
+                        message: "SpeakSwiftlyServer accepted the retained audio-file generation request. Read the returned request resource for progress, then inspect speak://generation/files or speak://generation/jobs.",
                     )
 
                 case "generate_batch":
@@ -85,11 +117,9 @@ extension MCPSurface {
                         items: items.map { try $0.model() },
                         profileName: profileName,
                     )
-                    return try toolResult(
-                        acceptedRequestResult(
-                            requestID: requestID,
-                            message: "SpeakSwiftlyServer accepted the retained audio-batch generation request. Read the returned request resource for progress, then inspect speak://generation/batches or speak://generation/jobs.",
-                        ),
+                    return try acceptedRequestToolResult(
+                        requestID: requestID,
+                        message: "SpeakSwiftlyServer accepted the retained audio-batch generation request. Read the returned request resource for progress, then inspect speak://generation/batches or speak://generation/jobs.",
                     )
 
                 case "create_voice_profile_from_description":
@@ -101,11 +131,9 @@ extension MCPSurface {
                         outputPath: optionalString("output_path", in: arguments),
                         cwd: optionalString("cwd", in: arguments),
                     )
-                    return try toolResult(
-                        acceptedRequestResult(
-                            requestID: requestID,
-                            message: "SpeakSwiftlyServer accepted the voice-profile creation request. Read the returned request resource for progress or read speak://voices to monitor the refreshed cache.",
-                        ),
+                    return try acceptedRequestToolResult(
+                        requestID: requestID,
+                        message: "SpeakSwiftlyServer accepted the voice-profile creation request. Read the returned request resource for progress or read speak://voices to monitor the refreshed cache.",
                     )
 
                 case "create_voice_profile_from_audio":
@@ -116,11 +144,9 @@ extension MCPSurface {
                         transcript: optionalString("transcript", in: arguments),
                         cwd: optionalString("cwd", in: arguments),
                     )
-                    return try toolResult(
-                        acceptedRequestResult(
-                            requestID: requestID,
-                            message: "SpeakSwiftlyServer accepted the voice-clone creation request. Read the returned request resource for progress or read speak://voices to monitor the refreshed cache.",
-                        ),
+                    return try acceptedRequestToolResult(
+                        requestID: requestID,
+                        message: "SpeakSwiftlyServer accepted the voice-clone creation request. Read the returned request resource for progress or read speak://voices to monitor the refreshed cache.",
                     )
 
                 case "list_voice_profiles":
@@ -131,33 +157,27 @@ extension MCPSurface {
                         profileName: requiredString("profile_name", in: arguments),
                         to: requiredString("new_profile_name", in: arguments),
                     )
-                    return try toolResult(
-                        acceptedRequestResult(
-                            requestID: requestID,
-                            message: "SpeakSwiftlyServer accepted the voice-profile rename request. Read the returned request resource for progress or read speak://voices to monitor the refreshed cache.",
-                        ),
+                    return try acceptedRequestToolResult(
+                        requestID: requestID,
+                        message: "SpeakSwiftlyServer accepted the voice-profile rename request. Read the returned request resource for progress or read speak://voices to monitor the refreshed cache.",
                     )
 
                 case "reroll_voice_profile":
                     let requestID = try await host.submitRerollVoiceProfile(
                         profileName: requiredString("profile_name", in: arguments),
                     )
-                    return try toolResult(
-                        acceptedRequestResult(
-                            requestID: requestID,
-                            message: "SpeakSwiftlyServer accepted the voice-profile reroll request. Read the returned request resource for progress or read speak://voices to monitor the refreshed cache.",
-                        ),
+                    return try acceptedRequestToolResult(
+                        requestID: requestID,
+                        message: "SpeakSwiftlyServer accepted the voice-profile reroll request. Read the returned request resource for progress or read speak://voices to monitor the refreshed cache.",
                     )
 
                 case "delete_voice_profile":
                     let requestID = try await host.submitDeleteVoiceProfile(
                         profileName: requiredString("profile_name", in: arguments),
                     )
-                    return try toolResult(
-                        acceptedRequestResult(
-                            requestID: requestID,
-                            message: "SpeakSwiftlyServer accepted the voice-profile deletion request. Read the returned request resource for progress or read speak://voices to monitor the refreshed cache.",
-                        ),
+                    return try acceptedRequestToolResult(
+                        requestID: requestID,
+                        message: "SpeakSwiftlyServer accepted the voice-profile deletion request. Read the returned request resource for progress or read speak://voices to monitor the refreshed cache.",
                     )
 
                 case "get_runtime_overview":
@@ -190,145 +210,131 @@ extension MCPSurface {
                     return try await toolResult(host.unloadModels())
 
                 case "get_text_normalizer_snapshot":
-                    do {
-                        return try await toolResult(host.textProfilesSnapshot())
-                    } catch {
-                        throw mapTextProfileToolError(error)
+                    return try await mappedTextProfileToolResult {
+                        try await host.textProfilesSnapshot()
                     }
 
                 case "get_text_profile_style":
                     return try await toolResult(host.textProfileStyleSnapshot())
 
                 case "set_text_profile_style":
-                    do {
-                        let result = try await host.setTextProfileStyle(
+                    return try await notifyingTextProfileToolResult(
+                        on: server,
+                        subscriptionBroker: subscriptionBroker,
+                    ) {
+                        try await host.setTextProfileStyle(
                             requiredBuiltInTextProfileStyle("built_in_style", in: arguments),
                         )
-                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                        return try toolResult(result)
-                    } catch {
-                        throw mapTextProfileToolError(error)
                     }
 
                 case "create_text_profile":
-                    do {
-                        let result = try await host.createTextProfile(
+                    return try await notifyingTextProfileToolResult(
+                        on: server,
+                        subscriptionBroker: subscriptionBroker,
+                    ) {
+                        try await host.createTextProfile(
                             name: requiredString("name", in: arguments),
                             replacements: decodeOptionalArgument("replacements", in: arguments, default: [TextReplacementSnapshot]())
                                 .map { try $0.model() },
                         )
-                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                        return try toolResult(result)
-                    } catch {
-                        throw mapTextProfileToolError(error)
                     }
 
                 case "load_text_profiles":
-                    do {
-                        let result = try await host.loadTextProfiles()
-                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                        return try toolResult(result)
-                    } catch {
-                        throw mapTextProfileToolError(error)
+                    return try await notifyingTextProfileToolResult(
+                        on: server,
+                        subscriptionBroker: subscriptionBroker,
+                    ) {
+                        try await host.loadTextProfiles()
                     }
 
                 case "save_text_profiles":
-                    do {
-                        let result = try await host.saveTextProfiles()
-                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                        return try toolResult(result)
-                    } catch {
-                        throw mapTextProfileToolError(error)
+                    return try await notifyingTextProfileToolResult(
+                        on: server,
+                        subscriptionBroker: subscriptionBroker,
+                    ) {
+                        try await host.saveTextProfiles()
                     }
 
                 case "rename_text_profile":
-                    do {
-                        let result = try await host.renameTextProfile(
+                    return try await notifyingTextProfileToolResult(
+                        on: server,
+                        subscriptionBroker: subscriptionBroker,
+                    ) {
+                        try await host.renameTextProfile(
                             id: requiredString("profile_id", in: arguments),
                             to: requiredString("name", in: arguments),
                         )
-                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                        return try toolResult(result)
-                    } catch {
-                        throw mapTextProfileToolError(error)
                     }
 
                 case "delete_text_profile":
-                    do {
-                        let result = try await host.removeTextProfile(id: requiredString("profile_id", in: arguments))
-                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                        return try toolResult(result)
-                    } catch {
-                        throw mapTextProfileToolError(error)
+                    return try await notifyingTextProfileToolResult(
+                        on: server,
+                        subscriptionBroker: subscriptionBroker,
+                    ) {
+                        try await host.removeTextProfile(id: requiredString("profile_id", in: arguments))
                     }
 
                 case "set_active_text_profile":
-                    do {
-                        let result = try await host.setActiveTextProfile(
+                    return try await notifyingTextProfileToolResult(
+                        on: server,
+                        subscriptionBroker: subscriptionBroker,
+                    ) {
+                        try await host.setActiveTextProfile(
                             id: requiredString("profile_id", in: arguments),
                         )
-                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                        return try toolResult(result)
-                    } catch {
-                        throw mapTextProfileToolError(error)
                     }
 
                 case "factory_reset_text_profiles":
-                    do {
-                        let result = try await host.factoryResetTextProfiles()
-                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                        return try toolResult(result)
-                    } catch {
-                        throw mapTextProfileToolError(error)
+                    return try await notifyingTextProfileToolResult(
+                        on: server,
+                        subscriptionBroker: subscriptionBroker,
+                    ) {
+                        try await host.factoryResetTextProfiles()
                     }
 
                 case "reset_text_profile":
-                    do {
-                        let result = try await host.resetTextProfile(
+                    return try await notifyingTextProfileToolResult(
+                        on: server,
+                        subscriptionBroker: subscriptionBroker,
+                    ) {
+                        try await host.resetTextProfile(
                             id: requiredString("profile_id", in: arguments),
                         )
-                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                        return try toolResult(result)
-                    } catch {
-                        throw mapTextProfileToolError(error)
                     }
 
                 case "add_text_replacement":
-                    do {
+                    return try await notifyingTextProfileToolResult(
+                        on: server,
+                        subscriptionBroker: subscriptionBroker,
+                    ) {
                         let replacement: TextReplacementSnapshot = try decodeArgument("replacement", in: arguments)
-                        let result = try await host.addTextReplacement(
+                        return try await host.addTextReplacement(
                             replacement.model(),
                             toStoredTextProfileID: optionalString("profile_id", in: arguments),
                         )
-                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                        return try toolResult(result)
-                    } catch {
-                        throw mapTextProfileToolError(error)
                     }
 
                 case "replace_text_replacement":
-                    do {
+                    return try await notifyingTextProfileToolResult(
+                        on: server,
+                        subscriptionBroker: subscriptionBroker,
+                    ) {
                         let replacement: TextReplacementSnapshot = try decodeArgument("replacement", in: arguments)
-                        let result = try await host.replaceTextReplacement(
+                        return try await host.replaceTextReplacement(
                             replacement.model(),
                             inStoredTextProfileID: optionalString("profile_id", in: arguments),
                         )
-                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                        return try toolResult(result)
-                    } catch {
-                        throw mapTextProfileToolError(error)
                     }
 
                 case "remove_text_replacement":
-                    do {
-                        let result = try await host.removeTextReplacement(
+                    return try await notifyingTextProfileToolResult(
+                        on: server,
+                        subscriptionBroker: subscriptionBroker,
+                    ) {
+                        try await host.removeTextReplacement(
                             id: requiredString("replacement_id", in: arguments),
                             fromStoredTextProfileID: optionalString("profile_id", in: arguments),
                         )
-                        await subscriptionBroker.notifyResourceChanges(for: .textProfiles, using: server)
-                        return try toolResult(result)
-                    } catch {
-                        throw mapTextProfileToolError(error)
                     }
 
                 case "list_generation_queue":

--- a/Sources/SpeakSwiftlyServer/MCP/MCPToolSupport.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPToolSupport.swift
@@ -108,6 +108,14 @@ func sourceFormat(in arguments: [String: Value]) throws -> TextForSpeech.SourceF
     try requestSourceFormat("source_format", in: arguments)
 }
 
+func requestContext(in arguments: [String: Value]) throws -> SpeakSwiftly.RequestContext? {
+    guard let value = arguments["request_context"] else {
+        return nil
+    }
+
+    return try decodeValue(value, fieldName: "request_context")
+}
+
 func requestTextFormat(in arguments: [String: Value]) throws -> TextForSpeech.TextFormat? {
     guard let rawValue = optionalString("text_format", in: arguments) else {
         return nil

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@
   Files: `Sources/SpeakSwiftlyServer/Host/ServerRuntimeAdapter.swift`
   Focus: text-profile transport shaping, crash-vs-error behavior, path resolution, and runtime API drift handling.
 
-- [ ] Slice 3: MCP tool dispatch and notification policy
+- [x] Slice 3: MCP tool dispatch and notification policy
   Files: `Sources/SpeakSwiftlyServer/MCP/MCPToolHandlers.swift`
   Focus: repeated argument parsing, accepted-request result shaping, resource-change notifications, and tool-handler drift.
 
@@ -38,3 +38,9 @@
 - [x] Translate MCP text-profile resource and tool bridge failures into explicit `MCPError.internalError(...)` payloads instead of relying on the default thrown-error path.
 - [x] Recheck runtime-adapter path-resolution behavior for edge cases like non-normalized relative `cwd` values and whitespace-padded `cwd` inputs, and cover it with direct helper tests.
 - [ ] Keep watching for future upstream transport-shape drift beyond the current text-profile bridge; if another released payload starts needing ad hoc JSON bridging, treat that as a new review slice rather than letting the adapter accumulate more silent translation seams.
+
+## Slice 3 Findings
+
+- [x] Collapse repeated accepted-request MCP tool result shaping behind one helper so speech-generation and voice-profile job tools keep a single request-resource response shape.
+- [x] Collapse repeated text-profile MCP mutation branches behind one helper that preserves explicit `MCPError` mapping and always emits the `textProfiles` resource-change notification after successful mutation work.
+- [x] Keep the text-profile snapshot read path on the same explicit error-mapping helper so read-only and mutation tool cases now fail through one predictable MCP error surface.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,40 @@
+# TODO
+
+## Thorough Review Slices
+
+- [~] Slice 1: Host state and job tracking
+  Files: `Sources/SpeakSwiftlyServer/Host/ServerHost+State.swift`, `Sources/SpeakSwiftlyServer/Host/ServerHost+JobTracking.swift`
+  Focus: runtime-derived state refresh policy, degraded-worker fallback behavior, profile-cache reconciliation, SSE replay, request retention and pruning.
+
+- [x] Slice 2: Runtime adapter transport bridging
+  Files: `Sources/SpeakSwiftlyServer/Host/ServerRuntimeAdapter.swift`
+  Focus: text-profile transport shaping, crash-vs-error behavior, path resolution, and runtime API drift handling.
+
+- [ ] Slice 3: MCP tool dispatch and notification policy
+  Files: `Sources/SpeakSwiftlyServer/MCP/MCPToolHandlers.swift`
+  Focus: repeated argument parsing, accepted-request result shaping, resource-change notifications, and tool-handler drift.
+
+- [ ] Slice 4: Embedded lifecycle and startup or shutdown ownership
+  Files: `Sources/SpeakSwiftlyServer/EmbeddedServerSession.swift`, `Sources/SpeakSwiftlyServer/EmbeddedLifecycleServices.swift`
+  Focus: readiness gates, sibling-service coordination, shutdown barriers, and transport-state transitions.
+
+- [ ] Slice 5: LaunchAgent operator flow
+  Files: `Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentRuntime.swift`
+  Focus: launchctl polling, uninstall timing, partial teardown states, and operator-facing diagnostics.
+
+- [ ] Slice 6: E2E MCP stream harness
+  Files: `Tests/SpeakSwiftlyServerE2ETests/E2EMCPEventStream.swift` and related E2E helpers
+  Focus: stream connection timing, polling sleeps, notification matching, and flake risk.
+
+## Slice 1 Findings
+
+- [x] Fix degraded-worker cached fallback so it clears `generationQueueStatus` alongside playback state, and add regression coverage for the degraded queue snapshot path.
+- [x] Refresh the cached voice-profile list after `reroll_voice_profile` completes, and add regression coverage that verifies profile-cache metadata is refreshed after reroll.
+- [ ] Review whether profile-mutation reconciliation should rely on profile-name set comparisons alone, especially when concurrent external profile edits can happen between retries.
+
+## Slice 2 Findings
+
+- [x] Replace the text-profile transport bridge `preconditionFailure` path with thrown runtime errors that surface through HTTP text-profile routes as operator-readable JSON failures.
+- [x] Translate MCP text-profile resource and tool bridge failures into explicit `MCPError.internalError(...)` payloads instead of relying on the default thrown-error path.
+- [x] Recheck runtime-adapter path-resolution behavior for edge cases like non-normalized relative `cwd` values and whitespace-padded `cwd` inputs, and cover it with direct helper tests.
+- [ ] Keep watching for future upstream transport-shape drift beyond the current text-profile bridge; if another released payload starts needing ad hoc JSON bridging, treat that as a new review slice rather than letting the adapter accumulate more silent translation seams.

--- a/Tests/SpeakSwiftlyServerTests/HTTPFailureTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/HTTPFailureTests.swift
@@ -47,6 +47,11 @@ extension ServerTests {
         let degradedHostState = await host.hostStateSnapshot()
         #expect(degradedHostState.playback.state == "idle")
         #expect(degradedHostState.playbackQueue.activeRequest == nil)
+        #expect(degradedHostState.generationQueue.activeRequest == nil)
+        #expect(degradedHostState.generationQueue.activeRequests.isEmpty)
+        #expect(degradedHostState.generationQueue.queuedRequests.isEmpty)
+        #expect(degradedHostState.generationQueue.activeCount == 0)
+        #expect(degradedHostState.generationQueue.queuedCount == 0)
         #expect(degradedHostState.runtimeRefresh?.source == "cached_worker_not_ready")
 
         let activeSnapshot = try await waitUntil(timeout: .seconds(1), pollInterval: .milliseconds(10)) {
@@ -117,6 +122,40 @@ extension ServerTests {
         let status = await host.statusSnapshot()
         #expect(status.profileCacheState == "stale")
         #expect(status.profileCacheWarning?.contains("could not confirm the refreshed profile list") == true)
+
+        await host.shutdown()
+    }
+
+    @available(macOS 14, *)
+    @Test func `text profile routes surface bridge failures as typed server errors`() async throws {
+        let runtime = MockRuntime(
+            textProfileTransportError: SpeakSwiftly.Error(
+                code: .internalError,
+                message: "Configured text-profile bridge failure for tests.",
+            ),
+        )
+        let state = await MainActor.run { EmbeddedServer() }
+        let host = ServerHost(
+            configuration: testConfiguration(),
+            runtime: runtime,
+            runtimeConfigurationStore: testRuntimeConfigurationStore(),
+            state: state,
+        )
+
+        await host.start()
+        await runtime.publishStatus(.residentModelReady)
+        try await waitUntilReady(host)
+
+        let app = assembleHBApp(configuration: testHTTPConfig(testConfiguration()), host: host)
+        try await app.test(.router) { client in
+            let response = try await client.execute(uri: "/text-profiles", method: .get)
+            let responseJSON = try jsonObject(from: response.body)
+            let error = try #require(responseJSON["error"] as? [String: Any])
+            let message = try #require(error["message"] as? String)
+
+            #expect(response.status == .internalServerError)
+            #expect(message.contains("Configured text-profile bridge failure for tests"))
+        }
 
         await host.shutdown()
     }

--- a/Tests/SpeakSwiftlyServerTests/HTTPWorkflowTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/HTTPWorkflowTests.swift
@@ -244,7 +244,7 @@ extension ServerTests {
                 uri: "/speech/live",
                 method: .post,
                 headers: [.contentType: "application/json"],
-                body: byteBuffer(#"{"text":"Route test","text_profile_id":"swift-docs","cwd":"./Sources","repo_root":"../SpeakSwiftlyServer","text_format":"markdown","nested_source_format":"swift_source","source_format":"python_source"}"#),
+                body: byteBuffer(#"{"text":"Route test","text_profile_id":"swift-docs","request_context":{"source":"http","app":"SpeakSwiftlyServerTests","project":"SpeakSwiftlyServer","topic":"route-coverage","attributes":{"surface":"http"}},"cwd":"./Sources","repo_root":"../SpeakSwiftlyServer","text_format":"markdown","nested_source_format":"swift_source","source_format":"python_source"}"#),
             )
             let speakJSON = try jsonObject(from: speakResponse.body)
             let speakJobID = try #require(speakJSON["request_id"] as? String)
@@ -264,6 +264,16 @@ extension ServerTests {
             )
             #expect(queuedSpeechInvocation.textProfileID == "swift-docs")
             #expect(queuedSpeechInvocation.sourceFormat == .python)
+            #expect(
+                queuedSpeechInvocation.requestContext
+                    == SpeakSwiftly.RequestContext(
+                        source: "http",
+                        app: "SpeakSwiftlyServerTests",
+                        project: "SpeakSwiftlyServer",
+                        topic: "route-coverage",
+                        attributes: ["surface": "http"],
+                    ),
+            )
             #expect(queuedSpeechInvocation.profileName == "default")
 
             _ = try await waitForJobSnapshot(speakJobID, on: host)

--- a/Tests/SpeakSwiftlyServerTests/HostStateTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/HostStateTests.swift
@@ -321,7 +321,7 @@ import Testing
                 refreshVoiceProfiles: {
                     try await host.refreshVoiceProfiles()
                 },
-                queueLiveSpeech: { text, profileName, textProfileID, normalizationContext, sourceFormat in
+                queueLiveSpeech: { text, profileName, textProfileID, normalizationContext, sourceFormat, requestContext in
                     guard let resolvedProfileName = await host.resolvedRequestedVoiceProfileName(profileName) else {
                         let errorMessage = await host.missingVoiceProfileNameMessage(for: "the live speech request")
                         throw ServerConfigurationError(errorMessage)
@@ -333,6 +333,7 @@ import Testing
                         textProfileID: textProfileID,
                         normalizationContext: normalizationContext,
                         sourceFormat: sourceFormat,
+                        requestContext: requestContext,
                     )
                 },
                 setDefaultVoiceProfileName: { profileName in
@@ -411,6 +412,13 @@ import Testing
             nestedSourceFormat: .swift,
         ),
         sourceFormat: .python,
+        requestContext: .init(
+            source: "embedded-session",
+            app: "SpeakSwiftlyServerTests",
+            project: "SpeakSwiftlyServer",
+            topic: "state-actions",
+            attributes: ["surface": "embedded"],
+        ),
     )
     let firstQueuedSpeechInvocation = try #require(await runtime.latestQueuedSpeechInvocation())
     #expect(firstQueuedRequestID.isEmpty == false)
@@ -425,6 +433,16 @@ import Testing
     )
     #expect(firstQueuedSpeechInvocation.normalizationContext == expectedNormalizationContext)
     #expect(firstQueuedSpeechInvocation.sourceFormat == .python)
+    #expect(
+        firstQueuedSpeechInvocation.requestContext
+            == SpeakSwiftly.RequestContext(
+                source: "embedded-session",
+                app: "SpeakSwiftlyServerTests",
+                project: "SpeakSwiftlyServer",
+                topic: "state-actions",
+                attributes: ["surface": "embedded"],
+            ),
+    )
     await runtime.finishHeldSpeak(id: firstQueuedRequestID)
 
     let defaultVoiceProfileName = try await state.setDefaultVoiceProfileName("default")
@@ -603,7 +621,7 @@ import Testing
                 refreshVoiceProfiles: {
                     try await host.refreshVoiceProfiles()
                 },
-                queueLiveSpeech: { text, profileName, textProfileID, normalizationContext, sourceFormat in
+                queueLiveSpeech: { text, profileName, textProfileID, normalizationContext, sourceFormat, requestContext in
                     guard let resolvedProfileName = await host.resolvedRequestedVoiceProfileName(profileName) else {
                         let errorMessage = await host.missingVoiceProfileNameMessage(for: "the live speech request")
                         throw ServerConfigurationError(errorMessage)
@@ -615,6 +633,7 @@ import Testing
                         textProfileID: textProfileID,
                         normalizationContext: normalizationContext,
                         sourceFormat: sourceFormat,
+                        requestContext: requestContext,
                     )
                 },
                 setDefaultVoiceProfileName: { profileName in

--- a/Tests/SpeakSwiftlyServerTests/HostStateTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/HostStateTests.swift
@@ -499,6 +499,93 @@ import Testing
 }
 
 @available(macOS 14, *)
+@Test func `rerolling a voice profile refreshes cached profile metadata`() async throws {
+    let originalCreatedAt = Date(timeIntervalSince1970: 1_700_000_000)
+    let runtime = MockRuntime(
+        profiles: [
+            SpeakSwiftly.ProfileSummary(
+                profileName: "default",
+                vibe: .femme,
+                createdAt: originalCreatedAt,
+                voiceDescription: "Warm guide voice",
+                sourceText: "Original training text",
+                transcriptSource: nil,
+                transcriptResolvedAt: nil,
+                transcriptionModelRepo: nil,
+            ),
+        ],
+    )
+    let state = await MainActor.run { EmbeddedServer() }
+    let host = ServerHost(
+        configuration: testConfiguration(),
+        runtime: runtime,
+        runtimeConfigurationStore: testRuntimeConfigurationStore(),
+        state: state,
+    )
+
+    await host.start()
+    await runtime.publishStatus(.residentModelReady)
+    try await waitUntilReady(host)
+
+    let baselineRefreshCount = await runtime.voiceProfileRefreshCount()
+    let baselineStatus = await host.statusSnapshot()
+    let baselineProfile = try #require(baselineStatus.cachedProfiles.first(where: { $0.profileName == "default" }))
+    #expect(baselineProfile.createdAt == TimestampFormatter.string(from: originalCreatedAt))
+    #expect(baselineProfile.voiceDescription == "Warm guide voice")
+    #expect(baselineProfile.sourceText == "Original training text")
+
+    let rerollJobID = try await host.submitRerollProfile(profileName: "default")
+    let rerollSnapshot = try await waitForJobSnapshot(rerollJobID, on: host)
+    #expect(rerollSnapshot.status == "completed")
+
+    let refreshedStatus = await host.statusSnapshot()
+    let refreshedProfile = try #require(refreshedStatus.cachedProfiles.first(where: { $0.profileName == "default" }))
+    let refreshedCount = await runtime.voiceProfileRefreshCount()
+    #expect(refreshedCount == baselineRefreshCount + 1)
+    #expect(refreshedProfile.createdAt == TimestampFormatter.string(from: originalCreatedAt.addingTimeInterval(60)))
+    #expect(refreshedProfile.voiceDescription == "Warm guide voice (rerolled)")
+    #expect(refreshedProfile.sourceText == "Original training text (rerolled)")
+
+    await host.shutdown()
+}
+
+@Test func `runtime adapter path resolution normalizes relative and whitespace padded cwd values`() {
+    let currentDirectoryPath = "/tmp/speakswiftly-tests/workspace"
+
+    #expect(
+        resolvedAbsoluteFilesystemPath(
+            "./Artifacts/output.wav",
+            cwd: "  /tmp/speakswiftly-tests/project  ",
+            currentDirectoryPath: currentDirectoryPath,
+        ) == "/tmp/speakswiftly-tests/project/Artifacts/output.wav",
+    )
+
+    #expect(
+        resolvedAbsoluteFilesystemPath(
+            "../Fixtures/reference.wav",
+            cwd: "  ./Runs/Session  ",
+            currentDirectoryPath: currentDirectoryPath,
+        ) == "/tmp/speakswiftly-tests/workspace/Runs/Fixtures/reference.wav",
+    )
+
+    #expect(
+        resolvedAbsoluteFilesystemPath(
+            "/tmp/speakswiftly-tests/../speakswiftly-tests/final.wav",
+            cwd: "./ignored",
+            currentDirectoryPath: currentDirectoryPath,
+        ) == "/tmp/speakswiftly-tests/final.wav",
+    )
+
+    #expect(
+        resolvedAbsoluteFilesystemPath(
+            "   ",
+            cwd: "/tmp/speakswiftly-tests/project",
+            currentDirectoryPath: currentDirectoryPath,
+        ) == nil,
+    )
+}
+
+@available(macOS 14, *)
 @Test func `clearing app managed default voice profile falls back to configured default`() async throws {
     let runtime = MockRuntime()
     let configuration = testConfiguration(defaultVoiceProfileName: "configured-default")

--- a/Tests/SpeakSwiftlyServerTests/MCPCatalogResourceTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/MCPCatalogResourceTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MCP
+import SpeakSwiftly
 @testable import SpeakSwiftlyServer
 import Testing
 
@@ -275,5 +276,76 @@ extension ServerTests {
             let jobDetailPayload = try jsonObject(from: Data(jobDetailText.utf8))
             #expect(jobDetailPayload["request_id"] as? String == requestID)
         }
+    }
+
+    @available(macOS 14, *)
+    @Test func `embedded MCP text profile resources surface bridge failures as explicit jsonrpc errors`() async throws {
+        let runtime = MockRuntime(
+            speakBehavior: .holdOpen,
+            textProfileTransportError: SpeakSwiftly.Error(
+                code: .internalError,
+                message: "Configured MCP text-profile bridge failure for tests.",
+            ),
+        )
+        let configuration = testConfiguration()
+        let state = await MainActor.run { EmbeddedServer() }
+        let runtimeProfileRootURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("profiles", isDirectory: true)
+        let host = ServerHost(
+            configuration: configuration,
+            httpConfig: testHTTPConfig(configuration),
+            mcpConfig: .init(
+                enabled: true,
+                path: "/mcp",
+                serverName: "speak-swiftly-test-mcp",
+                title: "SpeakSwiftly Test MCP",
+            ),
+            runtime: runtime,
+            runtimeConfigurationStore: .init(
+                environment: ["SPEAKSWIFTLY_PROFILE_ROOT": runtimeProfileRootURL.path],
+                activeRuntimeSpeechBackend: .qwen3,
+            ),
+            state: state,
+        )
+
+        await host.start()
+        await runtime.publishStatus(.residentModelReady)
+        try await waitUntilReady(host)
+        let mcpSurface = try #require(
+            await MCPSurface.build(
+                configuration: .init(
+                    enabled: true,
+                    path: "/mcp",
+                    serverName: "speak-swiftly-test-mcp",
+                    title: "SpeakSwiftly Test MCP",
+                ),
+                host: host,
+            ),
+        )
+
+        try await mcpSurface.start()
+        let initializeResponse = await mcpSurface.handle(mcpPOSTRequest(body: mcpInitializeRequestJSON()))
+        let sessionID = try #require(mcpSessionID(from: initializeResponse))
+        try await drainMCPResponse(initializeResponse)
+        _ = await mcpSurface.handle(
+            mcpPOSTRequest(
+                body: mcpInitializedNotificationJSON(),
+                sessionID: sessionID,
+            ),
+        )
+
+        let envelope = try await mcpEnvelope(
+            from: mcpSurface.handle(
+                mcpPOSTRequest(
+                    body: mcpReadResourceRequestJSON(uri: "speak://text-profiles"),
+                    sessionID: sessionID,
+                ),
+            ),
+        )
+        let error = try #require(envelope["error"] as? [String: Any])
+        let message = try #require(error["message"] as? String)
+        #expect((error["code"] as? Int) == -32603)
+        #expect(message.contains("Configured MCP text-profile bridge failure for tests."))
     }
 }

--- a/Tests/SpeakSwiftlyServerTests/MCPCatalogRuntimeTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/MCPCatalogRuntimeTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MCP
+import SpeakSwiftly
 @testable import SpeakSwiftlyServer
 import Testing
 
@@ -14,16 +15,7 @@ extension ServerTests {
                     mcpPOSTRequest(
                         body: mcpCallToolRequestJSON(
                             name: "generate_speech",
-                            arguments: [
-                                "text": "Inspect MCP resources",
-                                "profile_name": "default",
-                                "text_profile_id": "mcp-text",
-                                "cwd": "./Tests",
-                                "repo_root": "../SpeakSwiftlyServer",
-                                "text_format": "cli_output",
-                                "nested_source_format": "rust_source",
-                                "source_format": "source_code",
-                            ],
+                            argumentsJSON: #"{"text":"Inspect MCP resources","profile_name":"default","text_profile_id":"mcp-text","request_context":{"source":"mcp","app":"SpeakSwiftlyServerTests","project":"SpeakSwiftlyServer","topic":"catalog-runtime","attributes":{"surface":"mcp"}},"cwd":"./Tests","repo_root":"../SpeakSwiftlyServer","text_format":"cli_output","nested_source_format":"rust_source","source_format":"source_code"}"#,
                         ),
                         sessionID: sessionID,
                     ),
@@ -45,6 +37,16 @@ extension ServerTests {
             )
             #expect(queuedSpeechInvocation.textProfileID == "mcp-text")
             #expect(queuedSpeechInvocation.sourceFormat == .generic)
+            #expect(
+                queuedSpeechInvocation.requestContext
+                    == SpeakSwiftly.RequestContext(
+                        source: "mcp",
+                        app: "SpeakSwiftlyServerTests",
+                        project: "SpeakSwiftlyServer",
+                        topic: "catalog-runtime",
+                        attributes: ["surface": "mcp"],
+                    ),
+            )
 
             let createCloneToolEnvelope = try await mcpEnvelope(
                 from: mcpSurface.handle(

--- a/Tests/SpeakSwiftlyServerTests/MockRuntime+ProfilesAndArtifacts.swift
+++ b/Tests/SpeakSwiftlyServerTests/MockRuntime+ProfilesAndArtifacts.swift
@@ -128,6 +128,22 @@ extension MockRuntime {
     func rerollVoiceProfile(profileName: String) async -> RuntimeRequestHandle {
         let requestID = UUID().uuidString
         rerollProfileInvocations.append(.init(profileName: profileName))
+        if mutationRefreshBehavior == .applyMutations {
+            profiles = profiles.map { profile in
+                guard profile.profileName == profileName else { return profile }
+
+                return SpeakSwiftly.ProfileSummary(
+                    profileName: profile.profileName,
+                    vibe: profile.vibe,
+                    createdAt: profile.createdAt.addingTimeInterval(60),
+                    voiceDescription: "\(profile.voiceDescription) (rerolled)",
+                    sourceText: "\(profile.sourceText) (rerolled)",
+                    transcriptSource: profile.transcriptSource,
+                    transcriptResolvedAt: profile.transcriptResolvedAt,
+                    transcriptionModelRepo: profile.transcriptionModelRepo,
+                )
+            }
+        }
         let events = AsyncThrowingStream<SpeakSwiftly.RequestEvent, Error> { continuation in
             continuation.yield(.completed(SpeakSwiftly.Success(id: requestID, profileName: profileName, activeRequests: nil)))
             continuation.finish()

--- a/Tests/SpeakSwiftlyServerTests/MockRuntime+SpeechGeneration.swift
+++ b/Tests/SpeakSwiftlyServerTests/MockRuntime+SpeechGeneration.swift
@@ -13,6 +13,7 @@ extension MockRuntime {
         textProfileID: String?,
         normalizationContext: SpeechNormalizationContext?,
         sourceFormat: TextForSpeech.SourceFormat?,
+        requestContext: SpeakSwiftly.RequestContext?,
     ) async -> RuntimeRequestHandle {
         let requestID = UUID().uuidString
         let request = MockRequest(id: requestID, operation: "generate_speech", profileName: profileName)
@@ -23,6 +24,7 @@ extension MockRuntime {
                 textProfileID: textProfileID,
                 normalizationContext: normalizationContext,
                 sourceFormat: sourceFormat,
+                requestContext: requestContext,
             ),
         )
         var requestContinuation: AsyncThrowingStream<SpeakSwiftly.RequestEvent, Error>.Continuation?
@@ -59,6 +61,7 @@ extension MockRuntime {
         textProfileID: String?,
         normalizationContext: SpeechNormalizationContext?,
         sourceFormat: TextForSpeech.SourceFormat?,
+        requestContext: SpeakSwiftly.RequestContext?,
     ) async -> RuntimeRequestHandle {
         let requestID = UUID().uuidString
         let artifactID = "\(requestID)-artifact-1"
@@ -73,6 +76,7 @@ extension MockRuntime {
                     normalizationContext: normalizationContext,
                     sourceFormat: sourceFormat,
                 ),
+                requestContext: requestContext,
                 sampleRate: 24000,
                 filePath: "/tmp/\(artifactID).wav",
             )
@@ -87,7 +91,7 @@ extension MockRuntime {
                     normalizationContext: normalizationContext,
                     sourceFormat: sourceFormat,
                 ),
-                requestContext: nil,
+                requestContext: requestContext,
             ),
         ]
         let artifacts = [
@@ -103,7 +107,7 @@ extension MockRuntime {
                     normalizationContext: normalizationContext,
                     sourceFormat: sourceFormat,
                 ),
-                requestContext: nil,
+                requestContext: requestContext,
             ),
         ]
         generationJobs.append(

--- a/Tests/SpeakSwiftlyServerTests/MockRuntime+TextProfiles.swift
+++ b/Tests/SpeakSwiftlyServerTests/MockRuntime+TextProfiles.swift
@@ -6,6 +6,12 @@ import TextForSpeech
 
 @available(macOS 14, *)
 extension MockRuntime {
+    private func throwConfiguredTextProfileTransportErrorIfNeeded() throws {
+        if let textProfileTransportError {
+            throw textProfileTransportError
+        }
+    }
+
     func builtInTextProfileStyle() async -> TextForSpeech.BuiltInProfileStyle {
         textRuntime.style.getActive()
     }
@@ -17,15 +23,17 @@ extension MockRuntime {
         return textRuntime.style.getActive()
     }
 
-    func activeTextProfile() async -> SpeakSwiftly.TextProfileDetails {
-        transportDetails(textRuntime.profiles.getActive())
+    func activeTextProfile() async throws -> SpeakSwiftly.TextProfileDetails {
+        try throwConfiguredTextProfileTransportErrorIfNeeded()
+        return transportDetails(textRuntime.profiles.getActive())
     }
 
     func baseTextProfile() async -> TextForSpeech.Profile {
         .builtInBase(style: textRuntime.style.getActive())
     }
 
-    func textProfile(id profileID: String) async -> SpeakSwiftly.TextProfileDetails? {
+    func textProfile(id profileID: String) async throws -> SpeakSwiftly.TextProfileDetails? {
+        try throwConfiguredTextProfileTransportErrorIfNeeded()
         guard let details = try? textRuntime.profiles.get(id: profileID) else {
             return nil
         }
@@ -33,11 +41,13 @@ extension MockRuntime {
         return transportDetails(details)
     }
 
-    func textProfiles() async -> [SpeakSwiftly.TextProfileSummary] {
-        textRuntime.profiles.list().map(transportSummary)
+    func textProfiles() async throws -> [SpeakSwiftly.TextProfileSummary] {
+        try throwConfiguredTextProfileTransportErrorIfNeeded()
+        return textRuntime.profiles.list().map(transportSummary)
     }
 
-    func effectiveTextProfile(id profileID: String?) async -> SpeakSwiftly.TextProfileDetails {
+    func effectiveTextProfile(id profileID: String?) async throws -> SpeakSwiftly.TextProfileDetails {
+        try throwConfiguredTextProfileTransportErrorIfNeeded()
         if let profileID,
            let details = try? textRuntime.profiles.get(id: profileID) {
             return transportDetails(details)

--- a/Tests/SpeakSwiftlyServerTests/MockRuntime.swift
+++ b/Tests/SpeakSwiftlyServerTests/MockRuntime.swift
@@ -19,6 +19,7 @@ actor MockRuntime: ServerRuntimeProtocol {
         let textProfileID: String?
         let normalizationContext: SpeechNormalizationContext?
         let sourceFormat: TextForSpeech.SourceFormat?
+        let requestContext: SpeakSwiftly.RequestContext?
     }
 
     struct CreateCloneInvocation: Equatable {

--- a/Tests/SpeakSwiftlyServerTests/MockRuntime.swift
+++ b/Tests/SpeakSwiftlyServerTests/MockRuntime.swift
@@ -84,6 +84,7 @@ actor MockRuntime: ServerRuntimeProtocol {
     let textRuntimePersistenceURL: URL
     var loadTextProfilesCallCount = 0
     var saveTextProfilesCallCount = 0
+    var textProfileTransportError: SpeakSwiftly.Error?
     var generatedFiles = [SpeakSwiftly.GeneratedFile]()
     var generatedBatches = [SpeakSwiftly.GeneratedBatch]()
     var generationJobs = [SpeakSwiftly.GenerationJob]()
@@ -102,11 +103,13 @@ actor MockRuntime: ServerRuntimeProtocol {
         profiles: [SpeakSwiftly.ProfileSummary] = [sampleProfile()],
         speakBehavior: SpeakBehavior = .completeImmediately,
         mutationRefreshBehavior: MutationRefreshBehavior = .applyMutations,
+        textProfileTransportError: SpeakSwiftly.Error? = nil,
         startBehavior: StartBehavior = .immediate,
     ) {
         self.profiles = profiles
         self.speakBehavior = speakBehavior
         self.mutationRefreshBehavior = mutationRefreshBehavior
+        self.textProfileTransportError = textProfileTransportError
         self.startBehavior = startBehavior
         let persistenceURL = FileManager.default
             .temporaryDirectory

--- a/Tests/SpeakSwiftlyServerTests/SpeakSwiftlyServerMCPTestSupport.swift
+++ b/Tests/SpeakSwiftlyServerTests/SpeakSwiftlyServerMCPTestSupport.swift
@@ -59,6 +59,14 @@ func mcpCallToolRequestJSON(
     return #"{"jsonrpc":"2.0","id":"\#(id)","method":"tools/call","params":{"name":"\#(name)","arguments":{\#(sortedArguments)}}}"#
 }
 
+func mcpCallToolRequestJSON(
+    name: String,
+    argumentsJSON: String,
+    id: String = "tool-1",
+) -> String {
+    #"{"jsonrpc":"2.0","id":"\#(id)","method":"tools/call","params":{"name":"\#(name)","arguments":\#(argumentsJSON)}}"#
+}
+
 func mcpReadResourceRequestJSON(uri: String) -> String {
     #"{"jsonrpc":"2.0","id":"read-resource-1","method":"resources/read","params":{"uri":"\#(uri)"}}"#
 }

--- a/docs/maintainers/speakswiftly-api-coverage-matrix.md
+++ b/docs/maintainers/speakswiftly-api-coverage-matrix.md
@@ -48,7 +48,7 @@ That means the server is best understood as a transport adapter over the public 
 | `runtime.status()` | Full | `GET /runtime/status` | `get_runtime_status`, `speak://runtime/status` | Returned directly as runtime status data with transport-local shaping only. |
 | `runtime.switchSpeechBackend(to:)` | Full | `POST /runtime/backend` | `switch_speech_backend` | Hot-switches the active backend. Transport-facing input accepts `qwen3`, `chatterbox_turbo`, and `marvis`, and still normalizes legacy `qwen3_custom_voice` input onto `qwen3`. |
 | `runtime.reloadModels()` / `runtime.unloadModels()` | Full | `POST /runtime/models/reload`, `POST /runtime/models/unload` | `reload_models`, `unload_models` | Immediate runtime-control operations. |
-| `runtime.generate.speech(...)` | Full | `POST /speech/live` | `generate_speech` | Carries `text_profile_id`, `cwd`, `repo_root`, `text_format`, `nested_source_format`, and `source_format`. |
+| `runtime.generate.speech(...)` | Full | `POST /speech/live` | `generate_speech` | Carries `text_profile_id`, `request_context`, `cwd`, `repo_root`, `text_format`, `nested_source_format`, and `source_format`. |
 | `runtime.generate.audio(...)` | Full | `POST /speech/files` | `generate_audio_file` | Retains generated file artifacts for later reads. |
 | `runtime.generate.batch(_:with:)` | Full | `POST /speech/batches` | `generate_batch` | Uses the same retained-request and generated-batch shaping as the other submission lanes. |
 | `runtime.voices.create(design:from:vibe:voice:outputPath:)` | Full | `POST /voices/from-description` | `create_voice_profile_from_description` | Accepted-request flow with retained request inspection. |

--- a/docs/releases/v4.2.7-release-checklist.md
+++ b/docs/releases/v4.2.7-release-checklist.md
@@ -1,0 +1,51 @@
+# `v4.2.7` Release Checklist
+
+## Purpose
+
+This checklist is the maintainer-facing candidate path for `v4.2.7`.
+
+Use it when the release scope is the shared `RequestContext` adoption and the matching server forwarding pass so `request_context` survives the embedded, HTTP, and MCP submission paths instead of being accepted only by the underlying `SpeakSwiftly` runtime.
+
+For the standing branch-versus-main release contract, keep using [release-workflow.md](../maintainers/release-workflow.md). This document is only the candidate-specific checklist and release-shape note for `v4.2.7`.
+
+## Proposed Release Number
+
+Target the next release as `v4.2.7`.
+
+That patch bump matches the current change shape:
+
+- no intentional break to the published HTTP, MCP, or embedded-server contract
+- request-metadata compatibility cleanup rather than a new operator workflow
+- transport and runtime alignment so the already-supported shared request-context model now flows through the standalone server boundary
+
+## Pre-Tag Checklist
+
+- keep the worktree clean before release preparation or publish
+- confirm the package test lane passes:
+
+```bash
+swift test
+```
+
+- confirm the published-runtime transport smoke lane passes:
+
+```bash
+SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter ServerTransportE2ETests
+```
+
+## Suggested Release Notes Shape
+
+Center the release notes on three points:
+
+- `SpeakSwiftly.RequestContext` now staying shared with `TextForSpeech` instead of diverging
+- standalone server request submission now preserving `request_context` through embedded, HTTP, and MCP entry points
+- transport tests and maintainer docs now proving and documenting that request metadata survives the server boundary
+
+## Publish Reminder
+
+If this candidate moves forward, use the split release workflow rather than tagging directly from a feature branch:
+
+1. run `scripts/repo-maintenance/release-prepare.sh --version v4.2.7` from the feature branch or release candidate worktree
+2. let the PR merge back to `main`
+3. fast-forward local `main`
+4. run `scripts/repo-maintenance/release-publish.sh --version v4.2.7`

--- a/docs/releases/v4.2.7-release-notes.md
+++ b/docs/releases/v4.2.7-release-notes.md
@@ -1,0 +1,26 @@
+# v4.2.7 Release Notes
+
+## What changed
+
+- aligned the standalone server with the shared `SpeakSwiftly.RequestContext` model that now resolves to `TextForSpeech.RequestContext`
+- added end-to-end `request_context` forwarding across the embedded host, HTTP routes, MCP tool surface, and runtime adapter for live and retained speech requests
+- refreshed the server docs and transport tests so the accepted request metadata shape is documented and verified at the boundary where downstream consumers actually submit work
+
+## Breaking changes
+
+- none
+
+## Migration or upgrade notes
+
+- existing callers do not need to change their request payloads
+- downstream HTTP and MCP clients may now send `request_context` and expect that metadata to be retained through the shared `SpeakSwiftly` request surface instead of being dropped at the server boundary
+
+## Verification performed
+
+```bash
+swift test
+```
+
+```bash
+SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter ServerTransportE2ETests
+```


### PR DESCRIPTION
## Summary

- forward shared request-context metadata through the embedded, HTTP, and MCP speech submission paths
- keep the standalone server aligned with the shared `SpeakSwiftly.RequestContext` / `TextForSpeech.RequestContext` model
- add `v4.2.7` release notes and checklist docs

## Verification

- `swift test`
- `SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter ServerTransportE2ETests`
