### PR TITLE
runtime: prepare v4.2.11

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "92d6f82e69cc0b96a449bdff5383cb06a31ac445a0811c59cc9c966f20035301",
+  "originHash" : "64e4d0dd2c4943afed104239e0289f5cb580c42af4851afc4c638580c4bcb299",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/SpeakSwiftly.git",
       "state" : {
-        "revision" : "d6cd554a15f4dbccc25579b46ffce1f832d7f119",
-        "version" : "4.0.1"
+        "revision" : "cae74e2196d4815aacecb7724afd00cadb52f92d",
+        "version" : "4.0.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
         .package(
             url: "https://github.com/gaelic-ghost/SpeakSwiftly.git",
-            from: "4.0.1",
+            from: "4.0.3",
         ),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "2.30.6"),
         .package(url: "https://github.com/gaelic-ghost/TextForSpeech.git", from: "0.17.0"),

--- a/Sources/SpeakSwiftlyServer/EmbeddedLifecycleServices.swift
+++ b/Sources/SpeakSwiftlyServer/EmbeddedLifecycleServices.swift
@@ -206,7 +206,7 @@ struct HostLifecycleService: Service {
 
         let timeoutWatcher = Task {
             do {
-                try await Task.sleep(for: startupTimeout)
+                try await hostLifecycleDelay(for: startupTimeout)
                 continuation.yield(.timedOut)
                 continuation.finish()
             } catch is CancellationError {

--- a/Sources/SpeakSwiftlyServer/Host/HostLifecycleDelay.swift
+++ b/Sources/SpeakSwiftlyServer/Host/HostLifecycleDelay.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+private final class HostLifecycleDelayState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Error>?
+    private var isResolved = false
+
+    func install(_ continuation: CheckedContinuation<Void, Error>) {
+        lock.lock()
+        if isResolved {
+            lock.unlock()
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+
+        self.continuation = continuation
+        lock.unlock()
+    }
+
+    func resume(returning result: Result<Void, Error>) {
+        let pendingContinuation: CheckedContinuation<Void, Error>?
+
+        lock.lock()
+        if isResolved {
+            lock.unlock()
+            return
+        }
+
+        isResolved = true
+        pendingContinuation = continuation
+        continuation = nil
+        lock.unlock()
+
+        guard let pendingContinuation else { return }
+
+        switch result {
+            case .success:
+                pendingContinuation.resume()
+            case let .failure(error):
+                pendingContinuation.resume(throwing: error)
+        }
+    }
+}
+
+func hostLifecycleDelay(for duration: Duration) async throws {
+    let state = HostLifecycleDelayState()
+    let interval = max(0, duration.timeInterval)
+
+    try await withTaskCancellationHandler {
+        try await withCheckedThrowingContinuation { continuation in
+            state.install(continuation)
+            DispatchQueue.global().asyncAfter(deadline: .now() + interval) {
+                state.resume(returning: .success(()))
+            }
+        }
+    } onCancel: {
+        state.resume(returning: .failure(CancellationError()))
+    }
+}
+
+private extension Duration {
+    var timeInterval: TimeInterval {
+        let components = components
+        let seconds = TimeInterval(components.seconds)
+        let fractionalSeconds = TimeInterval(components.attoseconds) / 1_000_000_000_000_000_000
+        return seconds + fractionalSeconds
+    }
+}


### PR DESCRIPTION
## Release Prepare

- prepares release candidate `v4.2.11`
- bumps SpeakSwiftly to `4.0.3`, which carries the playback delay fix and Swift 6.3 CI lane
- leaves release artifact staging, final tag creation, tag push, and GitHub release publication for `scripts/repo-maintenance/release-publish.sh` after this pull request lands on `main`

## Verification

- `swift build`
- `swift test`
- `SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter ServerTransportE2ETests`
- `scripts/repo-maintenance/release-prepare.sh --version v4.2.11 --title "runtime: prepare v4.2.11" --no-auto-merge`

## Publish Follow-Up

After this pull request merges, switch to `main` locally and run:

```bash
scripts/repo-maintenance/release-publish.sh --version v4.2.11 --skip-live-service-refresh
```
