### PR TITLE
hooks: harden Codex TTS logging

### DIFF
--- a/.codex/hooks/stop-tts.mjs
+++ b/.codex/hooks/stop-tts.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { mkdir, readFile, writeFile, appendFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile, appendFile, rm } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -15,8 +15,12 @@ const runtimeBaseUrl = process.env.CODEX_HOOK_TTS_BASE_URL ?? "http://127.0.0.1:
 const liveSpeechEndpoint = new URL("/speech/live", runtimeBaseUrl).toString();
 const defaultProfileName = process.env.CODEX_HOOK_TTS_PROFILE_NAME ?? "default-femme";
 const skipContinuedTurns = (process.env.CODEX_HOOK_TTS_SKIP_CONTINUATIONS ?? "true") !== "false";
-const logFullPayload = (process.env.CODEX_HOOK_TTS_LOG_FULL_PAYLOAD ?? "true") !== "false";
+const skipStructuredMessages = (process.env.CODEX_HOOK_TTS_SKIP_STRUCTURED_MESSAGES ?? "true") !== "false";
+const logFullPayload = (process.env.CODEX_HOOK_TTS_LOG_FULL_PAYLOAD ?? "false") === "true";
 const maxSeenTurns = Number.parseInt(process.env.CODEX_HOOK_TTS_MAX_SEEN_TURNS ?? "200", 10);
+const stateLockDir = path.join(stateDir, "stop-tts-seen-turns.lock");
+const stateLockTimeoutMs = Number.parseInt(process.env.CODEX_HOOK_TTS_STATE_LOCK_TIMEOUT_MS ?? "3000", 10);
+const stateLockPollMs = Number.parseInt(process.env.CODEX_HOOK_TTS_STATE_LOCK_POLL_MS ?? "50", 10);
 
 async function readStdin() {
   const chunks = [];
@@ -48,6 +52,44 @@ async function saveSeenTurns(turns) {
   await writeFile(seenTurnsPath, `${JSON.stringify(turns.slice(-maxSeenTurns), null, 2)}\n`, "utf8");
 }
 
+async function removeDirectoryIfExists(directoryPath) {
+  try {
+    await rm(directoryPath, { recursive: true, force: true });
+  } catch {}
+}
+
+async function sleep(milliseconds) {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function withStateLock(operation) {
+  const deadline = Date.now() + stateLockTimeoutMs;
+  while (true) {
+    try {
+      await mkdir(stateLockDir);
+      break;
+    } catch (error) {
+      if (
+        error
+        && typeof error === "object"
+        && "code" in error
+        && error.code === "EEXIST"
+        && Date.now() < deadline
+      ) {
+        await sleep(stateLockPollMs);
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  try {
+    return await operation();
+  } finally {
+    await removeDirectoryIfExists(stateLockDir);
+  }
+}
+
 async function appendLog(entry) {
   const serialized = `${JSON.stringify({ timestamp: new Date().toISOString(), ...entry })}\n`;
   await appendFile(logPath, serialized, "utf8");
@@ -67,11 +109,92 @@ function payloadLogFields(rawInput, payload) {
   };
 }
 
+function structuredMessageReason(message) {
+  if (!skipStructuredMessages) return null;
+  const trimmed = message.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return null;
+
+  let parsed = null;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (Array.isArray(parsed)) return null;
+  if (!parsed || typeof parsed !== "object") return null;
+
+  const keys = Object.keys(parsed);
+  const compactMetadataKeys = new Set(["title", "suggestions", "exclude"]);
+  if (keys.length > 0 && keys.every((key) => compactMetadataKeys.has(key))) {
+    return "structured-assistant-metadata";
+  }
+
+  return null;
+}
+
+function stringAttribute(value) {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (typeof value === "boolean" || typeof value === "number") return String(value);
+  return null;
+}
+
+function speechRequestBody(message, payload, profileName) {
+  const {
+    session_id: sessionId = null,
+    turn_id: turnId = null,
+    transcript_path: transcriptPath = null,
+    cwd = null,
+    model = null,
+    permission_mode: permissionMode = null,
+    hook_event_name: hookEventName = null,
+  } = payload;
+
+  const attributes = Object.fromEntries(
+    Object.entries({
+      session_id: sessionId,
+      turn_id: turnId,
+      transcript_path: transcriptPath,
+      model,
+      permission_mode: permissionMode,
+      hook_event_name: hookEventName,
+    })
+      .map(([key, value]) => [key, stringAttribute(value)])
+      .filter(([, value]) => value !== null),
+  );
+
+  return {
+    text: message,
+    profile_name: profileName,
+    cwd: typeof cwd === "string" && cwd.length > 0 ? cwd : undefined,
+    request_context: {
+      source: "codex-stop-hook",
+      app: "Codex",
+      agent: model,
+      project: typeof cwd === "string" && cwd.length > 0 ? path.basename(cwd) : undefined,
+      topic: "assistant-final-reply",
+      attributes,
+    },
+  };
+}
+
 async function main() {
   await ensureRuntimePaths();
 
   const rawInput = await readStdin();
-  const payload = rawInput.trim().length > 0 ? JSON.parse(rawInput) : {};
+  let payload = {};
+  try {
+    payload = rawInput.trim().length > 0 ? JSON.parse(rawInput) : {};
+  } catch (error) {
+    await appendLog({
+      outcome: "skipped",
+      reason: "invalid-json-payload",
+      rawPayloadPreview: rawInput.slice(0, 500),
+      error: error instanceof Error ? { message: error.message } : String(error),
+    });
+    return;
+  }
+
   const {
     session_id: sessionId = null,
     turn_id: turnId = null,
@@ -117,11 +240,11 @@ async function main() {
     return;
   }
 
-  const seenTurns = await loadSeenTurns();
-  if (dedupeKey && seenTurns.includes(dedupeKey)) {
+  const structuredReason = structuredMessageReason(message);
+  if (structuredReason) {
     await appendLog({
       outcome: "skipped",
-      reason: "duplicate-turn",
+      reason: structuredReason,
       sessionId,
       turnId,
       stopHookActive,
@@ -134,16 +257,61 @@ async function main() {
     return;
   }
 
-  const response = await fetch(liveSpeechEndpoint, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({
-      text: message,
-      profile_name: defaultProfileName,
-    }),
-  });
+  if (dedupeKey) {
+    const reservedTurn = await withStateLock(async () => {
+      const seenTurns = await loadSeenTurns();
+      if (seenTurns.includes(dedupeKey)) {
+        return false;
+      }
+      seenTurns.push(dedupeKey);
+      await saveSeenTurns(seenTurns);
+      return true;
+    });
+
+    if (!reservedTurn) {
+      await appendLog({
+        outcome: "skipped",
+        reason: "duplicate-turn",
+        sessionId,
+        turnId,
+        stopHookActive,
+        transcriptPath,
+        cwd,
+        model,
+        preview: message.slice(0, 160),
+        ...fullPayloadLog,
+      });
+      return;
+    }
+  }
+
+  let response = null;
+  try {
+    response = await fetch(liveSpeechEndpoint, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(speechRequestBody(message, payload, defaultProfileName)),
+    });
+  } catch (error) {
+    await appendLog({
+      outcome: "error",
+      reason: "speech-route-unreachable",
+      sessionId,
+      turnId,
+      stopHookActive,
+      transcriptPath,
+      cwd,
+      model,
+      profileName: defaultProfileName,
+      endpoint: liveSpeechEndpoint,
+      preview: message.slice(0, 160),
+      error: error instanceof Error ? { message: error.message, cause: String(error.cause ?? "") } : String(error),
+      ...fullPayloadLog,
+    });
+    return;
+  }
 
   const responseBody = await response.text();
   if (!response.ok) {
@@ -165,11 +333,6 @@ async function main() {
       ...fullPayloadLog,
     });
     return;
-  }
-
-  if (dedupeKey) {
-    seenTurns.push(dedupeKey);
-    await saveSeenTurns(seenTurns);
   }
 
   let parsedResponse = null;
@@ -198,11 +361,9 @@ async function main() {
 main().catch(async (error) => {
   try {
     await ensureRuntimePaths();
-    const rawInput = await readStdin().catch(() => "");
     await appendLog({
       outcome: "error",
       reason: "unexpected-hook-failure",
-      ...(logFullPayload ? { rawPayload: rawInput } : {}),
       error: error instanceof Error ? { message: error.message, stack: error.stack } : String(error),
     });
   } catch {}

--- a/docs/codex-hooks-tts.md
+++ b/docs/codex-hooks-tts.md
@@ -14,6 +14,9 @@ final assistant replies and inspecting Codex notification payloads.
   Reads the Codex `Stop` payload from `stdin`, skips empty or duplicate turns,
   ignores continuation passes by default, and queues speech through the local
   `SpeakSwiftlyServer` HTTP route at `POST /speech/live`.
+  The hook now reserves a turn before posting to the speech route, under a
+  small local state lock, so concurrent duplicate `Stop` invocations for the
+  same `session_id + turn_id` do not queue duplicate audio jobs.
 - `.codex/hooks/notify-dump.mjs`
   Records whatever Codex passes to the `notify` command so we can inspect the
   real payload shape. The probe captures both the documented JSON argument and
@@ -42,8 +45,64 @@ The `Stop` hook script accepts a few optional environment overrides:
 - `CODEX_HOOK_TTS_SKIP_CONTINUATIONS`
   Defaults to `true`. Set to `false` if you want continued `Stop` turns read
   aloud too.
+- `CODEX_HOOK_TTS_SKIP_STRUCTURED_MESSAGES`
+  Defaults to `true`. Skips compact structured assistant payloads such as
+  `{"title":"..."}`, `{"suggestions":[...]}`, and `{"exclude":[...]}` because
+  those are UI or automation metadata rather than speakable final prose.
+- `CODEX_HOOK_TTS_LOG_FULL_PAYLOAD`
+  Defaults to `false`. Set to `true` only during focused debugging when the log
+  needs the full raw Codex hook payload and parsed payload.
 - `CODEX_HOOK_TTS_MAX_SEEN_TURNS`
   Controls how many dedupe keys are retained in the local state file.
+- `CODEX_HOOK_TTS_STATE_LOCK_TIMEOUT_MS`
+  Defaults to `3000`. Controls how long a hook process waits for the local
+  dedupe-state lock before logging an unexpected hook failure.
+- `CODEX_HOOK_TTS_STATE_LOCK_POLL_MS`
+  Defaults to `50`. Controls how frequently a waiting hook process retries the
+  local dedupe-state lock.
+
+## Runtime Insights
+
+The ignored logs under `.codex/logs/` have turned out to be useful as a small
+operator observability surface:
+
+- `Stop` is the right TTS trigger because it carries the final assistant text
+  in `last_assistant_message`.
+- `notify` is a good payload probe, but the observed Desktop process often runs
+  the notify command with process `cwd` as `/`; use the event's own `cwd` field
+  when interpreting where the turn happened.
+- Duplicate `Stop` invocations can happen for the same `session_id + turn_id`,
+  so state reservation must happen before the hook posts speech.
+- Some assistant messages are compact JSON metadata used by Codex UI or
+  automation flows. Those should be logged and skipped, not spoken aloud.
+- The speech route can distinguish a reachable-but-not-ready runtime from an
+  unreachable runtime:
+  - HTTP `503` with `SpeakSwiftly is not ready yet...` means the server is up
+    but not accepting speech work.
+  - `speech-route-unreachable` means the hook could not reach the local
+    `SpeakSwiftlyServer` route at all.
+
+The hook also sends `request_context` with each queued speech request. That
+keeps Codex-originated speech inspectable through the existing
+`SpeakSwiftlyServer` request model without adding a hook-specific server API.
+The context includes the Codex model, permission mode, transcript path, session
+id, turn id, and event name when those fields are available.
+
+## Product Ideas From The Logs
+
+The current hook logs suggest a few reusable surfaces for this repo and sibling
+products:
+
+- A small queue inspector could group speech requests by `request_context`
+  source, project, model, and turn id so Codex-, app-, browser-, and editor-
+  originated speech are easy to tell apart.
+- A readiness widget could expose the difference between “server reachable but
+  not ready” and “route unreachable,” which is more actionable than a single
+  failed/success state.
+- A future Codex or editor integration should treat structured assistant
+  metadata as UI state, not spoken text.
+- `notify` payloads are a promising source for client identity and input-turn
+  summaries, while `Stop` remains the safer source for speakable final replies.
 
 ## Validation Notes
 
@@ -55,6 +114,8 @@ documentation:
 - `Stop` must not emit plain text on `stdout`.
 - repo-local hooks should resolve from the git root or another stable path, not
   by assuming the session `cwd` is the repository root.
+- `notify` is a top-level Codex configuration command that receives a JSON
+  payload from Codex; it is not nested under `[features]`.
 
 The `Stop` hook script matches that current payload shape and was validated with
 a synthetic `Stop` payload plus real runtime requests queued through the local


### PR DESCRIPTION
## Summary
- reserve Stop hook turns before posting speech so duplicate hook processes do not queue duplicate audio
- skip compact structured assistant metadata and log full Codex payloads only when explicitly enabled
- send Codex turn metadata through request_context and document log-derived product insights

## Verification
- node --check .codex/hooks/stop-tts.mjs && node --check .codex/hooks/notify-dump.mjs
- synthetic hook validation: invalid JSON, structured metadata skip, duplicate Stop race, request_context POST
- bash scripts/repo-maintenance/validate-all.sh