### PR TITLE
runtime: keep launchagent config alias out of caches

### DIFF
--- a/Sources/SpeakSwiftlyServer/AppManagedInstallLayout.swift
+++ b/Sources/SpeakSwiftlyServer/AppManagedInstallLayout.swift
@@ -79,6 +79,9 @@ public struct ServerInstallLayout: Codable, Sendable, Equatable {
         let cacheDirectoryURL = fileManager
             .urls(for: .cachesDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("SpeakSwiftlyServer", isDirectory: true)
+        let launchAgentSupportDirectoryURL = homeDirectoryURL
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("SpeakSwiftlyServer", isDirectory: true)
         let logsDirectoryURL = fileManager
             .urls(for: .libraryDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("Logs", isDirectory: true)
@@ -104,7 +107,8 @@ public struct ServerInstallLayout: Codable, Sendable, Equatable {
             launchAgentsDirectoryURL: launchAgentsDirectoryURL,
             launchAgentPlistURL: launchAgentPlistURL,
             serverConfigFileURL: applicationSupportDirectoryURL.appendingPathComponent("server.yaml", isDirectory: false),
-            launchAgentConfigAliasURL: cacheDirectoryURL.appendingPathComponent("launch-agent-server.yaml", isDirectory: false),
+            launchAgentConfigAliasURL: launchAgentSupportDirectoryURL
+                .appendingPathComponent("launch-agent-server.yaml", isDirectory: false),
             runtimeBaseDirectoryURL: runtimeBaseDirectoryURL,
             runtimeProfileRootURL: runtimeProfileRootURL,
             runtimeConfigurationFileURL: runtimeConfigurationFileURL,

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentRuntime.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentRuntime.swift
@@ -94,8 +94,10 @@ struct LaunchAgentStatusOptions {
         }
     }
 
-    func removeStagedConfigAliasIfPresent() throws {
-        let layout = ServerInstallLayout.defaultForCurrentUser(launchAgentLabel: label)
+    func removeStagedConfigAliasIfPresent(
+        layout: ServerInstallLayout? = nil,
+    ) throws {
+        let layout = layout ?? ServerInstallLayout.defaultForCurrentUser(launchAgentLabel: label)
         let aliasPath = layout.launchAgentConfigAliasURL.path
         guard FileManager.default.fileExists(atPath: aliasPath) else {
             return

--- a/Tests/SpeakSwiftlyServerTests/InstallLayoutTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/InstallLayoutTests.swift
@@ -83,7 +83,21 @@ import Testing
     #expect(snapshot.stderr.lines.isEmpty)
 }
 
-@Test func `launch agent environment uses cache alias when config path contains spaces`() throws {
+@Test func `default install layout keeps launch agent config alias outside cache`() throws {
+    let homeDirectory = try makeTemporaryDirectory()
+    let layout = ServerInstallLayout.defaultForCurrentUser(homeDirectoryURL: homeDirectory)
+
+    #expect(
+        layout.launchAgentConfigAliasURL.path
+            == homeDirectory.appendingPathComponent(
+                "Library/SpeakSwiftlyServer/launch-agent-server.yaml",
+                isDirectory: false,
+            )
+            .path,
+    )
+}
+
+@Test func `launch agent environment uses durable alias when config path contains spaces`() throws {
     let tempDirectory = try makeTemporaryDirectory()
     let layout = ServerInstallLayout(
         launchAgentLabel: "com.example.test",

--- a/Tests/SpeakSwiftlyServerTests/LaunchAgentTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/LaunchAgentTests.swift
@@ -144,7 +144,7 @@ import Testing
         userDomain: "gui/501",
     )
 
-    try options.removeStagedConfigAliasIfPresent()
+    try options.removeStagedConfigAliasIfPresent(layout: layout)
     #expect(FileManager.default.fileExists(atPath: layout.launchAgentConfigAliasURL.path) == false)
 }
 

--- a/docs/maintainers/live-service-reliability-follow-ups.md
+++ b/docs/maintainers/live-service-reliability-follow-ups.md
@@ -14,7 +14,9 @@ The live service had two separate issues that combined into one confusing operat
 1. The LaunchAgent had been installed without `APP_CONFIG_FILE`, so the service fell back to built-in defaults and kept the MCP transport disabled.
 2. Once a real config file was supplied, the current config-loading path failed when `APP_CONFIG_FILE` pointed at `~/Library/Application Support/SpeakSwiftlyServer/server.yaml`, because that path contains spaces.
 
-The `v2.0.4` fix keeps the canonical config file in Application Support, but stages a copied LaunchAgent-owned alias config under `~/Library/Caches/SpeakSwiftlyServer/launch-agent-server.yaml` whenever the canonical path contains spaces. The LaunchAgent environment now points at that cache copy instead of the spaced canonical path.
+The `v2.0.4` fix kept the canonical config file in Application Support, but staged a copied LaunchAgent-owned alias config under `~/Library/Caches/SpeakSwiftlyServer/launch-agent-server.yaml` whenever the canonical path contained spaces. The LaunchAgent environment pointed at that cache copy instead of the spaced canonical path.
+
+The `v4.3.4` follow-up moves that alias to `~/Library/SpeakSwiftlyServer/launch-agent-server.yaml`. The alias still avoids the `Application Support` space that exposed the original config-provider bug, but it no longer depends on a cache directory that macOS or maintenance tooling can remove independently of the installed LaunchAgent plist.
 
 ## Reliability Follow-Ups
 
@@ -27,6 +29,7 @@ The intended flow is:
 - create a temporary per-user style install layout whose canonical config file lives under an `Application Support` path with spaces
 - run the LaunchAgent install path against the staged release artifact
 - confirm that the installed property list uses the alias config path instead of the canonical path
+- confirm that the default alias path is durable install support under `~/Library/SpeakSwiftlyServer`, not disposable cache state
 - boot the service
 - probe `GET /runtime/host`
 - probe MCP `initialize` over `POST /mcp`


### PR DESCRIPTION
## Release Prepare

- prepares release candidate `v4.3.4`
- leaves release artifact staging, final tag creation, tag push, and GitHub release publication for `scripts/repo-maintenance/release-publish.sh` after this pull request lands on `main`

## Publish Follow-Up

After this pull request merges, switch to `main` locally and run:

```bash
scripts/repo-maintenance/release-publish.sh --version v4.3.4 --skip-live-service-refresh
```
