### PR TITLE
Bump SpeakSwiftly to 4.0.6

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "881cebff30b331ce39cabff1a35ba2d0e80441266ecfd84765b581903c387549",
+  "originHash" : "3921ffc6400040b51fe1917e2a8bd1c79f9d61e94d73019372a5b79973be78fa",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/SpeakSwiftly.git",
       "state" : {
-        "revision" : "c2525c34a1fb4b50bafc78c23762d275e63ace5f",
-        "version" : "4.0.5"
+        "revision" : "28db32f234a2c75db70bb51f0fecab4be8355b9b",
+        "version" : "4.0.6"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
         .package(
             url: "https://github.com/gaelic-ghost/SpeakSwiftly.git",
-            from: "4.0.5",
+            from: "4.0.6",
         ),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "3.31.3"),
         .package(url: "https://github.com/gaelic-ghost/TextForSpeech.git", from: "0.18.6"),


### PR DESCRIPTION
## Summary
- bump the server's SpeakSwiftly dependency from 4.0.5 to 4.0.6
- lock the resolver to the release that normalizes VoiceDesign and imported clone profile reference audio
- keeps the HTTP/MCP server surfaces on the package implementation used by Qwen 0.6B and 1.7B conditioning

## Verification
- xcrun swift test
- sh scripts/repo-maintenance/validate-all.sh
- git diff --check