### PR TITLE
release: prepare v4.2.9

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,8 @@
 - Treat this standalone `SpeakSwiftlyServer` repository as the source of truth for development, tags, and releases.
 - Treat `main` as the release branch for this repository unless a future repo-local change says otherwise.
 - Use `scripts/repo-maintenance/release-prepare.sh` from feature branches and worktrees when the job is to validate a release candidate, push the branch, open or update the pull request, and queue auto-merge.
-- Use `scripts/repo-maintenance/release-publish.sh` only from local `main` after the release PR has merged when the job is to cut the annotated tag and GitHub release.
-- If local `main` is ahead of `origin/main`, do not try to publish from that unsynced checkout. Move that work onto a feature branch or keep it on the existing branch, run `release-prepare.sh`, merge the PR, fast-forward local `main`, and only then run `release-publish.sh`.
+- Use `scripts/repo-maintenance/release-publish.sh` only from local `main` after the release PR has merged when the job is to cut the annotated tag, push that tag, and create the GitHub release without pushing `main`.
+- If local `main` is ahead of `origin/main`, do not try to publish from that unsynced checkout. Move that work onto a feature branch or keep it on the existing branch, run `release-prepare.sh`, merge the PR, fast-forward local `main`, and only then run `release-publish.sh`. Protected-branch updates belong on the prepare side of the workflow, not inside publish.
 - Do not publish release tags or GitHub releases directly from a feature branch or feature worktree in this repository.
 - Treat the resolved `SpeakSwiftly` dependency declared in `Package.swift` and locked in `Package.resolved` as the source of truth for normal `xcrun swift build` and `xcrun swift test` runs here.
 - Do not retarget this package to a local `../SpeakSwiftly` checkout unless the manifest is being changed intentionally for a specific local-integration task.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "99936693df8774c3bb22a0e93149cbe4e3b4b4fe84bd6c7945307316d267a571",
+  "originHash" : "92d6f82e69cc0b96a449bdff5383cb06a31ac445a0811c59cc9c966f20035301",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/SpeakSwiftly.git",
       "state" : {
-        "revision" : "a870a2472c00240af62932f72a0a36b59a37987d",
-        "version" : "3.2.6"
+        "revision" : "d6cd554a15f4dbccc25579b46ffce1f832d7f119",
+        "version" : "4.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
         .package(
             url: "https://github.com/gaelic-ghost/SpeakSwiftly.git",
-            from: "3.2.6",
+            from: "4.0.1",
         ),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "2.30.6"),
         .package(url: "https://github.com/gaelic-ghost/TextForSpeech.git", from: "0.17.0"),

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ The short version is:
 - use `xcrun swift test` for the normal package-development loop
 - use `sh scripts/repo-maintenance/validate-all.sh` for the full maintainer and CI gate
 - use `scripts/repo-maintenance/release-prepare.sh` only for branch-side PR prep
-- use `scripts/repo-maintenance/release-publish.sh` as the single publish-time artifact and tag path
+- use `scripts/repo-maintenance/release-publish.sh` as the single publish-time artifact and tag path; it tags from fast-forwarded local `main` and pushes the tag, not the protected branch
 
 ## Repo Structure
 

--- a/Sources/SpeakSwiftlyServer/EmbeddedLifecycleServices.swift
+++ b/Sources/SpeakSwiftlyServer/EmbeddedLifecycleServices.swift
@@ -101,6 +101,20 @@ actor EmbeddedLifecycleShutdownBarrier {
     }
 }
 
+private func withEmbeddedShutdownBarrier<T>(
+    _ shutdownBarrier: EmbeddedLifecycleShutdownBarrier,
+    operation: () async throws -> T,
+) async throws -> T {
+    do {
+        let result = try await operation()
+        await shutdownBarrier.markCompleted()
+        return result
+    } catch {
+        await shutdownBarrier.markCompleted()
+        throw error
+    }
+}
+
 struct HostLifecycleService: Service {
     let host: ServerHost
     let readinessGate: EmbeddedLifecycleReadinessGate
@@ -126,23 +140,23 @@ struct HostPruneService: Service {
     let shutdownBarrier: EmbeddedLifecycleShutdownBarrier
 
     func run() async throws {
-        while !Task.isCancelled {
-            let interval = await host.jobPruneInterval()
-            var didReceiveTick = false
-            for await _ in AsyncTimerSequence(interval: interval, clock: .continuous)
-                .prefix(1)
-                .cancelOnGracefulShutdown() {
-                didReceiveTick = true
-            }
+        _ = try await withEmbeddedShutdownBarrier(shutdownBarrier) {
+            while !Task.isCancelled {
+                let interval = await host.jobPruneInterval()
+                var didReceiveTick = false
+                for await _ in AsyncTimerSequence(interval: interval, clock: .continuous)
+                    .prefix(1)
+                    .cancelOnGracefulShutdown() {
+                    didReceiveTick = true
+                }
 
-            guard didReceiveTick, !Task.isCancelled else {
-                break
-            }
+                guard didReceiveTick, !Task.isCancelled else {
+                    break
+                }
 
-            await host.runPruneMaintenanceTick()
+                await host.runPruneMaintenanceTick()
+            }
         }
-
-        await shutdownBarrier.markCompleted()
     }
 }
 
@@ -152,25 +166,23 @@ struct ConfigWatchService: Service {
     let shutdownBarrier: EmbeddedLifecycleShutdownBarrier
 
     func run() async throws {
-        do {
-            for try await update in configStore.updates().cancelOnGracefulShutdown() {
-                switch update {
-                    case let .reloaded(updatedConfig):
-                        await host.applyConfigurationUpdate(updatedConfig)
-                    case let .rejected(message):
-                        await host.markConfigurationReloadRejected(message)
+        _ = try await withEmbeddedShutdownBarrier(shutdownBarrier) {
+            do {
+                for try await update in configStore.updates().cancelOnGracefulShutdown() {
+                    switch update {
+                        case let .reloaded(updatedConfig):
+                            await host.applyConfigurationUpdate(updatedConfig)
+                        case let .rejected(message):
+                            await host.markConfigurationReloadRejected(message)
+                    }
                 }
+            } catch is CancellationError {
+                // Graceful shutdown or sibling failure cancelled the watch loop.
+            } catch {
+                await host.markConfigurationWatchFailed(error)
+                // Preserve the pre-service-lifecycle behavior: a config-watch failure should be
+                // reported clearly, but it should not tear down the embedded host.
             }
-            await shutdownBarrier.markCompleted()
-        } catch is CancellationError {
-            // Graceful shutdown or sibling failure cancelled the watch loop.
-            await shutdownBarrier.markCompleted()
-        } catch {
-            await host.markConfigurationWatchFailed(error)
-            // Preserve the pre-service-lifecycle behavior: a config-watch failure should be
-            // reported clearly, but it should not tear down the embedded host.
-            await shutdownBarrier.markCompleted()
-            return
         }
     }
 }
@@ -183,8 +195,17 @@ struct MCPLifecycleService: Service {
     func run() async throws {
         do {
             try await surface.start()
-            await readinessGate.markReady()
+        } catch {
+            await readinessGate.markFailed(
+                message: "SpeakSwiftly MCP could not finish starting inside the embedded session lifecycle. Likely cause: \(error.localizedDescription)",
+            )
+            await shutdownBarrier.markCompleted()
+            throw error
+        }
 
+        await readinessGate.markReady()
+
+        try await withEmbeddedShutdownBarrier(shutdownBarrier) {
             do {
                 try await gracefulShutdown()
             } catch is CancellationError {
@@ -192,13 +213,6 @@ struct MCPLifecycleService: Service {
             }
 
             await surface.stop()
-            await shutdownBarrier.markCompleted()
-        } catch {
-            await readinessGate.markFailed(
-                message: "SpeakSwiftly MCP could not finish starting inside the embedded session lifecycle. Likely cause: \(error.localizedDescription)",
-            )
-            await shutdownBarrier.markCompleted()
-            throw error
         }
     }
 }
@@ -208,12 +222,8 @@ struct EmbeddedApplicationService: Service {
     let shutdownBarrier: EmbeddedLifecycleShutdownBarrier
 
     func run() async throws {
-        do {
+        try await withEmbeddedShutdownBarrier(shutdownBarrier) {
             try await application.run()
-            await shutdownBarrier.markCompleted()
-        } catch {
-            await shutdownBarrier.markCompleted()
-            throw error
         }
     }
 }

--- a/Sources/SpeakSwiftlyServer/EmbeddedLifecycleServices.swift
+++ b/Sources/SpeakSwiftlyServer/EmbeddedLifecycleServices.swift
@@ -6,6 +6,14 @@ private struct EmbeddedLifecycleReadinessError: Error {
     let message: String
 }
 
+struct EmbeddedLifecycleStartupTimeoutError: Error, LocalizedError {
+    let message: String
+
+    var errorDescription: String? {
+        message
+    }
+}
+
 actor EmbeddedLifecycleReadinessGate {
     private enum State {
         case pending([CheckedContinuation<Void, Error>])
@@ -115,14 +123,51 @@ private func withEmbeddedShutdownBarrier<T>(
     }
 }
 
+private enum HostLifecycleStartupOutcome {
+    case started
+    case shutdownRequested
+    case timedOut
+}
+
+private func embeddedLifecycleDurationDescription(_ duration: Duration) -> String {
+    if duration.components.attoseconds == 0 {
+        return "\(duration.components.seconds) second(s)"
+    }
+
+    let fractionalSeconds = Double(duration.components.seconds)
+        + Double(duration.components.attoseconds) / 1_000_000_000_000_000_000
+    return String(format: "%.2f second(s)", fractionalSeconds)
+}
+
 struct HostLifecycleService: Service {
+    static let defaultStartupTimeout: Duration = .seconds(15)
+
     let host: ServerHost
     let readinessGate: EmbeddedLifecycleReadinessGate
     let shutdownBarrier: EmbeddedLifecycleShutdownBarrier
+    let startupTimeout: Duration
 
     func run() async throws {
-        await host.start()
-        await readinessGate.markReady()
+        let startupTask = Task {
+            await host.start()
+        }
+
+        switch await waitForStartupOutcome(startupTask: startupTask) {
+            case .started:
+                await readinessGate.markReady()
+            case .shutdownRequested:
+                startupTask.cancel()
+                await host.shutdown()
+                return
+            case .timedOut:
+                startupTask.cancel()
+                let message =
+                    "SpeakSwiftlyServer timed out while waiting for the embedded runtime to finish startup after \(embeddedLifecycleDurationDescription(startupTimeout)). Likely cause: the underlying SpeakSwiftly runtime start path stopped responding before it reported readiness."
+                await readinessGate.markFailed(message: message)
+                await host.markEmbeddedStartupFailure(message)
+                await host.shutdown()
+                throw EmbeddedLifecycleStartupTimeoutError(message: message)
+        }
 
         do {
             try await gracefulShutdown()
@@ -132,6 +177,50 @@ struct HostLifecycleService: Service {
 
         await shutdownBarrier.waitUntilCompleted()
         await host.shutdown()
+    }
+
+    private func waitForStartupOutcome(startupTask: Task<Void, Never>) async -> HostLifecycleStartupOutcome {
+        let (events, continuation) = AsyncStream.makeStream(
+            of: HostLifecycleStartupOutcome.self,
+            bufferingPolicy: .bufferingNewest(1),
+        )
+
+        let startupWatcher = Task {
+            await startupTask.value
+            continuation.yield(.started)
+            continuation.finish()
+        }
+
+        let shutdownWatcher = Task {
+            do {
+                try await gracefulShutdown()
+                continuation.yield(.shutdownRequested)
+                continuation.finish()
+            } catch is CancellationError {
+                continuation.finish()
+            } catch {
+                continuation.yield(.shutdownRequested)
+                continuation.finish()
+            }
+        }
+
+        let timeoutWatcher = Task {
+            do {
+                try await Task.sleep(for: startupTimeout)
+                continuation.yield(.timedOut)
+                continuation.finish()
+            } catch is CancellationError {
+                continuation.finish()
+            } catch {
+                continuation.finish()
+            }
+        }
+
+        let outcome = await events.first(where: { _ in true }) ?? .started
+        startupWatcher.cancel()
+        shutdownWatcher.cancel()
+        timeoutWatcher.cancel()
+        return outcome
     }
 }
 

--- a/Sources/SpeakSwiftlyServer/EmbeddedServerSession.swift
+++ b/Sources/SpeakSwiftlyServer/EmbeddedServerSession.swift
@@ -159,6 +159,7 @@ func embeddedServerLiveBootstrap(
                 host: host,
                 readinessGate: hostReadinessGate,
                 shutdownBarrier: shutdownBarrier,
+                startupTimeout: HostLifecycleService.defaultStartupTimeout,
             ),
         ),
     )

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+JobSubmission.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+JobSubmission.swift
@@ -66,7 +66,7 @@ extension ServerHost {
             outputPath: outputPath,
             cwd: cwd,
         )
-        return await enqueuePublicJob(handle)
+        return await enqueuePublicJob(handle, profileMutation: .create(profileName: profileName))
     }
 
     func createVoiceProfileFromAudio(
@@ -84,7 +84,7 @@ extension ServerHost {
             transcript: transcript,
             cwd: cwd,
         )
-        return await enqueuePublicJob(handle)
+        return await enqueuePublicJob(handle, profileMutation: .create(profileName: profileName))
     }
 
     func submitRenameVoiceProfile(
@@ -93,19 +93,19 @@ extension ServerHost {
     ) async throws -> String {
         try ensureWorkerReady()
         let handle = await runtime.renameVoiceProfile(profileName: profileName, to: newProfileName)
-        return await enqueuePublicJob(handle)
+        return await enqueuePublicJob(handle, profileMutation: .rename(from: profileName, to: newProfileName))
     }
 
     func submitRerollVoiceProfile(profileName: String) async throws -> String {
         try ensureWorkerReady()
         let handle = await runtime.rerollVoiceProfile(profileName: profileName)
-        return await enqueuePublicJob(handle)
+        return await enqueuePublicJob(handle, profileMutation: .reroll(profileName: profileName))
     }
 
     func submitDeleteVoiceProfile(profileName: String) async throws -> String {
         try ensureWorkerReady()
         let handle = await runtime.deleteVoiceProfile(profileName: profileName)
-        return await enqueuePublicJob(handle)
+        return await enqueuePublicJob(handle, profileMutation: .delete(profileName: profileName))
     }
 
     func ensureWorkerReady() throws {
@@ -117,11 +117,15 @@ extension ServerHost {
         }
     }
 
-    func enqueuePublicJob(_ handle: RuntimeRequestHandle) async -> String {
+    func enqueuePublicJob(
+        _ handle: RuntimeRequestHandle,
+        profileMutation: ProfileMutationExpectation? = nil,
+    ) async -> String {
         jobs[handle.id] = JobRecord(
             jobID: handle.id,
             op: handle.operation,
             profileName: handle.profileName,
+            profileMutation: profileMutation,
             submittedAt: Date(),
         )
 

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+JobTracking.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+JobTracking.swift
@@ -103,15 +103,11 @@ extension ServerHost {
                     case let .progress(progress):
                         await record(mapProgressEvent(progress), for: handle.id, terminal: false)
                     case let .completed(success):
-                        if handle.operation == "create_voice_profile_from_description"
-                            || handle.operation == "create_voice_profile_from_audio"
-                            || handle.operation == "update_voice_profile_name"
-                            || handle.operation == "reroll_voice_profile"
-                            || handle.operation == "delete_voice_profile" {
+                        if let mutationExpectation = jobs[handle.id]?.profileMutation {
                             await finalizeMutationSuccess(
                                 success: success,
                                 requestID: handle.id,
-                                operationName: handle.operation,
+                                expectation: mutationExpectation,
                             )
                         } else if handle.operation == "list_voice_profiles" {
                             await applyProfileRefresh(from: success)
@@ -137,12 +133,12 @@ extension ServerHost {
     func finalizeMutationSuccess(
         success: SpeakSwiftly.Success,
         requestID: String,
-        operationName: String,
+        expectation: ProfileMutationExpectation,
     ) async {
         do {
             let previousProfiles = profileCache
             let profiles = try await reconcileProfilesAfterMutation(
-                op: operationName,
+                expectation: expectation,
                 requestID: requestID,
                 success: success,
                 previousProfiles: previousProfiles,
@@ -176,7 +172,7 @@ extension ServerHost {
             await record(.completed(finalSuccess), for: requestID, terminal: true)
         } catch {
             profileCacheState = "stale"
-            profileCacheWarning = "SpeakSwiftly reported a successful profile mutation, but the server could not confirm the refreshed profile list afterward. The cached profile list may be stale. Likely cause: \(error.localizedDescription)"
+            profileCacheWarning = "SpeakSwiftly reported a successful \(expectation.operationName) mutation, but the server could not confirm the refreshed profile list afterward. The cached profile list may be stale. Likely cause: \(error.localizedDescription)"
             emitProfileCacheChanged()
             recordRecentError(
                 source: "profile_cache",
@@ -193,24 +189,29 @@ extension ServerHost {
     }
 
     func reconcileProfilesAfterMutation(
-        op: String,
+        expectation: ProfileMutationExpectation,
         requestID: String,
         success: SpeakSwiftly.Success,
         previousProfiles: [ProfileSnapshot],
     ) async throws -> [ProfileSnapshot] {
-        guard let profileName = success.profileName, !profileName.isEmpty else {
+        guard let reportedProfileName = success.profileName, !reportedProfileName.isEmpty else {
             throw SpeakSwiftly.Error(
                 code: .internalError,
-                message: "SpeakSwiftly returned a successful \(op) payload for request '\(requestID)', but it did not include a usable profile name for cache reconciliation.",
+                message: "SpeakSwiftly returned a successful \(expectation.operationName) payload for request '\(requestID)', but it did not include a usable profile name for cache reconciliation.",
+            )
+        }
+        guard reportedProfileName == expectation.expectedSuccessProfileName else {
+            throw SpeakSwiftly.Error(
+                code: .internalError,
+                message: "SpeakSwiftly returned a successful \(expectation.operationName) payload for request '\(requestID)', but it reported profile '\(reportedProfileName)' instead of the expected profile '\(expectation.expectedSuccessProfileName)'.",
             )
         }
 
         let retryDelays = Self.mutationRefreshRetryDelays
         for attempt in 0...retryDelays.count {
-            let refreshedProfiles = try await refreshProfiles(reason: "\(op):\(requestID):\(attempt)")
-            if profilesMatchExpectedMutation(
-                op: op,
-                profileName: profileName,
+            let refreshedProfiles = try await refreshProfiles(reason: "\(expectation.operationName):\(requestID):\(attempt)")
+            if refreshedProfilesMatchExpectedMutation(
+                expectation: expectation,
                 previousProfiles: previousProfiles,
                 refreshedProfiles: refreshedProfiles,
             ) {
@@ -224,7 +225,7 @@ extension ServerHost {
 
         throw SpeakSwiftly.Error(
             code: .internalError,
-            message: "SpeakSwiftly refreshed the profile cache after \(op) for profile '\(profileName)', but the list still did not reflect the expected mutation.",
+            message: "SpeakSwiftly refreshed the profile cache after \(expectation.operationName) for profile '\(expectation.expectedSuccessProfileName)', but the list still did not reflect the expected mutation.",
         )
     }
 
@@ -255,25 +256,40 @@ extension ServerHost {
         await requestPublish(mode: .immediate, refreshRuntimeState: false)
     }
 
-    func profilesMatchExpectedMutation(
-        op: String,
-        profileName: String,
+    func refreshedProfilesMatchExpectedMutation(
+        expectation: ProfileMutationExpectation,
         previousProfiles: [ProfileSnapshot],
         refreshedProfiles: [ProfileSnapshot],
     ) -> Bool {
-        let previousNames = Set(previousProfiles.map(\.profileName))
-        let refreshedNames = Set(refreshedProfiles.map(\.profileName))
+        switch expectation {
+            case let .create(profileName):
+                guard let refreshedProfile = refreshedProfiles.first(where: { $0.profileName == profileName }) else {
+                    return false
+                }
 
-        switch op {
-            case "create_voice_profile_from_description":
-                return refreshedNames.contains(profileName) && refreshedNames != previousNames
-            case "create_voice_profile_from_audio":
-                return refreshedNames.contains(profileName) && refreshedNames != previousNames
-            case "update_voice_profile_name":
-                return refreshedNames.contains(profileName)
-                    && !previousNames.contains(profileName)
-                    && refreshedNames.count == previousNames.count
-            case "reroll_voice_profile":
+                guard let previousProfile = previousProfiles.first(where: { $0.profileName == profileName }) else {
+                    return true
+                }
+
+                return refreshedProfile != previousProfile
+            case let .rename(previousProfileName, newProfileName):
+                guard refreshedProfiles.contains(where: { $0.profileName == previousProfileName }) == false else {
+                    return false
+                }
+                guard let refreshedProfile = refreshedProfiles.first(where: { $0.profileName == newProfileName }) else {
+                    return false
+                }
+
+                if previousProfiles.contains(where: { $0.profileName == previousProfileName }) {
+                    return true
+                }
+
+                guard let previousRenamedProfile = previousProfiles.first(where: { $0.profileName == newProfileName }) else {
+                    return true
+                }
+
+                return refreshedProfile != previousRenamedProfile
+            case let .reroll(profileName):
                 guard
                     let previousProfile = previousProfiles.first(where: { $0.profileName == profileName }),
                     let refreshedProfile = refreshedProfiles.first(where: { $0.profileName == profileName })
@@ -282,10 +298,8 @@ extension ServerHost {
                 }
 
                 return refreshedProfile != previousProfile
-            case "delete_voice_profile":
-                return !refreshedNames.contains(profileName) && refreshedNames != previousNames
-            default:
-                return false
+            case let .delete(profileName):
+                return refreshedProfiles.contains(where: { $0.profileName == profileName }) == false
         }
     }
 

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+JobTracking.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+JobTracking.swift
@@ -266,7 +266,6 @@ extension ServerHost {
                 guard let refreshedProfile = refreshedProfiles.first(where: { $0.profileName == profileName }) else {
                     return false
                 }
-
                 guard let previousProfile = previousProfiles.first(where: { $0.profileName == profileName }) else {
                     return true
                 }

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+Lifecycle.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+Lifecycle.swift
@@ -4,6 +4,18 @@ import Foundation
 extension ServerHost {
     // MARK: - Runtime Lifecycle
 
+    func markEmbeddedStartupFailure(_ message: String) async {
+        workerMode = "failed"
+        workerStage = "startup_failed"
+        startupError = message
+        recordRecentError(
+            source: "runtime:start",
+            code: "embedded_startup_failed",
+            message: message,
+        )
+        await requestPublish(mode: .immediate, refreshRuntimeState: false)
+    }
+
     func start() async {
         publishTask = Task {
             let immediateRequests = self.immediatePublishRequests

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost.swift
@@ -5,6 +5,37 @@ import SpeakSwiftly
 import TextForSpeech
 
 actor ServerHost {
+    enum ProfileMutationExpectation: Sendable, Equatable {
+        case create(profileName: String)
+        case rename(from: String, to: String)
+        case reroll(profileName: String)
+        case delete(profileName: String)
+
+        var operationName: String {
+            switch self {
+                case .create:
+                    "create_voice_profile"
+                case .rename:
+                    "update_voice_profile_name"
+                case .reroll:
+                    "reroll_voice_profile"
+                case .delete:
+                    "delete_voice_profile"
+            }
+        }
+
+        var expectedSuccessProfileName: String {
+            switch self {
+                case let .create(profileName),
+                    let .reroll(profileName),
+                    let .delete(profileName):
+                    profileName
+                case let .rename(_, newProfileName):
+                    newProfileName
+            }
+        }
+    }
+
     enum PublishMode {
         case immediate
         case coalesced
@@ -14,6 +45,7 @@ actor ServerHost {
         let jobID: String
         let op: String
         let profileName: String?
+        let profileMutation: ProfileMutationExpectation?
         let submittedAt: Date
         var startedAt: Date?
         var terminalAt: Date?

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost.swift
@@ -5,7 +5,7 @@ import SpeakSwiftly
 import TextForSpeech
 
 actor ServerHost {
-    enum ProfileMutationExpectation: Sendable, Equatable {
+    enum ProfileMutationExpectation: Equatable {
         case create(profileName: String)
         case rename(from: String, to: String)
         case reroll(profileName: String)
@@ -27,8 +27,8 @@ actor ServerHost {
         var expectedSuccessProfileName: String {
             switch self {
                 case let .create(profileName),
-                    let .reroll(profileName),
-                    let .delete(profileName):
+                     let .reroll(profileName),
+                     let .delete(profileName):
                     profileName
                 case let .rename(_, newProfileName):
                     newProfileName

--- a/Sources/SpeakSwiftlyServer/Host/ServerRuntimeAdapter.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerRuntimeAdapter.swift
@@ -21,24 +21,27 @@ func resolvedAbsoluteFilesystemPath(
     }
 
     let trimmedCWD = cwd?.trimmingCharacters(in: .whitespacesAndNewlines)
-    let resolvedBasePath: String
-    if let trimmedCWD, trimmedCWD.isEmpty == false {
+    let resolvedBasePath: String = if let trimmedCWD, trimmedCWD.isEmpty == false {
         if trimmedCWD.hasPrefix("/") {
-            resolvedBasePath = trimmedCWD
+            trimmedCWD
         } else {
-            resolvedBasePath = URL(
+            URL(
                 fileURLWithPath: trimmedCWD,
                 relativeTo: URL(fileURLWithPath: currentDirectoryPath, isDirectory: true),
-            ).standardizedFileURL.path
+            )
+            .standardizedFileURL
+            .path
         }
     } else {
-        resolvedBasePath = currentDirectoryPath
+        currentDirectoryPath
     }
 
     return URL(
         fileURLWithPath: trimmedPath,
         relativeTo: URL(fileURLWithPath: resolvedBasePath, isDirectory: true),
-    ).standardizedFileURL.path
+    )
+    .standardizedFileURL
+    .path
 }
 
 actor ServerRuntimeAdapter: ServerRuntimeProtocol {

--- a/Sources/SpeakSwiftlyServer/Host/ServerState.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerState.swift
@@ -229,6 +229,7 @@ public final class EmbeddedServer {
             await lifecycle.requestStop()
         }
         try await lifecycle.waitUntilStopped()
+        resetEmbeddedLifecycleState()
     }
 
     /// Returns the currently cached voice-profile summaries.
@@ -371,5 +372,11 @@ public final class EmbeddedServer {
         }
 
         try await lifecycle.waitUntilStopped()
+        resetEmbeddedLifecycleState()
+    }
+
+    private func resetEmbeddedLifecycleState() {
+        lifecycle = nil
+        stopCoordinator = EmbeddedServerStopCoordinator()
     }
 }

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentOptions+Installation.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentOptions+Installation.swift
@@ -64,8 +64,7 @@ extension LaunchAgentOptions {
             userDomain: userDomain,
         )
         if try status.isLoaded() {
-            try status.bootoutLoadedService()
-            try status.waitUntilNotLoaded()
+            try status.unloadLoadedService()
         }
 
         try bootstrapInstalledService()

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentRuntime.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentRuntime.swift
@@ -49,23 +49,28 @@ struct LaunchAgentStatusOptions {
 
     func statusSummary() throws -> String {
         let plistExists = FileManager.default.fileExists(atPath: plistPath)
-        let loaded = try isLoaded()
+        let loadState = try loadState()
         return """
         label: \(label)
         plist_path: \(plistPath)
         plist_exists: \(plistExists ? "yes" : "no")
-        loaded: \(loaded ? "yes" : "no")
+        loaded: \(loadState.isLoaded ? "yes" : "no")
         user_domain: \(userDomain)
+        load_state: \(loadState.summary)
         """
     }
 
     func isLoaded() throws -> Bool {
+        try loadState().isLoaded
+    }
+
+    func loadState() throws -> LaunchAgentLoadState {
         let result = try runLaunchctl(
             arguments: ["print", "\(userDomain)/\(label)"],
             allowNonZeroExit: true,
             launchctlPath: launchctlPath,
         )
-        return result.exitCode == 0
+        return try LaunchAgentLoadState(result: result)
     }
 
     func uninstall() throws {
@@ -123,6 +128,46 @@ struct LaunchAgentStatusOptions {
             Likely cause: launchd has not finished tearing the old job down yet.
             """,
         )
+    }
+}
+
+struct LaunchAgentLoadState {
+    let isLoaded: Bool
+    let summary: String
+
+    init(result: LaunchctlResult) throws {
+        if result.exitCode == 0 {
+            isLoaded = true
+            summary = "loaded"
+            return
+        }
+
+        if LaunchAgentLoadState.isKnownNotLoadedExit(result) {
+            isLoaded = false
+            summary = "not_loaded"
+            return
+        }
+
+        throw LaunchAgentCommandError(
+            """
+            \(speakSwiftlyServerToolName) asked launchctl to inspect the loaded state for the LaunchAgent job, but launchctl returned an unexpected failure instead of a normal loaded or not-loaded result.
+            Exit status: \(result.exitCode)
+            stdout: \(result.standardOutput)
+            stderr: \(result.standardError)
+            """,
+        )
+    }
+
+    private static func isKnownNotLoadedExit(_ result: LaunchctlResult) -> Bool {
+        if result.exitCode == 113 {
+            return true
+        }
+
+        let diagnostic = "\(result.standardOutput)\n\(result.standardError)".lowercased()
+        return diagnostic.contains("could not find service")
+            || diagnostic.contains("service not found")
+            || diagnostic.contains("unknown service")
+            || diagnostic.contains("not found")
     }
 }
 

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentRuntime.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentRuntime.swift
@@ -78,6 +78,8 @@ struct LaunchAgentStatusOptions {
             try unloadLoadedService()
         }
 
+        try removeStagedConfigAliasIfPresent()
+
         if FileManager.default.fileExists(atPath: plistPath) {
             do {
                 try FileManager.default.removeItem(atPath: plistPath)
@@ -89,6 +91,22 @@ struct LaunchAgentStatusOptions {
             print("Removed LaunchAgent plist '\(plistPath)' for label '\(label)'.")
         } else {
             print("LaunchAgent plist '\(plistPath)' was already absent for label '\(label)'.")
+        }
+    }
+
+    func removeStagedConfigAliasIfPresent() throws {
+        let layout = ServerInstallLayout.defaultForCurrentUser(launchAgentLabel: label)
+        let aliasPath = layout.launchAgentConfigAliasURL.path
+        guard FileManager.default.fileExists(atPath: aliasPath) else {
+            return
+        }
+
+        do {
+            try FileManager.default.removeItem(atPath: aliasPath)
+        } catch {
+            throw LaunchAgentCommandError(
+                "\(speakSwiftlyServerToolName) could not remove the staged LaunchAgent config copy '\(aliasPath)' during uninstall. Likely cause: \(error.localizedDescription)",
+            )
         }
     }
 

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentRuntime.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentRuntime.swift
@@ -70,7 +70,7 @@ struct LaunchAgentStatusOptions {
 
     func uninstall() throws {
         if try isLoaded() {
-            try bootoutLoadedService()
+            try unloadLoadedService()
         }
 
         if FileManager.default.fileExists(atPath: plistPath) {
@@ -98,6 +98,11 @@ struct LaunchAgentStatusOptions {
                 "\(speakSwiftlyServerToolName) asked launchctl to unload '\(userDomain)/\(label)', but launchctl exited with status \(result.exitCode). stderr: \(result.standardError)",
             )
         }
+    }
+
+    func unloadLoadedService() throws {
+        try bootoutLoadedService()
+        try waitUntilNotLoaded()
     }
 
     func waitUntilNotLoaded(

--- a/Sources/SpeakSwiftlyServer/MCP/MCPToolHandlers.swift
+++ b/Sources/SpeakSwiftlyServer/MCP/MCPToolHandlers.swift
@@ -29,20 +29,20 @@ private func acceptedRequestToolResult(
     )
 }
 
-private func mappedTextProfileToolResult<T: Encodable>(
-    _ operation: () async throws -> T,
+private func mappedTextProfileToolResult(
+    _ operation: () async throws -> some Encodable,
 ) async throws -> CallTool.Result {
     do {
-        return try toolResult(try await operation())
+        return try await toolResult(operation())
     } catch {
         throw mapTextProfileToolError(error)
     }
 }
 
-private func notifyingTextProfileToolResult<T: Encodable>(
+private func notifyingTextProfileToolResult(
     on server: Server,
     subscriptionBroker: MCPSubscriptionBroker,
-    _ operation: () async throws -> T,
+    _ operation: () async throws -> some Encodable,
 ) async throws -> CallTool.Result {
     do {
         let result = try await operation()

--- a/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/Embedding-The-Server.md
+++ b/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/Embedding-The-Server.md
@@ -21,7 +21,12 @@ and lets app code provide explicit `Options(port:runtimeProfileRootURL:)` values
 localhost port or another runtime-owned persistence root is a better fit.
 
 Call ``EmbeddedServer/land()`` when the app wants a graceful shutdown. If the server has already
-been asked to land, a second request simply waits for the same shutdown to finish.
+been asked to land, a second request simply waits for the same shutdown to finish. If shutdown is
+requested while the embedded runtime is still starting, that same `land()` call now cancels the
+in-flight startup attempt instead of waiting forever for startup to finish first. Embedded startup
+is also time-bounded: if the underlying runtime does not finish startup within the package-owned
+startup timeout, the session reports a clear startup failure and tears itself down instead of
+remaining stuck in a permanent starting state.
 
 ## Consumer Ownership Model
 

--- a/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/First-Embedded-Session.md
+++ b/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/First-Embedded-Session.md
@@ -32,6 +32,11 @@ try await server.liftoff()
 
 `EmbeddedServer` owns the host lifecycle. Internally it now coordinates host startup, optional config watching, optional MCP readiness, and HTTP serving through one service-owned lifecycle group, but app code should still treat the server object itself as the lifecycle boundary. Keep that object alive for as long as you want the shared server running in-process. If you do not pass `Options(port:)`, the embedded host defaults to `127.0.0.1:7339`.
 
+If the app decides to stop the embedded session while startup is still in flight, `land()` now
+cancels that startup attempt and proceeds through the same orderly teardown path. If the underlying
+runtime startup stalls completely, the embedded lifecycle also times out that startup attempt and
+surfaces a clear failure instead of staying stuck in startup indefinitely.
+
 If you pass `runtimeProfileRootURL`, the embedded host uses that explicit profile-store root for its own persisted runtime configuration bookkeeping and bridges it into the broader persistence root expected by the current pinned `SpeakSwiftly` runtime. Use that when the app wants an explicit app-owned or App Group-owned runtime root instead of relying on the default Application Support lookup.
 
 ## Read The App-Facing State

--- a/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/LaunchAgent-Workflow.md
+++ b/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/LaunchAgent-Workflow.md
@@ -63,6 +63,9 @@ xcrun swift run SpeakSwiftlyServerTool launch-agent uninstall
 `uninstall` now waits for `launchctl` to stop reporting the job as loaded before it returns. That
 keeps a plain remove flow aligned with the install and promote-live refresh flows, which already
 wait for launchd teardown before they try to bootstrap the next job incarnation.
+It also removes the staged LaunchAgent config alias copy from the managed install layout, so the
+remove flow now clears the launch-agent-owned config shim instead of leaving stale alias state
+behind after the job is gone.
 
 `status` now reports an explicit `load_state` field. A normal absent job shows `load_state: not_loaded`.
 If `launchctl print` fails for some other reason, the command now surfaces that failure directly

--- a/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/LaunchAgent-Workflow.md
+++ b/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/LaunchAgent-Workflow.md
@@ -64,6 +64,10 @@ xcrun swift run SpeakSwiftlyServerTool launch-agent uninstall
 keeps a plain remove flow aligned with the install and promote-live refresh flows, which already
 wait for launchd teardown before they try to bootstrap the next job incarnation.
 
+`status` now reports an explicit `load_state` field. A normal absent job shows `load_state: not_loaded`.
+If `launchctl print` fails for some other reason, the command now surfaces that failure directly
+instead of flattening it into `loaded: no`.
+
 For one explicit live-service verification pass, run:
 
 ```bash

--- a/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/LaunchAgent-Workflow.md
+++ b/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/LaunchAgent-Workflow.md
@@ -60,6 +60,10 @@ xcrun swift run SpeakSwiftlyServerTool launch-agent status
 xcrun swift run SpeakSwiftlyServerTool launch-agent uninstall
 ```
 
+`uninstall` now waits for `launchctl` to stop reporting the job as loaded before it returns. That
+keeps a plain remove flow aligned with the install and promote-live refresh flows, which already
+wait for launchd teardown before they try to bootstrap the next job incarnation.
+
 For one explicit live-service verification pass, run:
 
 ```bash

--- a/TODO.md
+++ b/TODO.md
@@ -56,3 +56,4 @@
 ## Slice 5 Findings
 
 - [x] Make plain LaunchAgent uninstall wait for launchd to finish unloading the job, not just issue `bootout`, so immediate status checks and follow-up install flows do not race a partially torn-down service.
+- [x] Distinguish a normal `not_loaded` LaunchAgent status from unexpected `launchctl print` failures so operator status output stops masking permission or launchd inspection errors as if the job were simply absent.

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 ## Thorough Review Slices
 
-- [~] Slice 1: Host state and job tracking
+- [x] Slice 1: Host state and job tracking
   Files: `Sources/SpeakSwiftlyServer/Host/ServerHost+State.swift`, `Sources/SpeakSwiftlyServer/Host/ServerHost+JobTracking.swift`
   Focus: runtime-derived state refresh policy, degraded-worker fallback behavior, profile-cache reconciliation, SSE replay, request retention and pruning.
 
@@ -30,7 +30,7 @@
 
 - [x] Fix degraded-worker cached fallback so it clears `generationQueueStatus` alongside playback state, and add regression coverage for the degraded queue snapshot path.
 - [x] Refresh the cached voice-profile list after `reroll_voice_profile` completes, and add regression coverage that verifies profile-cache metadata is refreshed after reroll.
-- [ ] Review whether profile-mutation reconciliation should rely on profile-name set comparisons alone, especially when concurrent external profile edits can happen between retries.
+- [x] Replace profile-name set reconciliation with request-scoped mutation intent checks so create, rename, reroll, and delete refreshes only verify the specific profile transition that was actually requested, even when unrelated external profile edits happen during the refresh window.
 
 ## Slice 2 Findings
 

--- a/TODO.md
+++ b/TODO.md
@@ -57,3 +57,4 @@
 
 - [x] Make plain LaunchAgent uninstall wait for launchd to finish unloading the job, not just issue `bootout`, so immediate status checks and follow-up install flows do not race a partially torn-down service.
 - [x] Distinguish a normal `not_loaded` LaunchAgent status from unexpected `launchctl print` failures so operator status output stops masking permission or launchd inspection errors as if the job were simply absent.
+- [x] Remove the staged LaunchAgent config alias during uninstall so the app-owned install surface does not leave behind a stale launch-agent-only config copy after the service has been removed.

--- a/TODO.md
+++ b/TODO.md
@@ -22,7 +22,7 @@
   Files: `Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentRuntime.swift`
   Focus: launchctl polling, uninstall timing, partial teardown states, and operator-facing diagnostics.
 
-- [ ] Slice 6: E2E MCP stream harness
+- [x] Slice 6: E2E MCP stream harness
   Files: `Tests/SpeakSwiftlyServerE2ETests/E2EMCPEventStream.swift` and related E2E helpers
   Focus: stream connection timing, polling sleeps, notification matching, and flake risk.
 
@@ -58,3 +58,9 @@
 - [x] Make plain LaunchAgent uninstall wait for launchd to finish unloading the job, not just issue `bootout`, so immediate status checks and follow-up install flows do not race a partially torn-down service.
 - [x] Distinguish a normal `not_loaded` LaunchAgent status from unexpected `launchctl print` failures so operator status output stops masking permission or launchd inspection errors as if the job were simply absent.
 - [x] Remove the staged LaunchAgent config alias during uninstall so the app-owned install surface does not leave behind a stale launch-agent-only config copy after the service has been removed.
+
+## Slice 6 Findings
+
+- [x] Replace the SSE helper's fixed post-connect sleep and buffer polling loop with explicit async wakeups for stream readiness, notification arrival, and terminal stream failure so MCP resource-update tests stop depending on arbitrary 100ms delays inside the harness.
+- [x] Recheck the broader MCP E2E helper path for places where startup or session-handshake failures are still flattened into retry polling instead of surfacing the real transport error once the server is reachable.
+- [x] Run one live MCP smoke path against the refactored stream helper once it is worth temporarily stopping any LaunchAgent-backed local service, so the async-wakeup harness changes have one real end-to-end proof point beyond helper-only tests.

--- a/TODO.md
+++ b/TODO.md
@@ -51,3 +51,4 @@
 - [x] Update lifecycle regression coverage so the post-shutdown `land()` path is treated as a no-op and add direct restart coverage for the reused embedded-session instance.
 - [x] Split MCP startup failure handling from the post-start shutdown path so readiness failures only describe real startup failures instead of conflating later lifecycle errors with startup.
 - [x] Collapse repeated sibling-service shutdown-barrier completion into one helper so prune, config-watch, MCP, and embedded-application services all use the same completion bookkeeping on success, graceful shutdown, and thrown failure paths.
+- [ ] Review whether embedded host startup should become explicitly cancellable or time-bounded; `HostLifecycleService` still cannot reach orderly shutdown or sibling-barrier waiting until `host.start()` returns, so a hung runtime startup remains the main unresolved lifecycle wedge.

--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@
   Files: `Sources/SpeakSwiftlyServer/MCP/MCPToolHandlers.swift`
   Focus: repeated argument parsing, accepted-request result shaping, resource-change notifications, and tool-handler drift.
 
-- [ ] Slice 4: Embedded lifecycle and startup or shutdown ownership
+- [~] Slice 4: Embedded lifecycle and startup or shutdown ownership
   Files: `Sources/SpeakSwiftlyServer/EmbeddedServerSession.swift`, `Sources/SpeakSwiftlyServer/EmbeddedLifecycleServices.swift`
   Focus: readiness gates, sibling-service coordination, shutdown barriers, and transport-state transitions.
 
@@ -44,3 +44,8 @@
 - [x] Collapse repeated accepted-request MCP tool result shaping behind one helper so speech-generation and voice-profile job tools keep a single request-resource response shape.
 - [x] Collapse repeated text-profile MCP mutation branches behind one helper that preserves explicit `MCPError` mapping and always emits the `textProfiles` resource-change notification after successful mutation work.
 - [x] Keep the text-profile snapshot read path on the same explicit error-mapping helper so read-only and mutation tool cases now fail through one predictable MCP error surface.
+
+## Slice 4 Findings
+
+- [x] Reset the embedded session lifecycle handle after shutdown completes so one long-lived `EmbeddedServer` instance can `liftoff()`, `land()`, and `liftoff()` again when an app feature is turned off and later turned back on.
+- [x] Update lifecycle regression coverage so the post-shutdown `land()` path is treated as a no-op and add direct restart coverage for the reused embedded-session instance.

--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@
   Files: `Sources/SpeakSwiftlyServer/MCP/MCPToolHandlers.swift`
   Focus: repeated argument parsing, accepted-request result shaping, resource-change notifications, and tool-handler drift.
 
-- [~] Slice 4: Embedded lifecycle and startup or shutdown ownership
+- [x] Slice 4: Embedded lifecycle and startup or shutdown ownership
   Files: `Sources/SpeakSwiftlyServer/EmbeddedServerSession.swift`, `Sources/SpeakSwiftlyServer/EmbeddedLifecycleServices.swift`
   Focus: readiness gates, sibling-service coordination, shutdown barriers, and transport-state transitions.
 
@@ -51,4 +51,4 @@
 - [x] Update lifecycle regression coverage so the post-shutdown `land()` path is treated as a no-op and add direct restart coverage for the reused embedded-session instance.
 - [x] Split MCP startup failure handling from the post-start shutdown path so readiness failures only describe real startup failures instead of conflating later lifecycle errors with startup.
 - [x] Collapse repeated sibling-service shutdown-barrier completion into one helper so prune, config-watch, MCP, and embedded-application services all use the same completion bookkeeping on success, graceful shutdown, and thrown failure paths.
-- [ ] Review whether embedded host startup should become explicitly cancellable or time-bounded; `HostLifecycleService` still cannot reach orderly shutdown or sibling-barrier waiting until `host.start()` returns, so a hung runtime startup remains the main unresolved lifecycle wedge.
+- [x] Make embedded host startup both cancellable and time-bounded so `land()` can preempt an in-flight startup attempt and a stuck runtime start now fails with a clear operator-facing timeout instead of wedging the lifecycle service indefinitely.

--- a/TODO.md
+++ b/TODO.md
@@ -49,3 +49,5 @@
 
 - [x] Reset the embedded session lifecycle handle after shutdown completes so one long-lived `EmbeddedServer` instance can `liftoff()`, `land()`, and `liftoff()` again when an app feature is turned off and later turned back on.
 - [x] Update lifecycle regression coverage so the post-shutdown `land()` path is treated as a no-op and add direct restart coverage for the reused embedded-session instance.
+- [x] Split MCP startup failure handling from the post-start shutdown path so readiness failures only describe real startup failures instead of conflating later lifecycle errors with startup.
+- [x] Collapse repeated sibling-service shutdown-barrier completion into one helper so prune, config-watch, MCP, and embedded-application services all use the same completion bookkeeping on success, graceful shutdown, and thrown failure paths.

--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@
   Files: `Sources/SpeakSwiftlyServer/EmbeddedServerSession.swift`, `Sources/SpeakSwiftlyServer/EmbeddedLifecycleServices.swift`
   Focus: readiness gates, sibling-service coordination, shutdown barriers, and transport-state transitions.
 
-- [ ] Slice 5: LaunchAgent operator flow
+- [~] Slice 5: LaunchAgent operator flow
   Files: `Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentRuntime.swift`
   Focus: launchctl polling, uninstall timing, partial teardown states, and operator-facing diagnostics.
 
@@ -52,3 +52,7 @@
 - [x] Split MCP startup failure handling from the post-start shutdown path so readiness failures only describe real startup failures instead of conflating later lifecycle errors with startup.
 - [x] Collapse repeated sibling-service shutdown-barrier completion into one helper so prune, config-watch, MCP, and embedded-application services all use the same completion bookkeeping on success, graceful shutdown, and thrown failure paths.
 - [x] Make embedded host startup both cancellable and time-bounded so `land()` can preempt an in-flight startup attempt and a stuck runtime start now fails with a clear operator-facing timeout instead of wedging the lifecycle service indefinitely.
+
+## Slice 5 Findings
+
+- [x] Make plain LaunchAgent uninstall wait for launchd to finish unloading the job, not just issue `bootout`, so immediate status checks and follow-up install flows do not race a partially torn-down service.

--- a/Tests/SpeakSwiftlyServerE2ETests/E2EMCPClient.swift
+++ b/Tests/SpeakSwiftlyServerE2ETests/E2EMCPClient.swift
@@ -14,21 +14,38 @@ struct E2EMCPClient {
         timeout: Duration,
         server: ServerProcess,
     ) async throws -> E2EMCPClient {
-        try await e2eWaitUntil(timeout: timeout, pollInterval: .seconds(1)) {
-            guard server.isStillRunning else {
+        let startupErrorRecorder = E2ERecordedError()
+        do {
+            return try await e2eWaitUntil(timeout: timeout, pollInterval: .seconds(1)) {
+                guard server.isStillRunning else {
+                    throw E2ETransportError(
+                        "The live SpeakSwiftlyServer process exited before the MCP transport became available.\n\(server.combinedOutput)",
+                    )
+                }
+
+                do {
+                    return try await connectNow(baseURL: baseURL, path: path)
+                } catch {
+                    if isRetryableConnectionDuringStartup(error) {
+                        startupErrorRecorder.record(error)
+                        return nil
+                    }
+
+                    throw E2ETransportError(
+                        "The live MCP transport became reachable, but the initial session handshake failed before a session was established. Underlying error: \(error)",
+                    )
+                }
+            }
+        } catch is E2ETimeoutError {
+            if let startupError = startupErrorRecorder.value {
                 throw E2ETransportError(
-                    "The live SpeakSwiftlyServer process exited before the MCP transport became available.\n\(server.combinedOutput)",
+                    "The live MCP transport did not become ready within \(timeout). The most recent retryable startup error was: \(startupError)",
                 )
             }
 
-            do {
-                return try await connectNow(baseURL: baseURL, path: path)
-            } catch {
-                if isRetryableConnectionDuringStartup(error) {
-                    return nil
-                }
-                return nil
-            }
+            throw E2ETransportError(
+                "The live MCP transport did not become ready within \(timeout), and the server never completed the initial MCP session handshake.",
+            )
         }
     }
 

--- a/Tests/SpeakSwiftlyServerE2ETests/E2EMCPEventStream.swift
+++ b/Tests/SpeakSwiftlyServerE2ETests/E2EMCPEventStream.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Testing
 
 // MARK: - E2EMCPEventStream
 
@@ -71,43 +72,47 @@ final class E2EMCPEventStream: @unchecked Sendable {
             }
         }
 
-        let _: Bool = try await e2eWaitUntil(timeout: .seconds(10), pollInterval: .milliseconds(100)) {
-            try await self.connectionState.streamReady()
+        try await e2eWithTimeout(.seconds(10)) {
+            try await self.connectionState.waitUntilReady()
         }
-        try await Task.sleep(for: .milliseconds(100))
     }
 
     func stop() {
         task?.cancel()
         task = nil
         urlSession.invalidateAndCancel()
+        let cancellationError = CancellationError()
+        Task {
+            await connectionState.finish(with: cancellationError)
+            await buffer.finish(with: cancellationError)
+        }
     }
 
     func waitForNotification(
         timeout: Duration,
         matching predicate: @escaping @Sendable ([String: Any]) -> Bool,
     ) async throws -> [String: Any] {
-        let deadline = ContinuousClock.now + timeout
-        while ContinuousClock.now < deadline {
-            if let data = try await buffer.takeMatching(predicate) {
-                let json = try JSONSerialization.jsonObject(with: data)
-                guard let object = json as? [String: Any] else {
-                    throw E2ETransportError(
-                        "The live MCP event stream produced a notification payload that was not a JSON object.",
-                    )
-                }
-
-                return object
+        do {
+            let data = try await e2eWithTimeout(timeout) {
+                try await self.buffer.waitForMatching(predicate)
             }
-            try await Task.sleep(for: .milliseconds(100))
+            let json = try JSONSerialization.jsonObject(with: data)
+            guard let object = json as? [String: Any] else {
+                throw E2ETransportError(
+                    "The live MCP event stream produced a notification payload that was not a JSON object.",
+                )
+            }
+
+            return object
+        } catch is E2ETimeoutError {
+            let observedPayloads = await buffer.recentPayloads(limit: 12)
+            let preview = observedPayloads.isEmpty
+                ? "none"
+                : observedPayloads.joined(separator: "\n")
+            throw E2ETransportError(
+                "The live MCP event stream timed out after waiting \(timeout) for a matching notification. The GET SSE stream stayed connected, but no matching notification arrived. Recent raw notification payloads seen before timeout:\n\(preview)",
+            )
         }
-        let observedPayloads = await buffer.recentPayloads(limit: 12)
-        let preview = observedPayloads.isEmpty
-            ? "none"
-            : observedPayloads.joined(separator: "\n")
-        throw E2ETransportError(
-            "The live MCP event stream timed out after waiting \(timeout) for a matching notification. The GET SSE stream stayed connected, but no matching notification arrived. Recent raw notification payloads seen before timeout:\n\(preview)",
-        )
     }
 }
 
@@ -116,51 +121,88 @@ final class E2EMCPEventStream: @unchecked Sendable {
 private actor E2EMCPEventStreamConnectionState {
     private var isConnected = false
     private var terminalError: Error?
+    private var waiters = [CheckedContinuation<Void, Error>]()
 
     func markConnected() {
         isConnected = true
+        let pendingWaiters = waiters
+        waiters.removeAll()
+        for waiter in pendingWaiters {
+            waiter.resume()
+        }
     }
 
     func finish(with error: Error) {
+        guard terminalError == nil else { return }
         terminalError = error
+        let pendingWaiters = waiters
+        waiters.removeAll()
+        for waiter in pendingWaiters {
+            waiter.resume(throwing: error)
+        }
     }
 
-    func streamReady() throws -> Bool? {
+    func waitUntilReady() async throws {
         if let terminalError {
             throw terminalError
         }
-        return isConnected ? true : nil
+        guard isConnected == false else { return }
+
+        try await withCheckedThrowingContinuation { continuation in
+            waiters.append(continuation)
+        }
     }
 }
 
 // MARK: - E2ENotificationBuffer
 
 private actor E2ENotificationBuffer {
+    private struct Waiter {
+        let id: UUID
+        let predicate: @Sendable ([String: Any]) -> Bool
+        let continuation: CheckedContinuation<Data, Error>
+    }
+
     private var notifications = [Data]()
     private var terminalError: Error?
     private var payloadHistory = [String]()
+    private var waiters = [Waiter]()
     private static let payloadHistoryLimit = 48
 
     func append(_ notification: Data) {
-        notifications.append(notification)
         payloadHistory.append(String(decoding: notification, as: UTF8.self))
         if payloadHistory.count > Self.payloadHistoryLimit {
             payloadHistory.removeFirst(payloadHistory.count - Self.payloadHistoryLimit)
         }
+
+        if let object = try? decodeJSONObject(from: notification),
+           let waiterIndex = waiters.firstIndex(where: { $0.predicate(object) })
+        {
+            let waiter = waiters.remove(at: waiterIndex)
+            waiter.continuation.resume(returning: notification)
+            return
+        }
+
+        notifications.append(notification)
     }
 
     func finish(with error: Error) {
+        guard terminalError == nil else { return }
         terminalError = error
+        let pendingWaiters = waiters
+        waiters.removeAll()
+        for waiter in pendingWaiters {
+            waiter.continuation.resume(throwing: error)
+        }
     }
 
-    func takeMatching(_ predicate: @escaping @Sendable ([String: Any]) -> Bool) throws -> Data? {
+    func waitForMatching(_ predicate: @escaping @Sendable ([String: Any]) -> Bool) async throws -> Data {
         if let terminalError {
             throw terminalError
         }
 
         for (index, notification) in notifications.enumerated() {
-            let json = try JSONSerialization.jsonObject(with: notification)
-            guard let object = json as? [String: Any] else {
+            guard let object = try? decodeJSONObject(from: notification) else {
                 continue
             }
 
@@ -168,10 +210,101 @@ private actor E2ENotificationBuffer {
                 return notifications.remove(at: index)
             }
         }
-        return nil
+
+        let waiterID = UUID()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                if let terminalError {
+                    continuation.resume(throwing: terminalError)
+                    return
+                }
+
+                waiters.append(.init(id: waiterID, predicate: predicate, continuation: continuation))
+            }
+        } onCancel: {
+            Task {
+                await self.cancelWaiter(id: waiterID)
+            }
+        }
     }
 
     func recentPayloads(limit: Int) -> [String] {
         Array(payloadHistory.suffix(limit))
+    }
+
+    private func cancelWaiter(id: UUID) {
+        guard let waiterIndex = waiters.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+
+        let waiter = waiters.remove(at: waiterIndex)
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+
+    private func decodeJSONObject(from notification: Data) throws -> [String: Any] {
+        let json = try JSONSerialization.jsonObject(with: notification)
+        guard let object = json as? [String: Any] else {
+            throw E2ETransportError(
+                "The live MCP event stream produced a notification payload that was not a JSON object.",
+            )
+        }
+        return object
+    }
+}
+
+// MARK: - Timeout Support
+
+private func e2eWithTimeout<T: Sendable>(
+    _ timeout: Duration,
+    operation: @escaping @Sendable () async throws -> T,
+) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask {
+            try await operation()
+        }
+        group.addTask {
+            try await Task.sleep(for: timeout)
+            throw E2ETimeoutError()
+        }
+
+        guard let value = try await group.next() else {
+            throw E2ETimeoutError()
+        }
+        group.cancelAll()
+        return value
+    }
+}
+
+// MARK: - E2E MCP Event Stream Tests
+
+@Test func `notification buffer wakes a matching waiter when payload arrives`() async throws {
+    let buffer = E2ENotificationBuffer()
+    let waiter = Task {
+        try await buffer.waitForMatching {
+            $0["method"] as? String == "notifications/resources/updated"
+        }
+    }
+
+    await Task.yield()
+    await buffer.append(
+        Data(#"{"method":"notifications/resources/updated","params":{"uri":"speak://voices"}}"#.utf8),
+    )
+
+    let data = try await waiter.value
+    let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    #expect(object["method"] as? String == "notifications/resources/updated")
+}
+
+@Test func `notification buffer finishes pending waiters on terminal error`() async throws {
+    let buffer = E2ENotificationBuffer()
+    let waiter = Task {
+        try await buffer.waitForMatching { _ in true }
+    }
+
+    await Task.yield()
+    await buffer.finish(with: E2ETransportError("The event stream closed before a notification arrived."))
+
+    await #expect(throws: E2ETransportError.self) {
+        _ = try await waiter.value
     }
 }

--- a/Tests/SpeakSwiftlyServerE2ETests/E2EMCPEventStream.swift
+++ b/Tests/SpeakSwiftlyServerE2ETests/E2EMCPEventStream.swift
@@ -134,6 +134,7 @@ private actor E2EMCPEventStreamConnectionState {
 
     func finish(with error: Error) {
         guard terminalError == nil else { return }
+
         terminalError = error
         let pendingWaiters = waiters
         waiters.removeAll()
@@ -163,11 +164,12 @@ private actor E2ENotificationBuffer {
         let continuation: CheckedContinuation<Data, Error>
     }
 
+    private static let payloadHistoryLimit = 48
+
     private var notifications = [Data]()
     private var terminalError: Error?
     private var payloadHistory = [String]()
     private var waiters = [Waiter]()
-    private static let payloadHistoryLimit = 48
 
     func append(_ notification: Data) {
         payloadHistory.append(String(decoding: notification, as: UTF8.self))
@@ -176,8 +178,7 @@ private actor E2ENotificationBuffer {
         }
 
         if let object = try? decodeJSONObject(from: notification),
-           let waiterIndex = waiters.firstIndex(where: { $0.predicate(object) })
-        {
+           let waiterIndex = waiters.firstIndex(where: { $0.predicate(object) }) {
             let waiter = waiters.remove(at: waiterIndex)
             waiter.continuation.resume(returning: notification)
             return
@@ -188,6 +189,7 @@ private actor E2ENotificationBuffer {
 
     func finish(with error: Error) {
         guard terminalError == nil else { return }
+
         terminalError = error
         let pendingWaiters = waiters
         waiters.removeAll()
@@ -248,6 +250,7 @@ private actor E2ENotificationBuffer {
                 "The live MCP event stream produced a notification payload that was not a JSON object.",
             )
         }
+
         return object
     }
 }
@@ -270,6 +273,7 @@ private func e2eWithTimeout<T: Sendable>(
         guard let value = try await group.next() else {
             throw E2ETimeoutError()
         }
+
         group.cancelAll()
         return value
     }

--- a/Tests/SpeakSwiftlyServerE2ETests/E2EPayloadHelpers.swift
+++ b/Tests/SpeakSwiftlyServerE2ETests/E2EPayloadHelpers.swift
@@ -163,6 +163,21 @@ extension NSLock {
     }
 }
 
+final class E2ERecordedError: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedError: Error?
+
+    var value: Error? {
+        lock.withLock { storedError }
+    }
+
+    func record(_ error: Error) {
+        lock.withLock {
+            storedError = error
+        }
+    }
+}
+
 // MARK: - Error Helpers
 
 struct E2ETimeoutError: Error {}

--- a/Tests/SpeakSwiftlyServerTests/HTTPFailureTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/HTTPFailureTests.swift
@@ -127,6 +127,84 @@ extension ServerTests {
     }
 
     @available(macOS 14, *)
+    @Test func `profile creation reconciliation rejects unrelated refresh-only changes`() async throws {
+        let originalCreatedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let runtime = MockRuntime(
+            profiles: [
+                SpeakSwiftly.ProfileSummary(
+                    profileName: "bright-guide",
+                    vibe: .femme,
+                    createdAt: originalCreatedAt,
+                    voiceDescription: "Existing voice",
+                    sourceText: "Existing text",
+                    transcriptSource: nil,
+                    transcriptResolvedAt: nil,
+                    transcriptionModelRepo: nil,
+                ),
+            ],
+            mutationRefreshBehavior: .leaveProfilesUnchanged,
+        )
+        let state = await MainActor.run { EmbeddedServer() }
+        let host = ServerHost(
+            configuration: testConfiguration(),
+            runtime: runtime,
+            runtimeConfigurationStore: testRuntimeConfigurationStore(),
+            state: state,
+        )
+
+        await host.start()
+        await runtime.publishStatus(.residentModelReady)
+        try await waitUntilReady(host)
+
+        await runtime.setScriptedProfileRefreshSnapshots(
+            [[
+                SpeakSwiftly.ProfileSummary(
+                    profileName: "bright-guide",
+                    vibe: .femme,
+                    createdAt: originalCreatedAt,
+                    voiceDescription: "Existing voice",
+                    sourceText: "Existing text",
+                    transcriptSource: nil,
+                    transcriptResolvedAt: nil,
+                    transcriptionModelRepo: nil,
+                ),
+                SpeakSwiftly.ProfileSummary(
+                    profileName: "external-addition",
+                    vibe: .femme,
+                    createdAt: originalCreatedAt.addingTimeInterval(30),
+                    voiceDescription: "Unrelated external voice",
+                    sourceText: "External text",
+                    transcriptSource: nil,
+                    transcriptResolvedAt: nil,
+                    transcriptionModelRepo: nil,
+                ),
+            ]],
+        )
+
+        let jobID = try await host.submitCreateProfile(
+            profileName: "bright-guide",
+            vibe: .femme,
+            text: "Hello there",
+            voiceDescription: "Warm and bright",
+            outputPath: nil,
+            cwd: nil,
+        )
+        let snapshot = try await waitForJobSnapshot(jobID, on: host)
+
+        switch snapshot.terminalEvent {
+            case let .failed(failure):
+                #expect(failure.code == "profile_refresh_mismatch")
+            default:
+                Issue.record("Expected create_voice_profile_from_description reconciliation to reject unrelated refresh-only changes when the target profile snapshot stayed unchanged.")
+        }
+
+        let status = await host.statusSnapshot()
+        #expect(status.profileCacheState == "stale")
+
+        await host.shutdown()
+    }
+
+    @available(macOS 14, *)
     @Test func `text profile routes surface bridge failures as typed server errors`() async throws {
         let runtime = MockRuntime(
             textProfileTransportError: SpeakSwiftly.Error(

--- a/Tests/SpeakSwiftlyServerTests/HostLifecycleTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/HostLifecycleTests.swift
@@ -128,7 +128,64 @@ import Testing
 
     let counts = await probe.counts()
     #expect(counts.requestStop == 1)
-    #expect(counts.waitUntilStopped == 2)
+    #expect(counts.waitUntilStopped == 1)
+}
+
+@available(macOS 14, *)
+@Test func `embedded server can liftoff again after landing`() async throws {
+    actor RestartProbe {
+        private var bootstrapCallCount = 0
+        private var requestStopCallCount = 0
+
+        func recordBootstrap() {
+            bootstrapCallCount += 1
+        }
+
+        func recordRequestStop() {
+            requestStopCallCount += 1
+        }
+
+        func counts() -> (bootstrap: Int, requestStop: Int) {
+            (bootstrapCallCount, requestStopCallCount)
+        }
+    }
+
+    let probe = RestartProbe()
+    let server = await MainActor.run { EmbeddedServer() }
+
+    try await server.liftoff(
+        environment: [:],
+        defaultProfile: .embeddedSession,
+        bootstrap: { _, _ in
+            await probe.recordBootstrap()
+            return EmbeddedServerLifecycleHooks(
+                requestStop: {
+                    await probe.recordRequestStop()
+                },
+                waitUntilStopped: {},
+            )
+        },
+    )
+    try await server.land()
+
+    try await server.liftoff(
+        environment: [:],
+        defaultProfile: .embeddedSession,
+        bootstrap: { _, _ in
+            await probe.recordBootstrap()
+            return EmbeddedServerLifecycleHooks(
+                requestStop: {
+                    await probe.recordRequestStop()
+                },
+                waitUntilStopped: {},
+            )
+        },
+    )
+    try await server.land()
+
+    let counts = await probe.counts()
+    #expect(counts.bootstrap == 2)
+    #expect(counts.requestStop == 2)
 }
 
 @available(macOS 14, *)

--- a/Tests/SpeakSwiftlyServerTests/HostLifecycleTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/HostLifecycleTests.swift
@@ -211,6 +211,7 @@ import Testing
         host: host,
         readinessGate: readinessGate,
         shutdownBarrier: shutdownBarrier,
+        startupTimeout: .seconds(15),
     )
     let serviceGroup = ServiceGroup(
         services: [service],
@@ -239,6 +240,80 @@ import Testing
 
     let finalCounts = await runtime.lifecycleCounts()
     #expect(finalCounts.shutdown == 1)
+}
+
+@available(macOS 14, *)
+@Test func `host lifecycle service can shut down while startup is still in flight`() async throws {
+    let runtime = MockRuntime(startBehavior: .waitForRelease)
+    let state = await MainActor.run { EmbeddedServer() }
+    let host = ServerHost(
+        configuration: testConfiguration(),
+        runtime: runtime,
+        runtimeConfigurationStore: testRuntimeConfigurationStore(),
+        state: state,
+    )
+    let readinessGate = EmbeddedLifecycleReadinessGate()
+    let shutdownBarrier = EmbeddedLifecycleShutdownBarrier(targetCount: 0)
+    let service = HostLifecycleService(
+        host: host,
+        readinessGate: readinessGate,
+        shutdownBarrier: shutdownBarrier,
+        startupTimeout: .seconds(15),
+    )
+    let serviceGroup = ServiceGroup(
+        services: [service],
+        gracefulShutdownSignals: [],
+        cancellationSignals: [],
+        logger: Logger(label: "ServerTests.HostLifecycleStartupCancellation"),
+    )
+
+    let runTask = Task {
+        try await serviceGroup.run()
+    }
+
+    await runtime.waitUntilStartReachesBarrier()
+    await serviceGroup.triggerGracefulShutdown()
+    try await runTask.value
+
+    let lifecycleCounts = await runtime.lifecycleCounts()
+    #expect(lifecycleCounts.start == 1)
+    #expect(lifecycleCounts.shutdown == 1)
+}
+
+@available(macOS 14, *)
+@Test func `host lifecycle service times out stuck startup clearly`() async throws {
+    let runtime = MockRuntime(startBehavior: .waitForRelease)
+    let state = await MainActor.run { EmbeddedServer() }
+    let host = ServerHost(
+        configuration: testConfiguration(),
+        runtime: runtime,
+        runtimeConfigurationStore: testRuntimeConfigurationStore(),
+        state: state,
+    )
+    let readinessGate = EmbeddedLifecycleReadinessGate()
+    let shutdownBarrier = EmbeddedLifecycleShutdownBarrier(targetCount: 0)
+    let service = HostLifecycleService(
+        host: host,
+        readinessGate: readinessGate,
+        shutdownBarrier: shutdownBarrier,
+        startupTimeout: .milliseconds(20),
+    )
+
+    await #expect(throws: Error.self) {
+        try await service.run()
+    }
+
+    let lifecycleCounts = await runtime.lifecycleCounts()
+    #expect(lifecycleCounts.start == 1)
+    #expect(lifecycleCounts.shutdown == 1)
+
+    let readiness = await #expect(throws: Error.self) {
+        try await readinessGate.waitUntilReady()
+    }
+    _ = readiness
+
+    let snapshot = await host.hostStateSnapshot()
+    #expect(snapshot.overview.startupError?.contains("timed out while waiting for the embedded runtime to finish startup") == true)
 }
 
 @available(macOS 14, *)

--- a/Tests/SpeakSwiftlyServerTests/HostStateTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/HostStateTests.swift
@@ -549,6 +549,73 @@ import Testing
     await host.shutdown()
 }
 
+@available(macOS 14, *)
+@Test func `renaming a voice profile tolerates unrelated profile refresh changes`() async throws {
+    let runtime = MockRuntime(
+        profiles: [
+            SpeakSwiftly.ProfileSummary(
+                profileName: "default",
+                vibe: .femme,
+                createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+                voiceDescription: "Default voice",
+                sourceText: "Default text",
+                transcriptSource: nil,
+                transcriptResolvedAt: nil,
+                transcriptionModelRepo: nil,
+            ),
+        ],
+    )
+    let state = await MainActor.run { EmbeddedServer() }
+    let host = ServerHost(
+        configuration: testConfiguration(),
+        runtime: runtime,
+        runtimeConfigurationStore: testRuntimeConfigurationStore(),
+        state: state,
+    )
+
+    await host.start()
+    await runtime.publishStatus(.residentModelReady)
+    try await waitUntilReady(host)
+
+    await runtime.setScriptedProfileRefreshSnapshots(
+        [[
+            SpeakSwiftly.ProfileSummary(
+                profileName: "renamed-default",
+                vibe: .femme,
+                createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+                voiceDescription: "Default voice",
+                sourceText: "Default text",
+                transcriptSource: nil,
+                transcriptResolvedAt: nil,
+                transcriptionModelRepo: nil,
+            ),
+            SpeakSwiftly.ProfileSummary(
+                profileName: "external-addition",
+                vibe: .femme,
+                createdAt: Date(timeIntervalSince1970: 1_700_000_120),
+                voiceDescription: "Added outside the host cache",
+                sourceText: "External text",
+                transcriptSource: nil,
+                transcriptResolvedAt: nil,
+                transcriptionModelRepo: nil,
+            ),
+        ]],
+    )
+
+    let jobID = try await host.submitRenameProfile(profileName: "default", newProfileName: "renamed-default")
+    let snapshot = try await waitForJobSnapshot(jobID, on: host)
+    #expect(snapshot.status == "completed")
+    #expect(snapshot.terminalEvent != nil)
+
+    let status = await host.statusSnapshot()
+    #expect(status.profileCacheState == "fresh")
+    #expect(status.cachedProfiles.contains { $0.profileName == "renamed-default" })
+    #expect(status.cachedProfiles.contains { $0.profileName == "external-addition" })
+    #expect(status.cachedProfiles.contains { $0.profileName == "default" } == false)
+
+    await host.shutdown()
+}
+
 @Test func `runtime adapter path resolution normalizes relative and whitespace padded cwd values`() {
     let currentDirectoryPath = "/tmp/speakswiftly-tests/workspace"
 

--- a/Tests/SpeakSwiftlyServerTests/LaunchAgentTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/LaunchAgentTests.swift
@@ -119,6 +119,35 @@ import Testing
     #expect(FileManager.default.fileExists(atPath: serviceStateURL.path) == false)
 }
 
+@Test func `launch agent uninstall removes staged config alias`() throws {
+    let homeDirectoryURL = try makeLaunchAgentCommandTestRepository()
+    let layout = ServerInstallLayout.defaultForCurrentUser(
+        homeDirectoryURL: homeDirectoryURL,
+        launchAgentLabel: "com.gaelic-ghost.test-launch-agent",
+    )
+
+    try FileManager.default.createDirectory(
+        at: layout.launchAgentConfigAliasURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true,
+    )
+    try FileManager.default.createDirectory(
+        at: layout.launchAgentPlistURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true,
+    )
+    try "aliased config".write(to: layout.launchAgentConfigAliasURL, atomically: true, encoding: .utf8)
+    try "plist".write(to: layout.launchAgentPlistURL, atomically: true, encoding: .utf8)
+
+    let options = LaunchAgentStatusOptions(
+        label: layout.launchAgentLabel,
+        plistPath: layout.launchAgentPlistURL.path,
+        launchctlPath: "/usr/bin/true",
+        userDomain: "gui/501",
+    )
+
+    try options.removeStagedConfigAliasIfPresent()
+    #expect(FileManager.default.fileExists(atPath: layout.launchAgentConfigAliasURL.path) == false)
+}
+
 @Test func `launch agent status reports explicit not loaded state`() throws {
     let temporaryRootURL = URL(fileURLWithPath: NSTemporaryDirectory())
         .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Tests/SpeakSwiftlyServerTests/LaunchAgentTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/LaunchAgentTests.swift
@@ -119,6 +119,70 @@ import Testing
     #expect(FileManager.default.fileExists(atPath: serviceStateURL.path) == false)
 }
 
+@Test func `launch agent status reports explicit not loaded state`() throws {
+    let temporaryRootURL = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: temporaryRootURL, withIntermediateDirectories: true)
+
+    let plistURL = temporaryRootURL.appendingPathComponent("SpeakSwiftlyServer.plist", isDirectory: false)
+    let launchctlScriptURL = temporaryRootURL.appendingPathComponent("launchctl", isDirectory: false)
+    let launchctlScript = """
+    #!/bin/sh
+    if [ "$1" = "print" ]; then
+      echo "Could not find service" >&2
+      exit 113
+    fi
+    exit 64
+    """
+    try launchctlScript.write(to: launchctlScriptURL, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: launchctlScriptURL.path)
+
+    let options = LaunchAgentStatusOptions(
+        label: "com.gaelic-ghost.test-launch-agent",
+        plistPath: plistURL.path,
+        launchctlPath: launchctlScriptURL.path,
+        userDomain: "gui/501",
+    )
+
+    let status = try options.statusSummary()
+    #expect(status.contains("loaded: no"))
+    #expect(status.contains("load_state: not_loaded"))
+}
+
+@Test func `launch agent status surfaces unexpected launchctl print failures`() throws {
+    let temporaryRootURL = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: temporaryRootURL, withIntermediateDirectories: true)
+
+    let plistURL = temporaryRootURL.appendingPathComponent("SpeakSwiftlyServer.plist", isDirectory: false)
+    let launchctlScriptURL = temporaryRootURL.appendingPathComponent("launchctl", isDirectory: false)
+    let launchctlScript = """
+    #!/bin/sh
+    if [ "$1" = "print" ]; then
+      echo "Permission denied while reading launchd state" >&2
+      exit 5
+    fi
+    exit 64
+    """
+    try launchctlScript.write(to: launchctlScriptURL, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: launchctlScriptURL.path)
+
+    let options = LaunchAgentStatusOptions(
+        label: "com.gaelic-ghost.test-launch-agent",
+        plistPath: plistURL.path,
+        launchctlPath: launchctlScriptURL.path,
+        userDomain: "gui/501",
+    )
+
+    do {
+        _ = try options.statusSummary()
+        Issue.record("Expected launch-agent status to surface an unexpected launchctl print failure.")
+    } catch let error as LaunchAgentCommandError {
+        #expect(error.message.contains("unexpected failure"))
+        #expect(error.message.contains("Permission denied while reading launchd state"))
+    }
+}
+
 @Test func `healthcheck command parses custom probe options`() throws {
     let command = try SpeakSwiftlyServerToolCommand.parse(
         arguments: [

--- a/Tests/SpeakSwiftlyServerTests/LaunchAgentTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/LaunchAgentTests.swift
@@ -68,6 +68,57 @@ import Testing
     }
 }
 
+@Test func `launch agent uninstall waits for delayed launchctl teardown`() throws {
+    let temporaryRootURL = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: temporaryRootURL, withIntermediateDirectories: true)
+
+    let plistURL = temporaryRootURL.appendingPathComponent("SpeakSwiftlyServer.plist", isDirectory: false)
+    try "plist".write(to: plistURL, atomically: true, encoding: .utf8)
+
+    let serviceStateURL = temporaryRootURL.appendingPathComponent("service-loaded", isDirectory: false)
+    try "loaded".write(to: serviceStateURL, atomically: true, encoding: .utf8)
+
+    let launchctlScriptURL = temporaryRootURL.appendingPathComponent("launchctl", isDirectory: false)
+    let launchctlScript = """
+    #!/bin/sh
+    STATE_FILE="\(serviceStateURL.path)"
+
+    case "$1" in
+      print)
+        if [ -f "$STATE_FILE" ]; then
+          exit 0
+        fi
+        exit 113
+        ;;
+      bootout)
+        (
+          sleep 0.2
+          rm -f "$STATE_FILE"
+        ) &
+        exit 0
+        ;;
+      *)
+        exit 64
+        ;;
+    esac
+    """
+    try launchctlScript.write(to: launchctlScriptURL, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: launchctlScriptURL.path)
+
+    let options = LaunchAgentStatusOptions(
+        label: "com.gaelic-ghost.test-launch-agent",
+        plistPath: plistURL.path,
+        launchctlPath: launchctlScriptURL.path,
+        userDomain: "gui/501",
+    )
+
+    try options.uninstall()
+
+    #expect(FileManager.default.fileExists(atPath: plistURL.path) == false)
+    #expect(FileManager.default.fileExists(atPath: serviceStateURL.path) == false)
+}
+
 @Test func `healthcheck command parses custom probe options`() throws {
     let command = try SpeakSwiftlyServerToolCommand.parse(
         arguments: [

--- a/Tests/SpeakSwiftlyServerTests/MockRuntime+ProfilesAndArtifacts.swift
+++ b/Tests/SpeakSwiftlyServerTests/MockRuntime+ProfilesAndArtifacts.swift
@@ -87,6 +87,9 @@ extension MockRuntime {
     func listVoiceProfiles() async -> RuntimeRequestHandle {
         let requestID = UUID().uuidString
         listVoiceProfilesCallCount += 1
+        if !scriptedProfileRefreshSnapshots.isEmpty {
+            profiles = scriptedProfileRefreshSnapshots.removeFirst()
+        }
         let profiles = profiles
         let events = AsyncThrowingStream<SpeakSwiftly.RequestEvent, Error> { continuation in
             continuation.yield(.completed(SpeakSwiftly.Success(id: requestID, profiles: profiles, activeRequests: nil)))

--- a/Tests/SpeakSwiftlyServerTests/MockRuntime+RuntimeControls.swift
+++ b/Tests/SpeakSwiftlyServerTests/MockRuntime+RuntimeControls.swift
@@ -69,7 +69,7 @@ extension MockRuntime {
     func generationQueue() async -> RuntimeRequestHandle {
         let requestID = UUID().uuidString
         generationQueueRequestCount += 1
-        let activeRequest = activeRequest.map(activeSummary(for:))
+        let activeRequest = activeRequest.map { activeSummary(for: $0) }
         let queue = queuedSummaries()
         let events = AsyncThrowingStream<SpeakSwiftly.RequestEvent, Error> { continuation in
             continuation.yield(
@@ -90,7 +90,7 @@ extension MockRuntime {
     func playbackQueue() async -> RuntimeRequestHandle {
         let requestID = UUID().uuidString
         playbackQueueRequestCount += 1
-        let activeRequest = playbackState == .idle ? nil : activeRequest.map(activeSummary(for:))
+        let activeRequest = playbackState == .idle ? nil : activeRequest.map { activeSummary(for: $0) }
         let events = AsyncThrowingStream<SpeakSwiftly.RequestEvent, Error> { continuation in
             continuation.yield(
                 .completed(

--- a/Tests/SpeakSwiftlyServerTests/MockRuntime+TestControl.swift
+++ b/Tests/SpeakSwiftlyServerTests/MockRuntime+TestControl.swift
@@ -129,7 +129,7 @@ extension MockRuntime {
     func playbackStateSummary() -> SpeakSwiftly.PlaybackStateSnapshot {
         .init(
             state: playbackState,
-            activeRequest: playbackState == .idle ? nil : activeRequest.map(activeSummary(for:)),
+            activeRequest: playbackState == .idle ? nil : activeRequest.map { activeSummary(for: $0) },
             isStableForConcurrentGeneration: playbackState == .playing,
             isRebuffering: false,
             stableBufferedAudioMS: playbackState == .playing ? 320 : nil,
@@ -138,14 +138,14 @@ extension MockRuntime {
     }
 
     func runtimeOverviewSummary() -> SpeakSwiftly.RuntimeOverview {
-        let generationActiveRequest = activeRequest.map(activeSummary(for:))
+        let generationActiveRequest = activeRequest.map { activeSummary(for: $0) }
         let generationQueue = SpeakSwiftly.QueueSnapshot(
             queueType: "generation",
             activeRequest: generationActiveRequest,
             activeRequests: generationActiveRequest.map { [$0] },
             queue: queuedSummaries(),
         )
-        let playbackActiveRequest = playbackState == .idle ? nil : activeRequest.map(activeSummary(for:))
+        let playbackActiveRequest = playbackState == .idle ? nil : activeRequest.map { activeSummary(for: $0) }
         let playbackQueue = SpeakSwiftly.QueueSnapshot(
             queueType: "playback",
             activeRequest: playbackActiveRequest,

--- a/Tests/SpeakSwiftlyServerTests/MockRuntime.swift
+++ b/Tests/SpeakSwiftlyServerTests/MockRuntime.swift
@@ -89,6 +89,7 @@ actor MockRuntime: ServerRuntimeProtocol {
     var generatedBatches = [SpeakSwiftly.GeneratedBatch]()
     var generationJobs = [SpeakSwiftly.GenerationJob]()
     var listVoiceProfilesCallCount = 0
+    var scriptedProfileRefreshSnapshots = [[SpeakSwiftly.ProfileSummary]]()
     var generationQueueRequestCount = 0
     var playbackQueueRequestCount = 0
     var playbackStateRequestCount = 0
@@ -105,12 +106,14 @@ actor MockRuntime: ServerRuntimeProtocol {
         mutationRefreshBehavior: MutationRefreshBehavior = .applyMutations,
         textProfileTransportError: SpeakSwiftly.Error? = nil,
         startBehavior: StartBehavior = .immediate,
+        scriptedProfileRefreshSnapshots: [[SpeakSwiftly.ProfileSummary]] = [],
     ) {
         self.profiles = profiles
         self.speakBehavior = speakBehavior
         self.mutationRefreshBehavior = mutationRefreshBehavior
         self.textProfileTransportError = textProfileTransportError
         self.startBehavior = startBehavior
+        self.scriptedProfileRefreshSnapshots = scriptedProfileRefreshSnapshots
         let persistenceURL = FileManager.default
             .temporaryDirectory
             .appendingPathComponent("ServerTests", isDirectory: true)
@@ -167,6 +170,10 @@ actor MockRuntime: ServerRuntimeProtocol {
 
     func lifecycleCounts() -> (start: Int, shutdown: Int) {
         (startCallCount, shutdownCallCount)
+    }
+
+    func setScriptedProfileRefreshSnapshots(_ snapshots: [[SpeakSwiftly.ProfileSummary]]) {
+        scriptedProfileRefreshSnapshots = snapshots
     }
 
     func waitUntilStartReachesBarrier() async {

--- a/Tests/SpeakSwiftlyServerTests/MockRuntime.swift
+++ b/Tests/SpeakSwiftlyServerTests/MockRuntime.swift
@@ -135,8 +135,14 @@ actor MockRuntime: ServerRuntimeProtocol {
             waiter.resume()
         }
 
-        await withCheckedContinuation { continuation in
-            startReleaseContinuation = continuation
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                startReleaseContinuation = continuation
+            }
+        } onCancel: {
+            Task {
+                await self.cancelStartWait()
+            }
         }
     }
 
@@ -180,5 +186,10 @@ actor MockRuntime: ServerRuntimeProtocol {
         startReleaseContinuation?.resume()
         startReleaseContinuation = nil
         startBehavior = .immediate
+    }
+
+    func cancelStartWait() {
+        startReleaseContinuation?.resume()
+        startReleaseContinuation = nil
     }
 }

--- a/Tests/SpeakSwiftlyServerTests/SpeakSwiftlyServerTestFixtures.swift
+++ b/Tests/SpeakSwiftlyServerTests/SpeakSwiftlyServerTestFixtures.swift
@@ -85,7 +85,7 @@ struct GeneratedFileFixture: Codable {
     let voiceProfile: String
     let textProfile: String?
     let inputTextContext: SpeakSwiftly.InputTextContext?
-    let requestContext: SpeakSwiftly.RequestContext?
+    let requestContext: TextForSpeech.RequestContext?
     let sampleRate: Int
     let filePath: String
 
@@ -112,7 +112,7 @@ struct GenerationArtifactFixture: Codable {
     let voiceProfile: String
     let textProfile: String?
     let inputTextContext: SpeakSwiftly.InputTextContext?
-    let requestContext: SpeakSwiftly.RequestContext?
+    let requestContext: TextForSpeech.RequestContext?
 
     enum CodingKeys: String, CodingKey {
         case artifactID = "artifact_id"
@@ -134,7 +134,7 @@ struct GenerationJobItemFixture: Codable {
     let text: String
     let textProfile: String?
     let inputTextContext: SpeakSwiftly.InputTextContext?
-    let requestContext: SpeakSwiftly.RequestContext?
+    let requestContext: TextForSpeech.RequestContext?
 
     enum CodingKeys: String, CodingKey {
         case artifactID = "artifact_id"
@@ -253,7 +253,7 @@ func makeGeneratedFile(
     voiceProfile: String,
     textProfile: String?,
     inputTextContext: SpeakSwiftly.InputTextContext? = nil,
-    requestContext: SpeakSwiftly.RequestContext? = nil,
+    requestContext: TextForSpeech.RequestContext? = nil,
     sampleRate: Int,
     filePath: String,
 ) throws -> SpeakSwiftly.GeneratedFile {

--- a/docs/maintainers/release-workflow.md
+++ b/docs/maintainers/release-workflow.md
@@ -9,7 +9,7 @@ Historical release notes and release checklists live under [`docs/releases`](../
 The release surface is intentionally split by checkout authority:
 
 - use `release-prepare.sh` from a feature branch or worktree when the job is "validate this release candidate, push it, open or update the PR, and queue auto-merge"
-- use `release-publish.sh` from the release branch when the job is "cut the actual tag and GitHub release from the merged branch tip"
+- use `release-publish.sh` from the release branch when the job is "cut the actual tag and GitHub release from the merged branch tip without pushing the protected release branch"
 
 That split keeps branch and worktree automation convenient without letting an unmerged feature branch publish a release tag accidentally.
 
@@ -25,9 +25,11 @@ Run:
 scripts/repo-maintenance/release-publish.sh --version vX.Y.Z --skip-live-service-refresh
 ```
 
-That path is the only supported tagged-release publisher. It syncs local `main` with `origin/main`, validates the repo unless told not to, stages the release artifact, creates the annotated tag, pushes the branch and tag, creates the GitHub release, and optionally refreshes the local LaunchAgent-backed live service.
+That path is the only supported tagged-release publisher. It syncs local `main` with `origin/main`, validates the repo unless told not to, stages the release artifact, creates the annotated tag, pushes the tag, creates the GitHub release, and optionally refreshes the local LaunchAgent-backed live service.
 
 If local `main` is ahead of `origin/main`, stop there. Do not try to force the publish path through that unsynced checkout. Put those commits on a feature branch if needed, run `release-prepare.sh`, merge the PR, fast-forward local `main`, and only then return to `release-publish.sh`.
+
+Protected `main` updates belong entirely on the prepare side of the workflow. `release-publish.sh` assumes the exact commit you want to tag is already reachable on `origin/main` and on your fast-forwarded local `main`, so publish never needs to push the branch itself.
 
 ### Local Feature Branch
 
@@ -167,5 +169,6 @@ Current defaults:
 - `release-publish.sh` refuses to run from any branch other than the configured release branch
 - `release-publish.sh` syncs the local release branch with the remote before tagging
 - `release-publish.sh` refuses to publish if local release-branch commits are ahead of the remote
+- `release-publish.sh` pushes the release tag only; it does not push the release branch
 - protected `main` policies are expected to force release-candidate commits through a PR before publish
 - both flows require a clean worktree

--- a/docs/maintainers/source-layout.md
+++ b/docs/maintainers/source-layout.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document is the maintainer map for the current `SpeakSwiftly 3.x`-aligned source split. The goal is to keep future cleanup, review, and feature work landing in the smallest file family that already owns the relevant concern, instead of letting `ServerHost.swift`, one host extension, or one mixed test file grow back into a monolith.
+This document is the maintainer map for the current `SpeakSwiftly 4.x`-aligned source split. The goal is to keep future cleanup, review, and feature work landing in the smallest file family that already owns the relevant concern, instead of letting `ServerHost.swift`, one host extension, or one mixed test file grow back into a monolith.
 
 Historical release artifacts belong under [`docs/releases`](../releases/), and historical debugging writeups belong under [`docs/investigations`](../investigations/), not beside the active maintainer maps in this directory.
 

--- a/docs/maintainers/speakswiftly-api-coverage-matrix.md
+++ b/docs/maintainers/speakswiftly-api-coverage-matrix.md
@@ -10,7 +10,7 @@ It answers three concrete questions:
 2. Which public capabilities are intentionally adapted instead of mirrored exactly?
 3. Which transport is the right client contract for each capability: HTTP, MCP, both, or neither?
 
-Current baseline checked against the `SpeakSwiftly 3.2.3` package state resolved by this repository on `2026-04-21`. The root package now follows `SpeakSwiftly` with an up-to-next-major semantic-version requirement starting at `3.2.3`.
+Current baseline checked against the `SpeakSwiftly 4.0.1` package state resolved by this repository on `2026-04-23`. The root package now follows `SpeakSwiftly` with an up-to-next-major semantic-version requirement starting at `4.0.1`.
 
 ## Summary
 

--- a/docs/releases/v4.2.9-release-checklist.md
+++ b/docs/releases/v4.2.9-release-checklist.md
@@ -1,0 +1,51 @@
+# `v4.2.9` Release Checklist
+
+## Purpose
+
+This checklist is the maintainer-facing candidate path for `v4.2.9`.
+
+Use it when the release scope is the `SpeakSwiftly 4.0.1` dependency refresh plus the matching server-side compatibility pass in the test support layer and the simplified protected-branch release workflow.
+
+For the standing branch-versus-main release contract, keep using [release-workflow.md](../maintainers/release-workflow.md). This document is only the candidate-specific checklist and release-shape note for `v4.2.9`.
+
+## Proposed Release Number
+
+Target the next release as `v4.2.9`.
+
+That patch bump matches the current change shape:
+
+- no intentional break to the published HTTP, MCP, or embedded-server contract
+- dependency refresh to `SpeakSwiftly 4.0.1`
+- test-support compatibility alignment for the current upstream request-summary and request-context ownership model
+- release-workflow simplification so publish pushes only the release tag and never the protected `main` branch
+
+## Pre-Tag Checklist
+
+- keep the worktree clean before release preparation or publish
+- confirm the full gated validation set passes:
+
+```bash
+xcrun swift test
+```
+
+```bash
+SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test
+```
+
+## Suggested Release Notes Shape
+
+Center the release notes on four points:
+
+- the `SpeakSwiftly 4.0.1` dependency refresh
+- the small test-support compatibility realignment for the current upstream request-summary and request-context surface
+- the completed host, runtime, LaunchAgent, MCP, and E2E review queue that shipped alongside the dependency bump
+- the simplified protected-branch release contract where `release-publish.sh` pushes only the tag
+
+## Publish Reminder
+
+If this candidate moves forward, use the split release workflow rather than tagging directly from a feature branch:
+
+1. run `scripts/repo-maintenance/release-prepare.sh --version v4.2.9` from the feature branch or release candidate worktree
+2. let the PR merge back to `main`
+3. fast-forward local `main`
+4. run `scripts/repo-maintenance/release-publish.sh --version v4.2.9`

--- a/docs/releases/v4.2.9-release-notes.md
+++ b/docs/releases/v4.2.9-release-notes.md
@@ -1,0 +1,27 @@
+# v4.2.9 Release Notes
+
+## What changed
+
+- refreshed the resolved `SpeakSwiftly` dependency to [`4.0.1`](https://github.com/gaelic-ghost/SpeakSwiftly/releases/tag/v4.0.1)
+- realigned the server test-support layer with the current upstream request-summary and request-context model so the package stays green on the new major dependency line
+- completed the current server review queue across host reconciliation, runtime adapter hardening, MCP handler cleanup, embedded lifecycle behavior, LaunchAgent cleanup, and MCP E2E stream synchronization
+- simplified the protected-branch release workflow so `release-publish.sh` now pushes only the release tag after local `main` has been fast-forwarded to `origin/main`
+
+## Breaking changes
+
+- none in the published server HTTP, MCP, or embedded surfaces
+
+## Migration or upgrade notes
+
+- downstream consumers should treat this as a compatibility and workflow refresh for the current `SpeakSwiftly 4.0.1` line
+- maintainers should keep using `release-prepare.sh` for any branch push or PR merge work; `release-publish.sh` now assumes `main` is already synced and only pushes the tag
+
+## Verification performed
+
+```bash
+xcrun swift test --filter ServerTests
+```
+
+```bash
+SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test
+```

--- a/scripts/repo-maintenance/release-prepare.sh
+++ b/scripts/repo-maintenance/release-prepare.sh
@@ -120,7 +120,7 @@ if [ -z "$body_file" ]; then
 ## Release Prepare
 
 - prepares release candidate \`$RELEASE_TAG\`
-- leaves release artifact staging, final tag creation, and GitHub release publication for \`scripts/repo-maintenance/release-publish.sh\` after this pull request lands on \`$base_branch\`
+- leaves release artifact staging, final tag creation, tag push, and GitHub release publication for \`scripts/repo-maintenance/release-publish.sh\` after this pull request lands on \`$base_branch\`
 
 ## Publish Follow-Up
 
@@ -228,4 +228,4 @@ if [ "$wait_for_merge" = "true" ]; then
   fi
 fi
 
-log "Release prepare completed. After this PR merges, switch to $base_branch and run release-publish.sh for $RELEASE_TAG to stage the release artifact, tag it, and publish it."
+log "Release prepare completed. After this PR merges, switch to $base_branch and run release-publish.sh for $RELEASE_TAG to stage the release artifact, create the tag, push the tag, and publish the release."

--- a/scripts/repo-maintenance/release-publish.sh
+++ b/scripts/repo-maintenance/release-publish.sh
@@ -53,7 +53,7 @@ while [ "$#" -gt 0 ]; do
 Usage:
   release-publish.sh --mode <standard|submodule> --version <vX.Y.Z> [--skip-validate] [--skip-gh-release] [--refresh-live-service|--skip-live-service-refresh] [--live-service-config-file <path>] [--dry-run]
 
-This workflow is for the release branch only. It syncs local main with origin, validates the checkout, stages the tagged release artifact, creates the annotated tag, pushes the tag, creates the GitHub release object, and optionally refreshes the live service.
+This workflow is for the release branch only. It syncs local main with origin, validates the checkout, stages the tagged release artifact, creates the annotated tag, pushes the tag, creates the GitHub release object, and optionally refreshes the live service. It does not push the release branch itself; protected-branch updates stay on the release-prepare side of the workflow.
 USAGE
       exit 0
       ;;
@@ -115,13 +115,11 @@ else
   log "Created annotated tag $RELEASE_TAG."
 fi
 
-branch_name="$(ensure_named_branch)"
 if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
-  log "Would push branch $branch_name and tag $RELEASE_TAG to $(release_remote)."
+  log "Would push tag $RELEASE_TAG to $(release_remote)."
 else
-  git -C "$REPO_ROOT" push -u "$(release_remote)" "$branch_name"
   git -C "$REPO_ROOT" push "$(release_remote)" "$RELEASE_TAG"
-  log "Pushed branch $branch_name and tag $RELEASE_TAG."
+  log "Pushed tag $RELEASE_TAG."
 fi
 
 if [ "$REPO_MAINTENANCE_SKIP_GH_RELEASE" = "true" ]; then


### PR DESCRIPTION
## Release Prepare

- prepares release candidate `v4.2.9`
- leaves release artifact staging, final tag creation, tag push, and GitHub release publication for `scripts/repo-maintenance/release-publish.sh` after this pull request lands on `main`

## Publish Follow-Up

After this pull request merges, switch to `main` locally and run:

```bash
scripts/repo-maintenance/release-publish.sh --version v4.2.9 --skip-live-service-refresh
```
