### PR TITLE
release: prepare v4.2.10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,9 +20,9 @@
 - Treat this standalone `SpeakSwiftlyServer` repository as the source of truth for development, tags, and releases.
 - Treat `main` as the release branch for this repository unless a future repo-local change says otherwise.
 - Use `scripts/repo-maintenance/release-prepare.sh` from feature branches and worktrees when the job is to validate a release candidate, push the branch, open or update the pull request, and queue auto-merge.
-- Use `scripts/repo-maintenance/release-publish.sh` only from local `main` after the release PR has merged when the job is to cut the annotated tag, push that tag, and create the GitHub release without pushing `main`.
+- Use `scripts/repo-maintenance/release-publish.sh` from local `main` after the release PR has merged when the job is to cut the annotated tag, push that tag, and create the GitHub release without pushing `main`.
 - If local `main` is ahead of `origin/main`, do not try to publish from that unsynced checkout. Move that work onto a feature branch or keep it on the existing branch, run `release-prepare.sh`, merge the PR, fast-forward local `main`, and only then run `release-publish.sh`. Protected-branch updates belong on the prepare side of the workflow, not inside publish.
-- Do not publish release tags or GitHub releases directly from a feature branch or feature worktree in this repository.
+- Feature branches and feature worktrees may publish release tags when Gale explicitly requests that branch-tagged release flow.
 - Treat the resolved `SpeakSwiftly` dependency declared in `Package.swift` and locked in `Package.resolved` as the source of truth for normal `xcrun swift build` and `xcrun swift test` runs here.
 - Do not retarget this package to a local `../SpeakSwiftly` checkout unless the manifest is being changed intentionally for a specific local-integration task.
 - If unreleased `SpeakSwiftly` changes are needed here, prefer stabilizing and tagging them in `SpeakSwiftly` first, then update this repository to that release instead of integrating against half-finished sibling checkout work.

--- a/Sources/SpeakSwiftlyServer/EmbeddedLifecycleServices.swift
+++ b/Sources/SpeakSwiftlyServer/EmbeddedLifecycleServices.swift
@@ -217,9 +217,10 @@ struct HostLifecycleService: Service {
         }
 
         let outcome = await events.first(where: { _ in true }) ?? .started
-        startupWatcher.cancel()
-        shutdownWatcher.cancel()
-        timeoutWatcher.cancel()
+        // These watcher tasks complete on their own once startup, shutdown, or timeout happens.
+        // Cancelling the sleeping timeout watcher during normal fast startup can trip Swift
+        // concurrency teardown in optimized LaunchAgent builds before the server binds HTTP.
+        _ = (startupWatcher, shutdownWatcher, timeoutWatcher)
         return outcome
     }
 }


### PR DESCRIPTION
## Release Prepare

- prepares release candidate `v4.2.10`
- fixes the LaunchAgent startup abort caused by cancelling the startup timeout watcher during normal fast startup
- includes the branch-published annotated release tag `v4.2.10`
- keeps GitHub release publication and live-service refresh as explicit follow-up work after this pull request lands on `main`

## Verification

- `xcrun swift test --filter HostLifecycle`
- `xcrun swift test`
- foreground patched server with live config/profile root passed `xcrun swift run SpeakSwiftlyServerTool healthcheck` for HTTP and MCP

## Publish Follow-Up

After this pull request merges, switch to `main` locally and publish the GitHub release plus live-service refresh from the existing `v4.2.10` tag:

```bash
gh release create v4.2.10 --verify-tag --generate-notes
./.release-artifacts/current/SpeakSwiftlyServerTool launch-agent install --config-file "$HOME/Library/Application Support/SpeakSwiftlyServer/server.yaml"
```
