### PR TITLE
build: format follow-up for v4.2.8

### DIFF
--- a/Sources/SpeakSwiftlyServer/Host/ServerRuntimeAdapter.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerRuntimeAdapter.swift
@@ -21,24 +21,27 @@ func resolvedAbsoluteFilesystemPath(
     }
 
     let trimmedCWD = cwd?.trimmingCharacters(in: .whitespacesAndNewlines)
-    let resolvedBasePath: String
-    if let trimmedCWD, trimmedCWD.isEmpty == false {
+    let resolvedBasePath: String = if let trimmedCWD, trimmedCWD.isEmpty == false {
         if trimmedCWD.hasPrefix("/") {
-            resolvedBasePath = trimmedCWD
+            trimmedCWD
         } else {
-            resolvedBasePath = URL(
+            URL(
                 fileURLWithPath: trimmedCWD,
                 relativeTo: URL(fileURLWithPath: currentDirectoryPath, isDirectory: true),
-            ).standardizedFileURL.path
+            )
+            .standardizedFileURL
+            .path
         }
     } else {
-        resolvedBasePath = currentDirectoryPath
+        currentDirectoryPath
     }
 
     return URL(
         fileURLWithPath: trimmedPath,
         relativeTo: URL(fileURLWithPath: resolvedBasePath, isDirectory: true),
-    ).standardizedFileURL.path
+    )
+    .standardizedFileURL
+    .path
 }
 
 actor ServerRuntimeAdapter: ServerRuntimeProtocol {

--- a/Sources/SpeakSwiftlyServer/MCP/MCPToolHandlers.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPToolHandlers.swift
@@ -29,20 +29,20 @@ private func acceptedRequestToolResult(
     )
 }
 
-private func mappedTextProfileToolResult<T: Encodable>(
-    _ operation: () async throws -> T,
+private func mappedTextProfileToolResult(
+    _ operation: () async throws -> some Encodable,
 ) async throws -> CallTool.Result {
     do {
-        return try toolResult(try await operation())
+        return try await toolResult(operation())
     } catch {
         throw mapTextProfileToolError(error)
     }
 }
 
-private func notifyingTextProfileToolResult<T: Encodable>(
+private func notifyingTextProfileToolResult(
     on server: Server,
     subscriptionBroker: MCPSubscriptionBroker,
-    _ operation: () async throws -> T,
+    _ operation: () async throws -> some Encodable,
 ) async throws -> CallTool.Result {
     do {
         let result = try await operation()

--- a/docs/releases/v4.2.8-release-checklist.md
+++ b/docs/releases/v4.2.8-release-checklist.md
@@ -1,0 +1,44 @@
+# `v4.2.8` Release Checklist
+
+## Purpose
+
+This checklist is the maintainer-facing candidate path for `v4.2.8`.
+
+Use it when the release scope is the formatter-only follow-up required to put the merged `request_context` forwarding work back onto a green validated commit after the first patch tag was cut too early.
+
+For the standing branch-versus-main release contract, keep using [release-workflow.md](../maintainers/release-workflow.md). This document is only the candidate-specific checklist and release-shape note for `v4.2.8`.
+
+## Proposed Release Number
+
+Target the next release as `v4.2.8`.
+
+That patch bump matches the current change shape:
+
+- no behavior change beyond source-formatting conformance
+- restores the release line to a green repo-maintenance validation state
+- keeps the published patch history honest instead of rewriting the already-published `v4.2.7` tag
+
+## Pre-Tag Checklist
+
+- keep the worktree clean before release preparation or publish
+- confirm the package test lane passes:
+
+```bash
+swift test
+```
+
+## Suggested Release Notes Shape
+
+Center the release notes on two points:
+
+- this is the formatter-only follow-up to the `request_context` forwarding release
+- the goal is a green validated release-line tag rather than a new feature surface
+
+## Publish Reminder
+
+If this candidate moves forward, use the split release workflow rather than tagging directly from a feature branch:
+
+1. run `scripts/repo-maintenance/release-prepare.sh --version v4.2.8` from the feature branch or release candidate worktree
+2. let the PR merge back to `main`
+3. fast-forward local `main`
+4. run `scripts/repo-maintenance/release-publish.sh --version v4.2.8`

--- a/docs/releases/v4.2.8-release-notes.md
+++ b/docs/releases/v4.2.8-release-notes.md
@@ -1,0 +1,21 @@
+# v4.2.8 Release Notes
+
+## What changed
+
+- applied the repo-required SwiftFormat cleanup for the shared request-context forwarding pass that shipped in `v4.2.7`
+- brings the merged `main` release line back onto a green validation commit without changing the request-context behavior introduced in the previous patch
+
+## Breaking changes
+
+- none
+
+## Migration or upgrade notes
+
+- no operator or client changes are required
+- downstream consumers should treat this as the green follow-up patch for the `request_context` forwarding work released in `v4.2.7`
+
+## Verification performed
+
+```bash
+swift test
+```


### PR DESCRIPTION
## Summary

- apply the repo-required SwiftFormat cleanup for the request-context forwarding release line
- add `v4.2.8` release notes and checklist docs so the corrected patch can be published from a green commit

## Verification

- `swift test`
