### PR TITLE
release: prepare v4.3.5

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3921ffc6400040b51fe1917e2a8bd1c79f9d61e94d73019372a5b79973be78fa",
+  "originHash" : "96091a92dad174e4a29a5add14f7b23a6b138097659a3b2c070662099a0af248",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/SpeakSwiftly.git",
       "state" : {
-        "revision" : "28db32f234a2c75db70bb51f0fecab4be8355b9b",
-        "version" : "4.0.6"
+        "revision" : "dfe21abd1840229c2201d884e303a3bd60f2a86e",
+        "version" : "4.0.7"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -60,6 +60,9 @@ let package = Package(
                 .product(name: "TextForSpeech", package: "TextForSpeech"),
             ],
             path: "Sources/SpeakSwiftlyServer",
+            resources: [
+                .process("Resources"),
+            ],
         ),
         .executableTarget(
             name: "SpeakSwiftlyServerTool",

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
         .package(
             url: "https://github.com/gaelic-ghost/SpeakSwiftly.git",
-            from: "4.0.6",
+            from: "4.0.7",
         ),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "3.31.3"),
         .package(url: "https://github.com/gaelic-ghost/TextForSpeech.git", from: "0.18.6"),

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The shared server supports these environment variables:
 - `APP_MCP_TITLE`
 - `SPEAKSWIFTLY_PROFILE_ROOT`
 
-If `APP_CONFIG_FILE` points at a YAML file, the server loads it through [swift-configuration](https://github.com/apple/swift-configuration), with environment variables taking precedence over YAML and YAML taking precedence over built-in defaults.
+If `APP_CONFIG_FILE` points at a YAML file, the server loads it through the package's Foundation URL-backed YAML provider and [swift-configuration](https://github.com/apple/swift-configuration), with environment variables taking precedence over YAML and YAML taking precedence over built-in defaults. Missing config files fail startup loudly. LaunchAgent install and refresh paths seed the default `~/Library/Application Support/SpeakSwiftlyServer/server.yaml` from the bundled template when that canonical file is missing.
 
 ```yaml
 app:

--- a/Sources/SpeakSwiftlyServer/AppManagedInstallLayout.swift
+++ b/Sources/SpeakSwiftlyServer/AppManagedInstallLayout.swift
@@ -21,7 +21,7 @@ public struct ServerInstallLayout: Codable, Sendable, Equatable {
     public let launchAgentPlistURL: URL
     /// The durable server config file an app should manage for the standalone server.
     public let serverConfigFileURL: URL
-    /// The alias config file path used when the real config path is not LaunchAgent-friendly.
+    /// The legacy alias config file path used by older LaunchAgent installs.
     public let launchAgentConfigAliasURL: URL
     /// The runtime state root used by the installed server process.
     public let runtimeBaseDirectoryURL: URL
@@ -133,11 +133,7 @@ public struct ServerInstallLayout: Codable, Sendable, Equatable {
     }
 
     func launchAgentConfigPath(for configFilePath: String) -> String {
-        let standardizedPath = URL(fileURLWithPath: configFilePath).standardizedFileURL.path
-        if standardizedPath.contains(" ") {
-            return launchAgentConfigAliasURL.path
-        }
-        return standardizedPath
+        URL(fileURLWithPath: configFilePath).standardizedFileURL.path
     }
 }
 

--- a/Sources/SpeakSwiftlyServer/Config/ConfigStore.swift
+++ b/Sources/SpeakSwiftlyServer/Config/ConfigStore.swift
@@ -1,7 +1,6 @@
 import Configuration
 import Foundation
 import ServiceLifecycle
-import SystemPackage
 
 struct ConfigStore {
     enum Update {
@@ -12,7 +11,7 @@ struct ConfigStore {
     let reader: ConfigReader
     let services: [any Service]
 
-    private let reloadingProvider: ReloadingFileProvider<YAMLSnapshot>?
+    private let reloadingProvider: URLReloadingYAMLConfigProvider?
 
     // MARK: - Initialization
 
@@ -29,12 +28,11 @@ struct ConfigStore {
             environment: environment,
         )
 
-        var reloadingProvider: ReloadingFileProvider<YAMLSnapshot>?
+        var reloadingProvider: URLReloadingYAMLConfigProvider?
 
         if let configFilePath = environment["APP_CONFIG_FILE"], !configFilePath.isEmpty {
-            let provider = try await ReloadingFileProvider<YAMLSnapshot>(
-                filePath: FilePath(configFilePath),
-                allowMissing: false,
+            let provider = try await URLReloadingYAMLConfigProvider(
+                fileURL: URL(fileURLWithPath: configFilePath),
                 pollInterval: Self.reloadPollInterval(from: environment),
             )
             providers.append(provider)

--- a/Sources/SpeakSwiftlyServer/Config/DefaultServerConfig.swift
+++ b/Sources/SpeakSwiftlyServer/Config/DefaultServerConfig.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+enum DefaultServerConfig {
+    static let resourceName = "default-server"
+    static let resourceExtension = "yaml"
+
+    static func seedIfMissing(at configURL: URL, fileManager: FileManager = .default) throws -> Bool {
+        let destinationURL = configURL.standardizedFileURL
+        guard fileManager.fileExists(atPath: destinationURL.path) == false else {
+            return false
+        }
+        guard let defaultConfigURL = Bundle.module.url(
+            forResource: resourceName,
+            withExtension: resourceExtension,
+        ) else {
+            throw LaunchAgentCommandError(
+                """
+                \(speakSwiftlyServerToolName) could not seed the default LaunchAgent config because the bundled resource '\(resourceName).\(resourceExtension)' is missing.
+                Likely cause: the package resources were not included in the built SpeakSwiftlyServer module.
+                """,
+            )
+        }
+
+        do {
+            try fileManager.createDirectory(
+                at: destinationURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true,
+            )
+            try fileManager.copyItem(at: defaultConfigURL, to: destinationURL)
+            return true
+        } catch {
+            throw LaunchAgentCommandError(
+                """
+                \(speakSwiftlyServerToolName) could not seed the default LaunchAgent config at '\(destinationURL.path)'.
+                Likely cause: \(error.localizedDescription)
+                """,
+            )
+        }
+    }
+}

--- a/Sources/SpeakSwiftlyServer/Config/URLReloadingYAMLConfigProvider.swift
+++ b/Sources/SpeakSwiftlyServer/Config/URLReloadingYAMLConfigProvider.swift
@@ -1,0 +1,189 @@
+import AsyncAlgorithms
+import Configuration
+import Foundation
+import ServiceLifecycle
+
+final class URLReloadingYAMLConfigProvider: ConfigProvider, Service, @unchecked Sendable {
+    private struct FileSource: Equatable {
+        var modifiedAt: Date
+        var size: UInt64
+    }
+
+    private struct Storage {
+        var snapshot: any ConfigSnapshot
+        var source: FileSource
+        var valueWatchers: [AbsoluteConfigKey: [UUID: AsyncStream<Result<LookupResult, any Error>>.Continuation]]
+        var snapshotWatchers: [UUID: AsyncStream<any ConfigSnapshot>.Continuation]
+    }
+
+    let providerName = "URLReloadingYAMLConfigProvider"
+
+    private let fileURL: URL
+    private let pollInterval: Duration
+    private let lock = NSLock()
+    private var storage: Storage
+
+    init(fileURL: URL, pollInterval: Duration) async throws {
+        self.fileURL = fileURL.standardizedFileURL
+        self.pollInterval = pollInterval
+        let loadedFile = try Self.loadSnapshot(from: self.fileURL, providerName: providerName)
+        storage = Storage(
+            snapshot: loadedFile.snapshot,
+            source: loadedFile.source,
+            valueWatchers: [:],
+            snapshotWatchers: [:],
+        )
+    }
+
+    private static func loadSnapshot(
+        from fileURL: URL,
+        providerName: String,
+    ) throws -> (snapshot: any ConfigSnapshot, source: FileSource) {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            throw ServerConfigurationError(
+                "Configuration file '\(fileURL.path)' does not exist. Set APP_CONFIG_FILE to an existing YAML file or run launch-agent install to seed the default Application Support config.",
+            )
+        }
+
+        let attributes: [FileAttributeKey: Any]
+        do {
+            attributes = try fileManager.attributesOfItem(atPath: fileURL.path)
+        } catch {
+            throw ServerConfigurationError(
+                "Configuration file '\(fileURL.path)' exists but its file attributes could not be read. Likely cause: \(error.localizedDescription)",
+            )
+        }
+        guard let modifiedAt = attributes[.modificationDate] as? Date else {
+            throw ServerConfigurationError(
+                "Configuration file '\(fileURL.path)' is missing a modification timestamp, so reload checks cannot track it safely.",
+            )
+        }
+
+        let size = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
+
+        let data: Data
+        do {
+            data = try Data(contentsOf: fileURL)
+        } catch {
+            throw ServerConfigurationError(
+                "Configuration file '\(fileURL.path)' exists but could not be read. Likely cause: \(error.localizedDescription)",
+            )
+        }
+
+        let snapshot = try YAMLSnapshot(
+            data: data.bytes,
+            providerName: providerName,
+            parsingOptions: .default,
+        )
+        return (snapshot, FileSource(modifiedAt: modifiedAt, size: size))
+    }
+
+    func value(forKey key: AbsoluteConfigKey, type: ConfigType) throws -> LookupResult {
+        try lock.withLock {
+            try storage.snapshot.value(forKey: key, type: type)
+        }
+    }
+
+    func fetchValue(forKey key: AbsoluteConfigKey, type: ConfigType) async throws -> LookupResult {
+        try await reloadIfNeeded()
+        return try value(forKey: key, type: type)
+    }
+
+    nonisolated(nonsending) func watchValue<Return: ~Copyable>(
+        forKey key: AbsoluteConfigKey,
+        type: ConfigType,
+        updatesHandler: nonisolated(nonsending) (_ updates: ConfigUpdatesAsyncSequence<Result<LookupResult, any Error>, Never>) async throws ->
+            Return,
+    ) async throws -> Return {
+        let (stream, continuation) = AsyncStream<Result<LookupResult, any Error>>
+            .makeStream(bufferingPolicy: .bufferingNewest(1))
+        let id = UUID()
+        let initialValue: Result<LookupResult, any Error> = lock.withLock {
+            storage.valueWatchers[key, default: [:]][id] = continuation
+            return Result { try storage.snapshot.value(forKey: key, type: type) }
+        }
+        defer {
+            lock.withLock {
+                storage.valueWatchers[key, default: [:]][id] = nil
+            }
+        }
+
+        continuation.yield(initialValue)
+        return try await updatesHandler(.init(stream))
+    }
+
+    func snapshot() -> any ConfigSnapshot {
+        lock.withLock {
+            storage.snapshot
+        }
+    }
+
+    nonisolated(nonsending) func watchSnapshot<Return: ~Copyable>(
+        updatesHandler: nonisolated(nonsending) (_ updates: ConfigUpdatesAsyncSequence<any ConfigSnapshot, Never>) async throws -> Return,
+    ) async throws -> Return {
+        let (stream, continuation) = AsyncStream<any ConfigSnapshot>
+            .makeStream(bufferingPolicy: .bufferingNewest(1))
+        let id = UUID()
+        let initialSnapshot = lock.withLock {
+            storage.snapshotWatchers[id] = continuation
+            return storage.snapshot
+        }
+        defer {
+            lock.withLock {
+                storage.snapshotWatchers[id] = nil
+            }
+        }
+
+        continuation.yield(initialSnapshot)
+        return try await updatesHandler(.init(stream))
+    }
+
+    func run() async throws {
+        for try await _ in AsyncTimerSequence(interval: pollInterval, clock: .continuous)
+            .cancelOnGracefulShutdown() {
+            try await reloadIfNeeded()
+        }
+    }
+
+    private func reloadIfNeeded() async throws {
+        let loadedFile = try Self.loadSnapshot(from: fileURL, providerName: providerName)
+        let watchers = lock.withLock { () -> (
+            [AsyncStream<any ConfigSnapshot>.Continuation],
+            [(AbsoluteConfigKey, [AsyncStream<Result<LookupResult, any Error>>.Continuation])],
+        )? in
+            guard storage.source != loadedFile.source else {
+                return nil
+            }
+
+            storage.snapshot = loadedFile.snapshot
+            storage.source = loadedFile.source
+            return (
+                Array(storage.snapshotWatchers.values),
+                storage.valueWatchers.map { key, continuations in
+                    (key, Array(continuations.values))
+                },
+            )
+        }
+
+        guard let watchers else { return }
+
+        for continuation in watchers.0 {
+            continuation.yield(loadedFile.snapshot)
+        }
+        for (key, continuations) in watchers.1 {
+            let value = Result { try loadedFile.snapshot.value(forKey: key, type: .string) }
+            for continuation in continuations {
+                continuation.yield(value)
+            }
+        }
+    }
+}
+
+private extension NSLock {
+    func withLock<Return>(_ body: () throws -> Return) rethrows -> Return {
+        lock()
+        defer { unlock() }
+        return try body()
+    }
+}

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentOptions+Installation.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentOptions+Installation.swift
@@ -16,7 +16,7 @@ extension LaunchAgentOptions {
 
         let layout = ServerInstallLayout.defaultForCurrentUser(launchAgentLabel: label)
         let environmentVariables = layout.launchAgentEnvironmentVariables(
-            configFilePath: configFilePath,
+            configFilePath: effectiveConfigFilePath(layout: layout),
             reloadIntervalSeconds: reloadIntervalSeconds,
         )
         .merging(
@@ -52,7 +52,7 @@ extension LaunchAgentOptions {
         try FileManager.default.createDirectory(atPath: profileRootPath, withIntermediateDirectories: true)
         try ensureParentDirectory(for: standardOutPath)
         try ensureParentDirectory(for: standardErrorPath)
-        try stageLaunchAgentConfigAliasIfNeeded(layout: layout)
+        try prepareLaunchAgentConfig(layout: layout)
 
         try propertyListData().write(to: URL(fileURLWithPath: plistPath), options: .atomic)
         try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: plistPath)
@@ -121,32 +121,28 @@ extension LaunchAgentOptions {
         }
     }
 
-    private func stageLaunchAgentConfigAliasIfNeeded(layout: ServerInstallLayout) throws {
-        guard let configFilePath, !configFilePath.isEmpty else { return }
-
-        let canonicalConfigURL = URL(fileURLWithPath: configFilePath).standardizedFileURL
-        guard FileManager.default.fileExists(atPath: canonicalConfigURL.path) else {
-            throw LaunchAgentCommandError(
-                "\(speakSwiftlyServerToolName) could not install the LaunchAgent because the config file '\(canonicalConfigURL.path)' does not exist.",
-            )
+    func effectiveConfigFilePath(layout: ServerInstallLayout) -> String {
+        if let configFilePath, !configFilePath.isEmpty {
+            return URL(fileURLWithPath: configFilePath).standardizedFileURL.path
         }
 
-        let aliasedConfigPath = layout.launchAgentConfigPath(for: canonicalConfigURL.path)
-        guard aliasedConfigPath != canonicalConfigURL.path else { return }
+        return layout.serverConfigFileURL.standardizedFileURL.path
+    }
 
-        let aliasURL = URL(fileURLWithPath: aliasedConfigPath)
-        try ensureParentDirectory(for: aliasURL.path)
+    func prepareLaunchAgentConfig(layout: ServerInstallLayout) throws {
+        let effectiveConfigURL = URL(fileURLWithPath: effectiveConfigFilePath(layout: layout)).standardizedFileURL
+        let canonicalConfigURL = layout.serverConfigFileURL.standardizedFileURL
 
-        do {
-            if FileManager.default.fileExists(atPath: aliasURL.path) {
-                try FileManager.default.removeItem(at: aliasURL)
-            }
-            try FileManager.default.copyItem(at: canonicalConfigURL, to: aliasURL)
-        } catch {
+        if effectiveConfigURL.path == canonicalConfigURL.path {
+            _ = try DefaultServerConfig.seedIfMissing(at: canonicalConfigURL)
+            return
+        }
+
+        guard FileManager.default.fileExists(atPath: effectiveConfigURL.path) else {
             throw LaunchAgentCommandError(
                 """
-                \(speakSwiftlyServerToolName) could not stage the LaunchAgent config copy at '\(aliasURL.path)' from canonical config '\(canonicalConfigURL.path)'.
-                Likely cause: \(error.localizedDescription)
+                \(speakSwiftlyServerToolName) could not install the LaunchAgent because the explicit config file '\(effectiveConfigURL.path)' does not exist.
+                Use the default Application Support config at '\(canonicalConfigURL.path)' to allow automatic seeding, or create the explicit config file before installing.
                 """,
             )
         }

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentRuntime.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentRuntime.swift
@@ -98,17 +98,19 @@ struct LaunchAgentStatusOptions {
         layout: ServerInstallLayout? = nil,
     ) throws {
         let layout = layout ?? ServerInstallLayout.defaultForCurrentUser(launchAgentLabel: label)
-        let aliasPath = layout.launchAgentConfigAliasURL.path
-        guard FileManager.default.fileExists(atPath: aliasPath) else {
-            return
-        }
+        let legacyAliasURLs = [
+            layout.launchAgentConfigAliasURL,
+            layout.cacheDirectoryURL.appendingPathComponent("launch-agent-server.yaml", isDirectory: false),
+        ]
 
-        do {
-            try FileManager.default.removeItem(atPath: aliasPath)
-        } catch {
-            throw LaunchAgentCommandError(
-                "\(speakSwiftlyServerToolName) could not remove the staged LaunchAgent config copy '\(aliasPath)' during uninstall. Likely cause: \(error.localizedDescription)",
-            )
+        for aliasURL in legacyAliasURLs where FileManager.default.fileExists(atPath: aliasURL.path) {
+            do {
+                try FileManager.default.removeItem(at: aliasURL)
+            } catch {
+                throw LaunchAgentCommandError(
+                    "\(speakSwiftlyServerToolName) could not remove the legacy staged LaunchAgent config copy '\(aliasURL.path)' during uninstall. Likely cause: \(error.localizedDescription)",
+                )
+            }
         }
     }
 

--- a/Sources/SpeakSwiftlyServer/Resources/default-server.yaml
+++ b/Sources/SpeakSwiftlyServer/Resources/default-server.yaml
@@ -1,0 +1,19 @@
+app:
+  name: speak-swiftly-server
+  environment: development
+  host: 127.0.0.1
+  port: 7337
+  sseHeartbeatSeconds: 10
+  completedJobTTLSeconds: 900
+  completedJobMaxCount: 200
+  jobPruneIntervalSeconds: 60
+  http:
+    enabled: true
+    host: 127.0.0.1
+    port: 7337
+    sseHeartbeatSeconds: 10
+  mcp:
+    enabled: true
+    path: /mcp
+    serverName: speak-swiftly-mcp
+    title: SpeakSwiftly

--- a/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/LaunchAgent-Workflow.md
+++ b/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/LaunchAgent-Workflow.md
@@ -26,6 +26,7 @@ That gives you the exact LaunchAgent payload the package currently wants to stag
 - the label
 - the `ProgramArguments` path and `serve` invocation
 - the working directory
+- the `APP_CONFIG_FILE` path for the canonical Application Support config
 - the stdout and stderr log files
 - the `SPEAKSWIFTLY_PROFILE_ROOT` environment override for the standalone server
 
@@ -33,12 +34,16 @@ That profile-root override is the LaunchAgent-owned profile-store root on the `S
 
 ## Install Or Refresh The Background Service
 
-Once the property list looks right, install it with the config file you want the background service to use:
+Once the property list looks right, install it. If no config file is supplied, the install path uses
+`~/Library/Application Support/SpeakSwiftlyServer/server.yaml` and seeds that file from the bundled
+default config when it is missing:
 
 ```bash
-xcrun swift run SpeakSwiftlyServerTool launch-agent install \
-  --config-file ./server.yaml
+xcrun swift run SpeakSwiftlyServerTool launch-agent install
 ```
+
+If you pass `--config-file`, custom paths must already exist. The default Application Support path is
+the only path that install and refresh flows seed automatically.
 
 This package's LaunchAgent path is designed around the staged release artifact, not around whichever debug binary happened to run the command. That keeps the installed service pointed at the package's maintained release surface instead of at a transient local build product.
 
@@ -64,7 +69,7 @@ xcrun swift run SpeakSwiftlyServerTool launch-agent uninstall
 keeps a plain remove flow aligned with the install and promote-live refresh flows, which already
 wait for launchd teardown before they try to bootstrap the next job incarnation.
 It also removes the staged LaunchAgent config alias copy from the managed install layout, so the
-remove flow now clears the launch-agent-owned config shim instead of leaving stale alias state
+remove flow now clears legacy launch-agent-owned config shims instead of leaving stale alias state
 behind after the job is gone.
 
 `status` now reports an explicit `load_state` field. A normal absent job shows `load_state: not_loaded`.

--- a/Tests/SpeakSwiftlyServerTests/ConfigTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/ConfigTests.swift
@@ -157,6 +157,43 @@ import Testing
     #expect(initialConfig.server.completedJobMaxCount == 25)
 }
 
+@Test func `config store loads application support yaml path with spaces directly`() async throws {
+    let applicationSupportDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        .appendingPathComponent("Application Support/SpeakSwiftlyServer", isDirectory: true)
+    try FileManager.default.createDirectory(at: applicationSupportDirectory, withIntermediateDirectories: true)
+    let yamlURL = applicationSupportDirectory.appendingPathComponent("server.yaml", isDirectory: false)
+    try """
+    app:
+      name: application-support-server
+      environment: development
+      host: 127.0.0.1
+      port: 7337
+      sseHeartbeatSeconds: 10
+      completedJobTTLSeconds: 900
+      completedJobMaxCount: 200
+      jobPruneIntervalSeconds: 60
+      http:
+        enabled: true
+        host: 127.0.0.1
+        port: 7337
+        sseHeartbeatSeconds: 10
+      mcp:
+        enabled: true
+        path: /mcp
+        serverName: speak-swiftly-mcp
+        title: SpeakSwiftly
+    """.write(to: yamlURL, atomically: true, encoding: .utf8)
+
+    let config = try await AppConfig.load(environment: ["APP_CONFIG_FILE": yamlURL.path])
+
+    #expect(yamlURL.path.contains("Application Support"))
+    #expect(config.server.name == "application-support-server")
+    #expect(config.server.port == 7337)
+    #expect(config.http.enabled)
+    #expect(config.mcp.enabled)
+}
+
 @Test func `host reports and persists runtime configuration state`() async throws {
     let runtime = MockRuntime()
     let state = await MainActor.run { EmbeddedServer() }

--- a/Tests/SpeakSwiftlyServerTests/InstallLayoutTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/InstallLayoutTests.swift
@@ -83,21 +83,16 @@ import Testing
     #expect(snapshot.stderr.lines.isEmpty)
 }
 
-@Test func `default install layout keeps launch agent config alias outside cache`() throws {
+@Test func `default install layout uses application support for canonical config`() throws {
     let homeDirectory = try makeTemporaryDirectory()
     let layout = ServerInstallLayout.defaultForCurrentUser(homeDirectoryURL: homeDirectory)
 
     #expect(
-        layout.launchAgentConfigAliasURL.path
-            == homeDirectory.appendingPathComponent(
-                "Library/SpeakSwiftlyServer/launch-agent-server.yaml",
-                isDirectory: false,
-            )
-            .path,
+        layout.serverConfigFileURL.path.contains("/Library/Application Support/SpeakSwiftlyServer/server.yaml"),
     )
 }
 
-@Test func `launch agent environment uses durable alias when config path contains spaces`() throws {
+@Test func `launch agent environment uses canonical config path when it contains spaces`() throws {
     let tempDirectory = try makeTemporaryDirectory()
     let layout = ServerInstallLayout(
         launchAgentLabel: "com.example.test",
@@ -121,7 +116,7 @@ import Testing
         reloadIntervalSeconds: nil,
     )
 
-    #expect(environmentVariables["APP_CONFIG_FILE"] == layout.launchAgentConfigAliasURL.path)
+    #expect(environmentVariables["APP_CONFIG_FILE"] == layout.serverConfigFileURL.standardizedFileURL.path)
     #expect(environmentVariables["SPEAKSWIFTLY_PROFILE_ROOT"] == layout.runtimeProfileRootURL.path)
 }
 

--- a/Tests/SpeakSwiftlyServerTests/LaunchAgentTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/LaunchAgentTests.swift
@@ -119,15 +119,20 @@ import Testing
     #expect(FileManager.default.fileExists(atPath: serviceStateURL.path) == false)
 }
 
-@Test func `launch agent uninstall removes staged config alias`() throws {
+@Test func `launch agent uninstall removes legacy staged config aliases`() throws {
     let homeDirectoryURL = try makeLaunchAgentCommandTestRepository()
     let layout = ServerInstallLayout.defaultForCurrentUser(
         homeDirectoryURL: homeDirectoryURL,
         launchAgentLabel: "com.gaelic-ghost.test-launch-agent",
     )
+    let cacheAliasURL = layout.cacheDirectoryURL.appendingPathComponent("launch-agent-server.yaml", isDirectory: false)
 
     try FileManager.default.createDirectory(
         at: layout.launchAgentConfigAliasURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true,
+    )
+    try FileManager.default.createDirectory(
+        at: cacheAliasURL.deletingLastPathComponent(),
         withIntermediateDirectories: true,
     )
     try FileManager.default.createDirectory(
@@ -135,6 +140,7 @@ import Testing
         withIntermediateDirectories: true,
     )
     try "aliased config".write(to: layout.launchAgentConfigAliasURL, atomically: true, encoding: .utf8)
+    try "cache aliased config".write(to: cacheAliasURL, atomically: true, encoding: .utf8)
     try "plist".write(to: layout.launchAgentPlistURL, atomically: true, encoding: .utf8)
 
     let options = LaunchAgentStatusOptions(
@@ -146,6 +152,48 @@ import Testing
 
     try options.removeStagedConfigAliasIfPresent(layout: layout)
     #expect(FileManager.default.fileExists(atPath: layout.launchAgentConfigAliasURL.path) == false)
+    #expect(FileManager.default.fileExists(atPath: cacheAliasURL.path) == false)
+}
+
+@Test func `launch agent config preparation seeds missing canonical application support config`() throws {
+    let homeDirectoryURL = try makeLaunchAgentCommandTestRepository()
+    let layout = ServerInstallLayout(
+        launchAgentLabel: "com.gaelic-ghost.test-launch-agent",
+        workingDirectoryURL: homeDirectoryURL,
+        applicationSupportDirectoryURL: homeDirectoryURL
+            .appendingPathComponent("Library/Application Support/SpeakSwiftlyServer", isDirectory: true),
+        cacheDirectoryURL: homeDirectoryURL.appendingPathComponent("Library/Caches/SpeakSwiftlyServer", isDirectory: true),
+        logsDirectoryURL: homeDirectoryURL.appendingPathComponent("Library/Logs/SpeakSwiftlyServer", isDirectory: true),
+        launchAgentsDirectoryURL: homeDirectoryURL.appendingPathComponent("Library/LaunchAgents", isDirectory: true),
+        launchAgentPlistURL: homeDirectoryURL
+            .appendingPathComponent("Library/LaunchAgents/com.gaelic-ghost.test-launch-agent.plist", isDirectory: false),
+        serverConfigFileURL: homeDirectoryURL
+            .appendingPathComponent("Library/Application Support/SpeakSwiftlyServer/server.yaml", isDirectory: false),
+        launchAgentConfigAliasURL: homeDirectoryURL
+            .appendingPathComponent("Library/SpeakSwiftlyServer/launch-agent-server.yaml", isDirectory: false),
+        runtimeBaseDirectoryURL: homeDirectoryURL
+            .appendingPathComponent("Library/Application Support/SpeakSwiftlyServer/runtime", isDirectory: true),
+        runtimeProfileRootURL: homeDirectoryURL
+            .appendingPathComponent("Library/Application Support/SpeakSwiftlyServer/runtime/profiles", isDirectory: true),
+        runtimeConfigurationFileURL: homeDirectoryURL
+            .appendingPathComponent("Library/Application Support/SpeakSwiftlyServer/runtime/configuration.json", isDirectory: false),
+        standardOutLogURL: homeDirectoryURL.appendingPathComponent("Library/Logs/SpeakSwiftlyServer/stdout.log"),
+        standardErrorLogURL: homeDirectoryURL.appendingPathComponent("Library/Logs/SpeakSwiftlyServer/stderr.log"),
+    )
+    let options = try LaunchAgentOptions(
+        label: layout.launchAgentLabel,
+        toolExecutablePath: "/tmp/SpeakSwiftlyServerTool",
+        plistPath: layout.launchAgentPlistURL.path,
+        configFilePath: layout.serverConfigFileURL.path,
+        requireToolExecutableExists: false,
+    )
+
+    try options.prepareLaunchAgentConfig(layout: layout)
+
+    let seededConfig = try String(contentsOf: layout.serverConfigFileURL, encoding: .utf8)
+    #expect(seededConfig.contains("port: 7337"))
+    #expect(seededConfig.contains("enabled: true"))
+    #expect(options.effectiveConfigFilePath(layout: layout) == layout.serverConfigFileURL.standardizedFileURL.path)
 }
 
 @Test func `launch agent status reports explicit not loaded state`() throws {

--- a/Tests/SpeakSwiftlyServerToolTests/SpeakSwiftlyServerToolTests.swift
+++ b/Tests/SpeakSwiftlyServerToolTests/SpeakSwiftlyServerToolTests.swift
@@ -155,6 +155,9 @@ import Testing
 
     try "#!/bin/sh\nexit 0\n".write(to: executableURL, atomically: true, encoding: .utf8)
     try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executableURL.path)
+    let configURL = tempDirectory.appendingPathComponent("config/server.yaml", isDirectory: false)
+    try FileManager.default.createDirectory(at: configURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try "app:\n  port: 7337\n".write(to: configURL, atomically: true, encoding: .utf8)
 
     let fakeLaunchctlScript = """
     #!/bin/sh
@@ -188,6 +191,7 @@ import Testing
         label: "com.example.test",
         toolExecutablePath: executableURL.path,
         plistPath: plistURL.path,
+        configFilePath: configURL.path,
         workingDirectory: tempDirectory.path,
         profileRootPath: tempDirectory.appendingPathComponent("runtime/profiles").path,
         standardOutPath: tempDirectory.appendingPathComponent("logs/stdout.log").path,
@@ -217,6 +221,9 @@ import Testing
     try "#!/bin/sh\nexit 0\n".write(to: executableURL, atomically: true, encoding: .utf8)
     try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executableURL.path)
     try Data().write(to: stateURL)
+    let configURL = tempDirectory.appendingPathComponent("config/server.yaml", isDirectory: false)
+    try FileManager.default.createDirectory(at: configURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try "app:\n  port: 7337\n".write(to: configURL, atomically: true, encoding: .utf8)
 
     let fakeLaunchctlScript = """
     #!/bin/sh
@@ -263,6 +270,7 @@ import Testing
         label: "com.example.test",
         toolExecutablePath: executableURL.path,
         plistPath: plistURL.path,
+        configFilePath: configURL.path,
         workingDirectory: tempDirectory.path,
         profileRootPath: tempDirectory.appendingPathComponent("runtime/profiles").path,
         standardOutPath: tempDirectory.appendingPathComponent("logs/stdout.log").path,

--- a/docs/maintainers/application-support-config-plan.md
+++ b/docs/maintainers/application-support-config-plan.md
@@ -1,8 +1,12 @@
 # Application Support Config Plan
 
+Status: implemented on `runtime/application-support-config`. The active LaunchAgent path now points
+directly at `~/Library/Application Support/SpeakSwiftlyServer/server.yaml`, and install/refresh
+paths seed that canonical file from a bundled default when it is missing.
+
 ## Context
 
-The live LaunchAgent-backed service now starts from a copied config alias at
+The live `v4.3.4` LaunchAgent-backed service starts from a copied config alias at
 `~/Library/SpeakSwiftlyServer/launch-agent-server.yaml` when the canonical config path contains
 spaces. That alias is a patch-level durability fix: it moved the copied config out of
 `~/Library/Caches`, which macOS and maintenance tools can remove independently of the installed
@@ -58,36 +62,35 @@ Resolve the Application Support root through Foundation URL APIs instead of hand
 escaping the path string. The space in `Application Support` is normal filesystem state, not a
 special case the package should work around with alternate active config paths.
 
-## Implementation Plan
+## Implementation Notes
 
 ### 1. Prove the path-with-spaces failure locally
 
-Add a focused test or small diagnostic that asks the current config loader to read a YAML file at an
-`Application Support` path with spaces. This should use the same `ConfigStore` path as service
-startup instead of a different YAML parser path.
+Added a focused test that asks `ConfigStore` to read a YAML file at an `Application Support` path
+with spaces. This uses the same service startup config-loading path rather than a separate parser.
 
-Expected result before the fix:
+Initial result before the fix:
 
-- the test reproduces the failure that originally forced the alias
-- or the test proves the failure has already been removed upstream, in which case the remaining work
-  can be a cleanup without a parser fix
+- `ReloadingFileProvider<YAMLSnapshot>` reported the file as missing at the Application Support path
+- the file had been written first, so the failure was in the provider path handling rather than the
+  test fixture or YAML contents
 
 ### 2. Fix canonical config loading
 
-Make `ConfigStore` load `APP_CONFIG_FILE` paths with spaces directly. Prefer a fix that keeps the
-current `ReloadingFileProvider<YAMLSnapshot>` behavior if the provider can support it cleanly.
+`ConfigStore` now loads `APP_CONFIG_FILE` paths with spaces directly through
+`URLReloadingYAMLConfigProvider`.
 
-If the provider cannot support that path shape reliably, split the behavior deliberately:
+The provider keeps `swift-configuration` for `ConfigReader`, precedence behavior, YAML parsing, and
+snapshot shape, but it owns the filesystem read and reload polling through Foundation file URLs. That
+avoids the current `ReloadingFileProvider<YAMLSnapshot>` path conversion that treats the normal
+`Application Support` space as an unsafe path.
 
-- startup reads the YAML config through a direct Foundation-backed file read
-- optional reload watching is layered on top only after direct startup loading is proven reliable
-
-Do not preserve a stringly fallback that silently swaps to the alias after a failed direct open. If
-the canonical path is invalid or missing, startup should fail with an explicit path-specific error.
+There is no stringly alias fallback. If the configured path is invalid or missing, startup fails with
+an explicit path-specific error.
 
 ### 3. Seed the canonical config during install and refresh
 
-Add a package-bundled default config template and have install-style commands seed
+Added a package-bundled default config template and made install-style commands seed
 `~/Library/Application Support/SpeakSwiftlyServer/server.yaml` when it is missing.
 
 The install/update/refresh policy is:
@@ -104,20 +107,18 @@ failure.
 
 ### 4. Change LaunchAgent environment shaping
 
-Update `ServerInstallLayout.launchAgentEnvironmentVariables(...)` so `APP_CONFIG_FILE` points to the
+Updated `ServerInstallLayout.launchAgentEnvironmentVariables(...)` so `APP_CONFIG_FILE` points to the
 canonical config path, including when that path contains spaces.
 
 After this change:
 
-- `launchAgentConfigPath(for:)` should either return the canonical standardized path unconditionally
-  or be removed
-- `launchAgentConfigAliasURL` should be removed from the public install layout unless a separate
-  migration step still needs to delete old aliases
-- `stageLaunchAgentConfigAliasIfNeeded(...)` should be removed from the install path
+- `launchAgentConfigPath(for:)` returns the canonical standardized path unconditionally
+- `launchAgentConfigAliasURL` remains only as a legacy cleanup location in the public install layout
+- the active install path no longer stages a copied alias config
 
 ### 5. Clean up old alias state
 
-Keep uninstall cleanup for both historical alias locations during the migration:
+Uninstall cleanup now removes both historical alias locations during the migration:
 
 - `~/Library/Caches/SpeakSwiftlyServer/launch-agent-server.yaml`
 - `~/Library/SpeakSwiftlyServer/launch-agent-server.yaml`
@@ -130,16 +131,15 @@ operator hygiene.
 
 ### 6. Add bundle-backed defaults only where they help
 
-Add package-bundled resources only for read-only shipped data. A good first slice is a template or
-default config resource that app/bootstrap code can copy into Application Support when no canonical
-`server.yaml` exists.
+The package now bundles `default-server.yaml` as read-only shipped data that app/bootstrap code can
+copy into Application Support when no canonical `server.yaml` exists.
 
 Do not make the package bundle the active config store. Active config is user and operator state,
 and it needs to remain writable outside the package artifact.
 
 ### 7. Update docs and release notes
 
-Refresh the operator-facing docs that currently mention alias behavior:
+Refresh or release-note the operator-facing docs that currently mention alias behavior:
 
 - `README.md`
 - `Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/LaunchAgent-Workflow.md`
@@ -170,9 +170,9 @@ Then run the live-service proof serially:
 7. remove or temporarily rename the canonical config after install, start the service without the
    install/refresh seeding path, and confirm startup fails loudly with the missing config path
 
-## Open Questions
+## Resolved Questions
 
-- Was the original path-with-spaces failure inside `swift-configuration`, this package's
-  `FilePath(configFilePath)` handoff, or an earlier release's command/property-list construction?
-- Should the app-managed install layout expose a public method for seeding the default config from
-  bundle resources, or should seeding stay inside the command/app install path?
+- The path-with-spaces failure is in the `ReloadingFileProvider<YAMLSnapshot>` filesystem path flow
+  used by this package, not in the LaunchAgent property list or YAML contents.
+- Seeding currently stays inside the command install/refresh path. A future app-facing public seeding
+  API can be added when the app integration needs to call the same behavior directly.

--- a/docs/maintainers/application-support-config-plan.md
+++ b/docs/maintainers/application-support-config-plan.md
@@ -1,0 +1,178 @@
+# Application Support Config Plan
+
+## Context
+
+The live LaunchAgent-backed service now starts from a copied config alias at
+`~/Library/SpeakSwiftlyServer/launch-agent-server.yaml` when the canonical config path contains
+spaces. That alias is a patch-level durability fix: it moved the copied config out of
+`~/Library/Caches`, which macOS and maintenance tools can remove independently of the installed
+LaunchAgent plist.
+
+The cleaner target is simpler: the installed service should derive its durable config root from
+Foundation's standard Application Support URL, read the active config directly from
+`~/Library/Application Support/SpeakSwiftlyServer/server.yaml`, and use the package bundle only for
+shipped read-only defaults, templates, and resources.
+
+## Current Failure Mode
+
+The original alias existed because LaunchAgent installs that pointed `APP_CONFIG_FILE` directly at
+`~/Library/Application Support/SpeakSwiftlyServer/server.yaml` failed while loading YAML config
+through the current `swift-configuration` file-provider path. The practical symptom was that a
+canonical config path containing `Application Support` was not safe enough for service startup.
+
+The `v4.3.4` alias path avoids the immediate failure, but it still leaves two config files with
+different jobs:
+
+- the canonical operator-owned config in Application Support
+- the copied LaunchAgent startup config outside Application Support
+
+That duplication is useful only as a temporary compatibility surface. It should disappear once the
+server can load the canonical path directly and reliably.
+
+## Target Layout
+
+Use the package bundle for shipped read-only inputs:
+
+- default config templates
+- schemas or documented example config files
+- package resources such as `default.metallib`
+- seed data that should be copied into user state before mutation
+
+Use Application Support for durable per-user service state:
+
+- `server.yaml`
+- `runtime/configuration.json`
+- `runtime/text-profiles.json`
+- voice profile state
+- any generated or user-edited runtime files that must survive restarts and cache cleanup
+
+Use Caches only for rebuildable disposable data:
+
+- temporary derived files
+- short-lived diagnostics that can be regenerated
+- noncritical indexes or scratch state
+
+No LaunchAgent-critical config should live in Caches.
+
+Resolve the Application Support root through Foundation URL APIs instead of hand-assembling or
+escaping the path string. The space in `Application Support` is normal filesystem state, not a
+special case the package should work around with alternate active config paths.
+
+## Implementation Plan
+
+### 1. Prove the path-with-spaces failure locally
+
+Add a focused test or small diagnostic that asks the current config loader to read a YAML file at an
+`Application Support` path with spaces. This should use the same `ConfigStore` path as service
+startup instead of a different YAML parser path.
+
+Expected result before the fix:
+
+- the test reproduces the failure that originally forced the alias
+- or the test proves the failure has already been removed upstream, in which case the remaining work
+  can be a cleanup without a parser fix
+
+### 2. Fix canonical config loading
+
+Make `ConfigStore` load `APP_CONFIG_FILE` paths with spaces directly. Prefer a fix that keeps the
+current `ReloadingFileProvider<YAMLSnapshot>` behavior if the provider can support it cleanly.
+
+If the provider cannot support that path shape reliably, split the behavior deliberately:
+
+- startup reads the YAML config through a direct Foundation-backed file read
+- optional reload watching is layered on top only after direct startup loading is proven reliable
+
+Do not preserve a stringly fallback that silently swaps to the alias after a failed direct open. If
+the canonical path is invalid or missing, startup should fail with an explicit path-specific error.
+
+### 3. Seed the canonical config during install and refresh
+
+Add a package-bundled default config template and have install-style commands seed
+`~/Library/Application Support/SpeakSwiftlyServer/server.yaml` when it is missing.
+
+The install/update/refresh policy is:
+
+- `install` seeds the default config when the canonical config file is missing
+- refresh/update flows also seed the default config when the canonical config file is missing
+- startup fails loudly when the resolved `APP_CONFIG_FILE` path is missing
+- explicit user-provided config paths still fail loudly when missing instead of being replaced with
+  bundled defaults
+
+The default seed is a first-run convenience, not a runtime fallback. Once the LaunchAgent is pointed
+at a canonical config path, the service should either load that file or report a clear missing-config
+failure.
+
+### 4. Change LaunchAgent environment shaping
+
+Update `ServerInstallLayout.launchAgentEnvironmentVariables(...)` so `APP_CONFIG_FILE` points to the
+canonical config path, including when that path contains spaces.
+
+After this change:
+
+- `launchAgentConfigPath(for:)` should either return the canonical standardized path unconditionally
+  or be removed
+- `launchAgentConfigAliasURL` should be removed from the public install layout unless a separate
+  migration step still needs to delete old aliases
+- `stageLaunchAgentConfigAliasIfNeeded(...)` should be removed from the install path
+
+### 5. Clean up old alias state
+
+Keep uninstall cleanup for both historical alias locations during the migration:
+
+- `~/Library/Caches/SpeakSwiftlyServer/launch-agent-server.yaml`
+- `~/Library/SpeakSwiftlyServer/launch-agent-server.yaml`
+
+This cleanup should be explicit legacy removal code, not a continuing part of the active install
+layout.
+
+Once enough releases have passed, decide whether to delete the legacy cleanup or keep it as harmless
+operator hygiene.
+
+### 6. Add bundle-backed defaults only where they help
+
+Add package-bundled resources only for read-only shipped data. A good first slice is a template or
+default config resource that app/bootstrap code can copy into Application Support when no canonical
+`server.yaml` exists.
+
+Do not make the package bundle the active config store. Active config is user and operator state,
+and it needs to remain writable outside the package artifact.
+
+### 7. Update docs and release notes
+
+Refresh the operator-facing docs that currently mention alias behavior:
+
+- `README.md`
+- `Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/LaunchAgent-Workflow.md`
+- `docs/maintainers/live-service-reliability-follow-ups.md`
+- release checklist or release notes for the patch that removes active alias use
+
+The docs should say that Application Support owns durable config and runtime state, the package
+bundle owns shipped read-only defaults, and Caches is not part of the LaunchAgent startup contract.
+
+## Validation
+
+Run the normal package and maintainer checks:
+
+- `xcrun swift build`
+- `xcrun swift test`
+- `scripts/repo-maintenance/validate-all.sh`
+
+Then run the live-service proof serially:
+
+1. publish the patch release through `scripts/repo-maintenance/release-prepare.sh`
+2. after merge, publish through `scripts/repo-maintenance/release-publish.sh --refresh-live-service`
+3. verify the LaunchAgent environment shows `APP_CONFIG_FILE` pointing directly at
+   `~/Library/Application Support/SpeakSwiftlyServer/server.yaml`
+4. run `.release-artifacts/current/SpeakSwiftlyServerTool healthcheck --base-url http://127.0.0.1:7337`
+5. confirm HTTP and MCP are both listening and MCP initialize succeeds
+6. remove or temporarily rename the canonical config, rerun install or refresh, and confirm the
+   bundled default is seeded back into Application Support before bootstrapping
+7. remove or temporarily rename the canonical config after install, start the service without the
+   install/refresh seeding path, and confirm startup fails loudly with the missing config path
+
+## Open Questions
+
+- Was the original path-with-spaces failure inside `swift-configuration`, this package's
+  `FilePath(configFilePath)` handoff, or an earlier release's command/property-list construction?
+- Should the app-managed install layout expose a public method for seeding the default config from
+  bundle resources, or should seeding stay inside the command/app install path?

--- a/docs/maintainers/live-service-reliability-follow-ups.md
+++ b/docs/maintainers/live-service-reliability-follow-ups.md
@@ -18,20 +18,20 @@ The `v2.0.4` fix kept the canonical config file in Application Support, but stag
 
 The `v4.3.4` follow-up moves that alias to `~/Library/SpeakSwiftlyServer/launch-agent-server.yaml`. The alias still avoids the `Application Support` space that exposed the original config-provider bug, but it no longer depends on a cache directory that macOS or maintenance tooling can remove independently of the installed LaunchAgent plist.
 
-The next cleanup plan is tracked in [Application Support Config Plan](./application-support-config-plan.md). That plan treats the alias as a temporary compatibility shim and moves the target design back to direct `~/Library/Application Support/SpeakSwiftlyServer/server.yaml` loading.
+The Application Support cleanup is implemented on the `runtime/application-support-config` branch. It treats the alias as a temporary compatibility shim and moves the target design back to direct `~/Library/Application Support/SpeakSwiftlyServer/server.yaml` loading, with install/refresh seeding the canonical file from a bundled default when needed.
 
 ## Reliability Follow-Ups
 
 ### 1. Add a full LaunchAgent smoke test for the real per-user install layout
 
-The existing unit coverage now proves that LaunchAgent installs rewrite `APP_CONFIG_FILE` to the cache alias when the canonical config path contains spaces. That should be extended into an end-to-end smoke test that verifies the whole app-managed install contract, not only the environment shaping.
+The current unit coverage now proves that LaunchAgent installs point `APP_CONFIG_FILE` directly at the canonical Application Support config path, even when the path contains spaces. That should be extended into an end-to-end smoke test that verifies the whole app-managed install contract, not only the environment shaping.
 
 The intended flow is:
 
 - create a temporary per-user style install layout whose canonical config file lives under an `Application Support` path with spaces
 - run the LaunchAgent install path against the staged release artifact
-- confirm that the installed property list uses the alias config path instead of the canonical path
-- confirm that the default alias path is durable install support under `~/Library/SpeakSwiftlyServer`, not disposable cache state
+- confirm that the installed property list uses the canonical Application Support config path
+- confirm that install/refresh seeds the canonical config when it is missing
 - boot the service
 - probe `GET /runtime/host`
 - probe MCP `initialize` over `POST /mcp`
@@ -39,28 +39,28 @@ The intended flow is:
 
 That test should fail for any future regression where:
 
-- the alias copy is not staged
-- the property list keeps pointing at the spaced canonical path
+- the canonical config is not seeded during install/refresh
+- the property list stops pointing at the spaced canonical path
 - the service starts but the MCP transport silently falls back to disabled
 
 ### 2. Make config-path staging and config-open behavior visible in operator logs
 
-The current fix is operationally correct, but it still asks a maintainer to infer too much from side effects. Startup logs should say exactly which config path the service intended to use and whether an alias copy was staged.
+The current fix is operationally correct, but it still asks a maintainer to infer too much from side effects. Startup logs should say exactly which config path the service intended to use and whether a default config was seeded.
 
 Add explicit log lines for:
 
 - canonical config path requested for LaunchAgent install
-- alias config path selected for LaunchAgent use
-- whether the alias path was copied or left untouched
+- canonical config path selected for LaunchAgent use
+- whether the canonical config was seeded or already present
 - the exact config path the runtime config loader is opening at startup
 - whether config reload watching is enabled for that path
 
 If the config file cannot be opened, the error should name:
 
 - the path that failed
-- whether it was the canonical path or the LaunchAgent alias path
+- whether it was the canonical path or an explicit custom path
 - whether the file existed
-- one likely cause, such as a missing file, a stale alias copy, or a provider/path handling bug
+- one likely cause, such as a missing file, permissions problem, or provider/path handling bug
 
 ### 3. Add a first-class health-check command for the live service
 
@@ -90,14 +90,7 @@ Status update on `2026-04-15`: this is now shipped as `xcrun swift run SpeakSwif
 
 ### 4. Revisit whether LaunchAgent-owned config needs a reloading provider
 
-The current server config path uses `swift-configuration` reloading providers for YAML-backed config, which is the right long-term default for operator-edited config files. It is less clear that the LaunchAgent-owned startup config path needs the same behavior when the practical requirement is "start reliably from a known file under the app-managed layout".
-
-The project should make an explicit decision here instead of inheriting that behavior accidentally:
-
-- keep the reloading provider for LaunchAgent config and harden the file-path behavior further
-- or split startup config loading from live reload watching so LaunchAgent startup uses a simpler file-open path and optional later reload support is layered on top
-
-Before changing architecture, verify the documented `swift-configuration` behavior being relied on and confirm whether the path-with-spaces failure came from the provider stack itself or from the way this package integrates with it.
+Status update: the package now keeps reload behavior, but uses a small Foundation URL-backed YAML provider for the filesystem read and polling. `swift-configuration` still owns the reader, precedence behavior, YAML snapshot parsing, and value lookup shape; only the path-sensitive file access moved out of `ReloadingFileProvider<YAMLSnapshot>`.
 
 ### 5. Add explicit self-reporting for transport policy at startup
 

--- a/docs/maintainers/live-service-reliability-follow-ups.md
+++ b/docs/maintainers/live-service-reliability-follow-ups.md
@@ -18,6 +18,8 @@ The `v2.0.4` fix kept the canonical config file in Application Support, but stag
 
 The `v4.3.4` follow-up moves that alias to `~/Library/SpeakSwiftlyServer/launch-agent-server.yaml`. The alias still avoids the `Application Support` space that exposed the original config-provider bug, but it no longer depends on a cache directory that macOS or maintenance tooling can remove independently of the installed LaunchAgent plist.
 
+The next cleanup plan is tracked in [Application Support Config Plan](./application-support-config-plan.md). That plan treats the alias as a temporary compatibility shim and moves the target design back to direct `~/Library/Application Support/SpeakSwiftlyServer/server.yaml` loading.
+
 ## Reliability Follow-Ups
 
 ### 1. Add a full LaunchAgent smoke test for the real per-user install layout

--- a/docs/maintainers/speakswiftly-api-coverage-matrix.md
+++ b/docs/maintainers/speakswiftly-api-coverage-matrix.md
@@ -10,11 +10,11 @@ It answers three concrete questions:
 2. Which public capabilities are intentionally adapted instead of mirrored exactly?
 3. Which transport is the right client contract for each capability: HTTP, MCP, both, or neither?
 
-Current baseline checked against the `SpeakSwiftly 4.0.5` package state resolved by this repository on `2026-04-24`. The root package now follows `SpeakSwiftly` with an up-to-next-major semantic-version requirement starting at `4.0.5`.
+Current baseline checked against the `SpeakSwiftly 4.0.7` package state resolved by this repository on `2026-04-25`. The root package now follows `SpeakSwiftly` with an up-to-next-major semantic-version requirement starting at `4.0.7`.
 
 ## Summary
 
-`SpeakSwiftlyServer` exposes most of the public runtime control plane that makes sense outside Swift code, with the current `SpeakSwiftly 4.0.5` Qwen additions called out below as deliberate follow-up decisions:
+`SpeakSwiftlyServer` exposes most of the public runtime control plane that makes sense outside Swift code, with the current `SpeakSwiftly 4.0.7` Qwen additions called out below as deliberate follow-up decisions:
 
 - speech generation for live playback, retained file output, and batches
 - voice design and voice cloning with explicit `vibe`

--- a/scripts/repo-maintenance/release-publish.sh
+++ b/scripts/repo-maintenance/release-publish.sh
@@ -11,7 +11,8 @@ release_tag=""
 skip_validate="false"
 skip_gh_release="false"
 refresh_live_service="${REPO_MAINTENANCE_DEFAULT_REFRESH_LIVE_SERVICE:-true}"
-live_service_config_file="${REPO_MAINTENANCE_DEFAULT_LIVE_SERVICE_CONFIG_FILE:-$HOME/Library/Application Support/SpeakSwiftlyServer/server.yaml}"
+default_live_service_config_file="${REPO_MAINTENANCE_DEFAULT_LIVE_SERVICE_CONFIG_FILE:-$HOME/Library/Application Support/SpeakSwiftlyServer/server.yaml}"
+live_service_config_file="$default_live_service_config_file"
 dry_run="false"
 
 while [ "$#" -gt 0 ]; do
@@ -141,7 +142,13 @@ if [ "$REPO_MAINTENANCE_REFRESH_LIVE_SERVICE" = "true" ]; then
     log "Would refresh the live LaunchAgent-backed service with $staged_tool using config $REPO_MAINTENANCE_LIVE_SERVICE_CONFIG_FILE."
   else
     [ -n "$REPO_MAINTENANCE_LIVE_SERVICE_CONFIG_FILE" ] || die "Live service refresh requires a non-empty config file path. Pass --live-service-config-file /absolute/path/to/server.yaml or use --skip-live-service-refresh."
-    [ -f "$REPO_MAINTENANCE_LIVE_SERVICE_CONFIG_FILE" ] || die "Live service refresh expected a server config file at $REPO_MAINTENANCE_LIVE_SERVICE_CONFIG_FILE, but that file does not exist. Pass --live-service-config-file /absolute/path/to/server.yaml or use --skip-live-service-refresh."
+    if [ ! -f "$REPO_MAINTENANCE_LIVE_SERVICE_CONFIG_FILE" ]; then
+      if [ "$REPO_MAINTENANCE_LIVE_SERVICE_CONFIG_FILE" = "$default_live_service_config_file" ]; then
+        log "Live service config is missing at $REPO_MAINTENANCE_LIVE_SERVICE_CONFIG_FILE; launch-agent install will seed the default Application Support config."
+      else
+        die "Live service refresh expected a server config file at $REPO_MAINTENANCE_LIVE_SERVICE_CONFIG_FILE, but that file does not exist. Use the default Application Support config path to allow seeding, pass an existing --live-service-config-file /absolute/path/to/server.yaml, or use --skip-live-service-refresh."
+      fi
+    fi
     [ -x "$staged_tool" ] || die "Live service refresh expected the staged release tool at $staged_tool, but it was missing or not executable."
     log "Refreshing the live LaunchAgent-backed service from $staged_tool."
     "$staged_tool" launch-agent install --config-file "$REPO_MAINTENANCE_LIVE_SERVICE_CONFIG_FILE"


### PR DESCRIPTION
## Release Prepare

- prepares release candidate `v4.3.5`
- leaves release artifact staging, final tag creation, tag push, and GitHub release publication for `scripts/repo-maintenance/release-publish.sh` after this pull request lands on `main`

## Publish Follow-Up

After this pull request merges, switch to `main` locally and run:

```bash
scripts/repo-maintenance/release-publish.sh --version v4.3.5 --skip-live-service-refresh
```
