### PR TITLE
ci: fix backend switch formatting

### DIFF
--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+JobTracking.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+JobTracking.swift
@@ -150,7 +150,6 @@ extension ServerHost {
             await record(.failed(failure), for: requestID, terminal: true)
             return
         }
-
         guard resolvedSpeechBackend == expectation.requestedSpeechBackend else {
             let failure = ServerFailureEvent(
                 id: requestID,

--- a/Sources/SpeakSwiftlyServer/Host/ServerHost+State.swift
+++ b/Sources/SpeakSwiftlyServer/Host/ServerHost+State.swift
@@ -261,6 +261,7 @@ extension ServerHost {
         guard case let .queued(queued) = event else {
             return nil
         }
+
         return queued.reason
     }
 

--- a/Tests/SpeakSwiftlyServerTests/HTTPWorkflowTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/HTTPWorkflowTests.swift
@@ -341,6 +341,7 @@ extension ServerTests {
                 guard transition.requestID == switchJobID, transition.state == "queued" else {
                     return nil
                 }
+
                 return transition
             }
             #expect(queuedTransition.activeSpeechBackend == "qwen3")


### PR DESCRIPTION
## Summary
- fix SwiftFormat guard spacing in the queued backend-switch follow-up
- keep the merged runtime behavior unchanged

## Verification
- bash scripts/repo-maintenance/validate-all.sh