### PR TITLE
release: remove local runtime coupling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@
 - If local `main` is ahead of `origin/main`, do not try to publish from that unsynced checkout. Move that work onto a feature branch or keep it on the existing branch, run `release-prepare.sh`, merge the PR, fast-forward local `main`, and only then run `release-publish.sh`. Protected-branch updates belong on the prepare side of the workflow, not inside publish.
 - Feature branches and feature worktrees may publish release tags when Gale explicitly requests that branch-tagged release flow.
 - Treat the resolved `SpeakSwiftly` dependency declared in `Package.swift` and locked in `Package.resolved` as the source of truth for normal `xcrun swift build` and `xcrun swift test` runs here.
-- Do not retarget this package to a local `../SpeakSwiftly` checkout unless the manifest is being changed intentionally for a specific local-integration task.
+- Do not retarget this package to a local SpeakSwiftly checkout unless the manifest is being changed intentionally for a specific local-integration task.
 - If unreleased `SpeakSwiftly` changes are needed here, prefer stabilizing and tagging them in `SpeakSwiftly` first, then update this repository to that release instead of integrating against half-finished sibling checkout work.
 - Treat `macOS 15` as the current standalone package baseline and keep the host and state model friendly to a near-future `iOS 18` reuse path.
 - Prefer maintainable Apple-platform architecture over speculative Linux abstraction. If Linux support would require major design compromise, stop and discuss whether a separate Rust implementation is the cleaner path.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ xcrun swift run SpeakSwiftlyServerTool serve
 
 Install or refresh the per-user LaunchAgent with a config file:
 
-This command expects the staged tool artifact to already exist at `.release-artifacts/current/SpeakSwiftlyServerTool`. On a clean checkout, build and stage the release artifact first, or pass `--tool-executable-path /absolute/path/to/SpeakSwiftlyServerTool` explicitly.
+This command expects the staged tool artifact to already exist at `.release-artifacts/current/SpeakSwiftlyServerTool`. On a clean checkout, build and stage the release artifact first, or pass `--tool-executable-path <SpeakSwiftlyServerTool>` explicitly.
 
 ```bash
 xcrun swift run SpeakSwiftlyServerTool launch-agent install \

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,7 +58,7 @@
 
 ## Milestone 5: Library Integration Follow-Through
 
-- [x] Split `../SpeakSwiftly` so it vends a reusable library product alongside its executable product.
+- [x] Split the SpeakSwiftly package so it vends a reusable library product alongside its executable product.
 - [x] Switch this package from subprocess-style integration to direct `SpeakSwiftly` package import when that library product exists.
 - [x] Collapse temporary integration-only scaffolding that became unnecessary after direct import.
 - [x] Align the runtime bridge with the public `SpeakSwiftly` library surface instead of constructing raw worker requests across the library boundary.

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentPromotion.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentPromotion.swift
@@ -60,27 +60,17 @@ private struct ReleaseArtifactPromotionResult {
 }
 
 private enum ReleaseArtifactPromoter {
-    private struct SpeakSwiftlyPublishedRuntimeMetadata: Decodable {
-        let buildConfiguration: String
-        let metallibPath: String
-        let sourceRoot: String?
-
-        enum CodingKeys: String, CodingKey {
-            case buildConfiguration = "build_configuration"
-            case metallibPath = "metallib_path"
-            case sourceRoot = "source_root"
-        }
-    }
-
     static func promoteLive(
         repositoryRootPath: String,
         stagedExecutablePath: String,
     ) throws -> ReleaseArtifactPromotionResult {
-        let repositoryRootURL = URL(fileURLWithPath: repositoryRootPath, isDirectory: true)
         try buildReleaseTool(repositoryRootPath: repositoryRootPath)
 
         let builtExecutablePath = try builtReleaseExecutablePath(repositoryRootPath: repositoryRootPath)
-        let builtMetallibURL = try publishedRuntimeMetallibURL(repositoryRootURL: repositoryRootURL)
+        let builtMetallibURL = try builtReleaseMetallibURL(
+            productsURL: URL(fileURLWithPath: builtExecutablePath, isDirectory: false)
+                .deletingLastPathComponent(),
+        )
         let stagedExecutableURL = URL(fileURLWithPath: stagedExecutablePath, isDirectory: false)
         let stagedDirectoryURL = stagedExecutableURL.deletingLastPathComponent()
         let stagedMetallibURL = stagedDirectoryURL
@@ -145,54 +135,25 @@ private enum ReleaseArtifactPromoter {
         return executablePath
     }
 
-    private static func publishedRuntimeMetallibURL(repositoryRootURL: URL) throws -> URL {
-        let siblingSourceRootURL = repositoryRootURL
-            .deletingLastPathComponent()
-            .appendingPathComponent("SpeakSwiftly", isDirectory: true)
-        let metadataURL = siblingSourceRootURL
-            .appendingPathComponent(".local/xcode/SpeakSwiftly.release.json", isDirectory: false)
-        let deterministicMetallibURL = siblingSourceRootURL
-            .appendingPathComponent(".local/derived-data/runtime-release/Build/Products/Release/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib", isDirectory: false)
+    private static func builtReleaseMetallibURL(productsURL: URL) throws -> URL {
+        let candidates = [
+            productsURL.appendingPathComponent(
+                "SpeakSwiftly_SpeakSwiftly.bundle/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib",
+                isDirectory: false,
+            ),
+            productsURL.appendingPathComponent(
+                "SpeakSwiftly_SpeakSwiftlyCore.bundle/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib",
+                isDirectory: false,
+            ),
+            productsURL.appendingPathComponent("Resources/default.metallib", isDirectory: false),
+        ]
 
-        if !FileManager.default.fileExists(atPath: metadataURL.path) {
-            guard FileManager.default.fileExists(atPath: deterministicMetallibURL.path) else {
-                throw LaunchAgentCommandError(
-                    "The live-service promotion path requires either sibling SpeakSwiftly release runtime metadata at '\(metadataURL.path)' or the deterministic release runtime metallib at '\(deterministicMetallibURL.path)'. Publish and verify the sibling release runtime first.",
-                )
-            }
-
-            return deterministicMetallibURL
-        }
-
-        let metadata = try JSONDecoder().decode(
-            SpeakSwiftlyPublishedRuntimeMetadata.self,
-            from: Data(contentsOf: metadataURL),
-        )
-        guard metadata.buildConfiguration == "Release" else {
-            throw LaunchAgentCommandError(
-                "The sibling SpeakSwiftly release runtime metadata at '\(metadataURL.path)' reported build configuration '\(metadata.buildConfiguration)' instead of the expected 'Release'.",
-            )
-        }
-
-        let recordedURL = URL(fileURLWithPath: metadata.metallibPath, isDirectory: false)
-        if FileManager.default.fileExists(atPath: recordedURL.path) {
-            return recordedURL
-        }
-
-        if let sourceRoot = metadata.sourceRoot, metadata.metallibPath.hasPrefix(sourceRoot) {
-            let relativeSuffix = String(metadata.metallibPath.dropFirst(sourceRoot.count))
-                .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-            if relativeSuffix.isEmpty == false {
-                let rebasedURL = siblingSourceRootURL
-                    .appendingPathComponent(relativeSuffix, isDirectory: false)
-                if FileManager.default.fileExists(atPath: rebasedURL.path) {
-                    return rebasedURL
-                }
-            }
+        if let metallibURL = candidates.first(where: { FileManager.default.fileExists(atPath: $0.path) }) {
+            return metallibURL
         }
 
         throw LaunchAgentCommandError(
-            "The sibling SpeakSwiftly release runtime metadata at '\(metadataURL.path)' pointed at a missing metallib path '\(metadata.metallibPath)'. Publish and verify the sibling release runtime first.",
+            "\(speakSwiftlyServerToolName) completed a release build, but no SpeakSwiftly MLX metallib was found in SwiftPM product directory '\(productsURL.path)'. Expected the SpeakSwiftly package dependency to bundle mlx-swift_Cmlx.bundle in the release build products.",
         )
     }
 

--- a/Tests/SpeakSwiftlyServerE2ETests/SpeakSwiftlyServerE2EServerHelpers.swift
+++ b/Tests/SpeakSwiftlyServerE2ETests/SpeakSwiftlyServerE2EServerHelpers.swift
@@ -7,194 +7,6 @@ import Darwin
 // MARK: - Server Runtime Helpers
 
 extension ServerE2E {
-    private struct SpeakSwiftlyPublishedRuntimeMetadata: Decodable {
-        let buildConfiguration: String
-        let productsPath: String
-        let executablePath: String
-        let launcherPath: String
-        let metallibPath: String
-        let aliasPath: String
-        let sourceRoot: String?
-
-        enum CodingKeys: String, CodingKey {
-            case buildConfiguration = "build_configuration"
-            case productsPath = "products_path"
-            case executablePath = "executable_path"
-            case launcherPath = "launcher_path"
-            case metallibPath = "metallib_path"
-            case aliasPath = "alias_path"
-            case sourceRoot = "source_root"
-        }
-    }
-
-    private struct SpeakSwiftlyPublishedRuntimeArtifacts {
-        let metadataURL: URL
-        let metadata: SpeakSwiftlyPublishedRuntimeMetadata
-        let productsURL: URL
-        let executableURL: URL
-        let launcherURL: URL
-        let metallibURL: URL
-    }
-
-    private static func speakSwiftlyPublishedRuntimeArtifacts(configuration: String) throws -> SpeakSwiftlyPublishedRuntimeArtifacts {
-        let serverRootURL = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let siblingSourceRootURL = serverRootURL
-            .deletingLastPathComponent()
-            .appendingPathComponent("SpeakSwiftly", isDirectory: true)
-        let metadataURL = siblingSourceRootURL
-            .appendingPathComponent(".local/xcode/SpeakSwiftly.\(configuration.lowercased()).json", isDirectory: false)
-        let localXcodeRootURL = siblingSourceRootURL
-            .appendingPathComponent(".local/xcode", isDirectory: true)
-        let deterministicRuntimeURL = siblingSourceRootURL
-            .appendingPathComponent(".local/derived-data/runtime-\(configuration.lowercased())", isDirectory: true)
-        let deterministicProductsURL = deterministicRuntimeURL
-            .appendingPathComponent("Build/Products/\(configuration)", isDirectory: true)
-        let deterministicLauncherURL = deterministicRuntimeURL
-            .appendingPathComponent("run-speakswiftly", isDirectory: false)
-        let deterministicExecutableURL = deterministicProductsURL
-            .appendingPathComponent("SpeakSwiftlyTool", isDirectory: false)
-        let deterministicMetallibURL = deterministicProductsURL
-            .appendingPathComponent("mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib", isDirectory: false)
-
-        if !FileManager.default.fileExists(atPath: metadataURL.path) {
-            guard FileManager.default.fileExists(atPath: deterministicMetallibURL.path) else {
-                throw SpeakSwiftlyBuildError(
-                    "The live SpeakSwiftlyServer end-to-end suite requires either sibling SpeakSwiftly published runtime metadata at '\(metadataURL.path)' or the deterministic \(configuration) runtime metallib at '\(deterministicMetallibURL.path)'. Publish and verify the sibling \(configuration) runtime first.",
-                )
-            }
-            guard FileManager.default.isExecutableFile(atPath: deterministicLauncherURL.path) else {
-                throw SpeakSwiftlyBuildError(
-                    "The deterministic sibling SpeakSwiftly \(configuration) runtime launcher was expected at '\(deterministicLauncherURL.path)', but it was missing or not executable. Publish and verify the sibling \(configuration) runtime first.",
-                )
-            }
-            guard FileManager.default.isExecutableFile(atPath: deterministicExecutableURL.path) else {
-                throw SpeakSwiftlyBuildError(
-                    "The deterministic sibling SpeakSwiftly \(configuration) runtime executable was expected at '\(deterministicExecutableURL.path)', but it was missing or not executable. Publish and verify the sibling \(configuration) runtime first.",
-                )
-            }
-
-            return .init(
-                metadataURL: metadataURL,
-                metadata: .init(
-                    buildConfiguration: configuration,
-                    productsPath: deterministicProductsURL.path,
-                    executablePath: deterministicExecutableURL.path,
-                    launcherPath: deterministicLauncherURL.path,
-                    metallibPath: deterministicMetallibURL.path,
-                    aliasPath: deterministicRuntimeURL.path,
-                    sourceRoot: siblingSourceRootURL.path,
-                ),
-                productsURL: deterministicProductsURL,
-                executableURL: deterministicExecutableURL,
-                launcherURL: deterministicLauncherURL,
-                metallibURL: deterministicMetallibURL,
-            )
-        }
-
-        let metadata = try decode(
-            SpeakSwiftlyPublishedRuntimeMetadata.self,
-            from: Data(contentsOf: metadataURL),
-        )
-        guard metadata.buildConfiguration == configuration else {
-            throw SpeakSwiftlyBuildError(
-                "The sibling SpeakSwiftly published runtime metadata at '\(metadataURL.path)' reported build configuration '\(metadata.buildConfiguration)' instead of the expected '\(configuration)'.",
-            )
-        }
-
-        let productsURL = resolvedPublishedRuntimeURL(
-            recordedPath: metadata.productsPath,
-            recordedSourceRoot: metadata.sourceRoot,
-            actualSourceRootURL: siblingSourceRootURL,
-            fallbackURL: localXcodeRootURL.appendingPathComponent(configuration, isDirectory: true),
-            isDirectory: true,
-        )
-        let executableURL = resolvedPublishedRuntimeURL(
-            recordedPath: metadata.executablePath,
-            recordedSourceRoot: metadata.sourceRoot,
-            actualSourceRootURL: siblingSourceRootURL,
-            fallbackURL: productsURL.appendingPathComponent("SpeakSwiftly", isDirectory: false),
-            isDirectory: false,
-        )
-        let launcherURL = resolvedPublishedRuntimeURL(
-            recordedPath: metadata.launcherPath,
-            recordedSourceRoot: metadata.sourceRoot,
-            actualSourceRootURL: siblingSourceRootURL,
-            fallbackURL: productsURL.appendingPathComponent("run-speakswiftly", isDirectory: false),
-            isDirectory: false,
-        )
-        let metallibURL = resolvedPublishedRuntimeURL(
-            recordedPath: metadata.metallibPath,
-            recordedSourceRoot: metadata.sourceRoot,
-            actualSourceRootURL: siblingSourceRootURL,
-            fallbackURL: productsURL.appendingPathComponent(
-                "mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib",
-                isDirectory: false,
-            ),
-            isDirectory: false,
-        )
-        guard FileManager.default.fileExists(atPath: metallibURL.path) else {
-            throw SpeakSwiftlyBuildError(
-                "The sibling SpeakSwiftly published runtime metadata pointed at a missing metallib path '\(metallibURL.path)'. Re-publish and verify the sibling \(configuration) runtime before running the live server suite.",
-            )
-        }
-        guard FileManager.default.isExecutableFile(atPath: launcherURL.path) else {
-            throw SpeakSwiftlyBuildError(
-                "The sibling SpeakSwiftly published runtime metadata pointed at a missing runtime launcher '\(launcherURL.path)'. Re-publish and verify the sibling \(configuration) runtime before running the live server suite.",
-            )
-        }
-        guard FileManager.default.isExecutableFile(atPath: executableURL.path) else {
-            throw SpeakSwiftlyBuildError(
-                "The sibling SpeakSwiftly published runtime metadata pointed at a missing executable '\(executableURL.path)'. Re-publish and verify the sibling \(configuration) runtime before running the live server suite.",
-            )
-        }
-
-        return .init(
-            metadataURL: metadataURL,
-            metadata: metadata,
-            productsURL: productsURL,
-            executableURL: executableURL,
-            launcherURL: launcherURL,
-            metallibURL: metallibURL,
-        )
-    }
-
-    private static func resolvedPublishedRuntimeURL(
-        recordedPath: String,
-        recordedSourceRoot: String?,
-        actualSourceRootURL: URL,
-        fallbackURL: URL,
-        isDirectory: Bool,
-    ) -> URL {
-        let recordedURL = URL(fileURLWithPath: recordedPath, isDirectory: isDirectory)
-        if FileManager.default.fileExists(atPath: recordedURL.path) {
-            return recordedURL
-        }
-
-        guard
-            let recordedSourceRoot,
-            recordedPath.hasPrefix(recordedSourceRoot)
-        else {
-            return fallbackURL
-        }
-
-        let relativeSuffix = String(recordedPath.dropFirst(recordedSourceRoot.count))
-            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        guard relativeSuffix.isEmpty == false else {
-            return fallbackURL
-        }
-
-        let rebasedURL = actualSourceRootURL
-            .appendingPathComponent(relativeSuffix, isDirectory: isDirectory)
-        if FileManager.default.fileExists(atPath: rebasedURL.path) {
-            return rebasedURL
-        }
-
-        return fallbackURL
-    }
-
     static func serverToolExecutableURL() throws -> URL {
         let serverRootURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -210,6 +22,29 @@ extension ServerE2E {
         }
 
         return executableURL
+    }
+
+    static func serverBuildMetallibURL(serverExecutableURL: URL) throws -> URL {
+        let productsURL = serverExecutableURL.deletingLastPathComponent()
+        let candidates = [
+            productsURL.appendingPathComponent(
+                "SpeakSwiftly_SpeakSwiftly.bundle/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib",
+                isDirectory: false,
+            ),
+            productsURL.appendingPathComponent(
+                "SpeakSwiftly_SpeakSwiftlyCore.bundle/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib",
+                isDirectory: false,
+            ),
+            productsURL.appendingPathComponent("Resources/default.metallib", isDirectory: false),
+        ]
+
+        if let metallibURL = candidates.first(where: { FileManager.default.fileExists(atPath: $0.path) }) {
+            return metallibURL
+        }
+
+        throw SpeakSwiftlyBuildError(
+            "The live SpeakSwiftlyServer end-to-end suite could not find the SpeakSwiftly MLX metallib in SwiftPM product directory '\(productsURL.path)'. Run `swift build` before the live end-to-end suite and confirm the SpeakSwiftly package dependency bundled mlx-swift_Cmlx.bundle.",
+        )
     }
 
     private static func stageMetallibForServerBinary(
@@ -241,10 +76,9 @@ extension ServerE2E {
         }
 
         let executionLaneLease = try E2ELiveServerExecutionLaneLease.acquire(timeout: e2eTimeout)
-        let publishedRuntimeArtifacts = try speakSwiftlyPublishedRuntimeArtifacts(configuration: "Debug")
         let executableURL = try serverToolExecutableURL()
         try stageMetallibForServerBinary(
-            sourceURL: publishedRuntimeArtifacts.metallibURL,
+            sourceURL: serverBuildMetallibURL(serverExecutableURL: executableURL),
             serverExecutableURL: executableURL,
         )
 

--- a/Tests/SpeakSwiftlyServerTests/ConfigTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/ConfigTests.swift
@@ -415,7 +415,8 @@ import Testing
 }
 
 @Test func `runtime launcher bridges a profiles directory override onto the broader SpeakSwiftly runtime root`() {
-    let profileRootURL = URL(fileURLWithPath: "/tmp/speakswiftly-runtime/profiles", isDirectory: true)
+    let profileRootURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("speakswiftly-runtime/profiles", isDirectory: true)
 
     #expect(
         SpeakSwiftlyRuntimeLauncher.bridgedSpeakSwiftlyProfileRoot(profileRootURL.path)
@@ -424,7 +425,8 @@ import Testing
 }
 
 @Test func `runtime launcher leaves non-profiles override paths unchanged`() {
-    let runtimeRootURL = URL(fileURLWithPath: "/tmp/SpeakSwiftlyRuntime", isDirectory: true)
+    let runtimeRootURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("SpeakSwiftlyRuntime", isDirectory: true)
 
     #expect(
         SpeakSwiftlyRuntimeLauncher.bridgedSpeakSwiftlyProfileRoot(runtimeRootURL.path)

--- a/Tests/SpeakSwiftlyServerTests/HTTPWorkflowTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/HTTPWorkflowTests.swift
@@ -203,7 +203,7 @@ extension ServerTests {
                 method: .post,
                 headers: [.contentType: "application/json"],
                 body: byteBuffer(
-                    #"{"profile_name":"clone-default","vibe":"femme","reference_audio_path":"./Fixtures/reference.wav","transcript":"Cloned route test transcript.","cwd":"/tmp/http-clone-cwd"}"#,
+                    #"{"profile_name":"clone-default","vibe":"femme","reference_audio_path":"./Fixtures/reference.wav","transcript":"Cloned route test transcript.","cwd":"./http-clone-cwd"}"#,
                 ),
             )
             let cloneJSON = try jsonObject(from: cloneResponse.body)
@@ -215,7 +215,7 @@ extension ServerTests {
             #expect(cloneInvocation.profileName == "clone-default")
             #expect(cloneInvocation.referenceAudioPath == "./Fixtures/reference.wav")
             #expect(cloneInvocation.transcript == "Cloned route test transcript.")
-            #expect(cloneInvocation.cwd == "/tmp/http-clone-cwd")
+            #expect(cloneInvocation.cwd == "./http-clone-cwd")
 
             let renameResponse = try await client.execute(
                 uri: "/voices/clone-default/name",
@@ -254,7 +254,7 @@ extension ServerTests {
                 uri: "/speech/live",
                 method: .post,
                 headers: [.contentType: "application/json"],
-                body: byteBuffer(#"{"text":"Route test","text_profile_id":"swift-docs","request_context":{"source":"http","app":"SpeakSwiftlyServerTests","project":"SpeakSwiftlyServer","topic":"route-coverage","attributes":{"surface":"http"}},"cwd":"./Sources","repo_root":"../SpeakSwiftlyServer","text_format":"markdown","nested_source_format":"swift_source","source_format":"python_source","qwen_pre_model_text_chunking":true}"#),
+                body: byteBuffer(#"{"text":"Route test","text_profile_id":"swift-docs","request_context":{"source":"http","app":"SpeakSwiftlyServerTests","project":"SpeakSwiftlyServer","topic":"route-coverage","attributes":{"surface":"http"}},"cwd":"./Sources","repo_root":".","text_format":"markdown","nested_source_format":"swift_source","source_format":"python_source","qwen_pre_model_text_chunking":true}"#),
             )
             let speakJSON = try jsonObject(from: speakResponse.body)
             let speakJobID = try #require(speakJSON["request_id"] as? String)
@@ -267,7 +267,7 @@ extension ServerTests {
                 queuedSpeechInvocation.normalizationContext
                     == SpeechNormalizationContext(
                         cwd: "./Sources",
-                        repoRoot: "../SpeakSwiftlyServer",
+                        repoRoot: ".",
                         textFormat: .markdown,
                         nestedSourceFormat: .swift,
                     ),

--- a/Tests/SpeakSwiftlyServerTests/HostStateTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/HostStateTests.swift
@@ -408,7 +408,7 @@ import Testing
         textProfileID: "swift-docs",
         normalizationContext: .init(
             cwd: "./Sources",
-            repoRoot: "../SpeakSwiftlyServer",
+            repoRoot: ".",
             textFormat: .markdown,
             nestedSourceFormat: .swift,
         ),
@@ -428,7 +428,7 @@ import Testing
     #expect(firstQueuedSpeechInvocation.textProfileID == "swift-docs")
     let expectedNormalizationContext = SpeechNormalizationContext(
         cwd: "./Sources",
-        repoRoot: "../SpeakSwiftlyServer",
+        repoRoot: ".",
         textFormat: .markdown,
         nestedSourceFormat: .swift,
     )
@@ -636,14 +636,23 @@ import Testing
 }
 
 @Test func `runtime adapter path resolution normalizes relative and whitespace padded cwd values`() {
-    let currentDirectoryPath = "/tmp/speakswiftly-tests/workspace"
+    let temporaryRootURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("speakswiftly-tests", isDirectory: true)
+    let currentDirectoryPath = temporaryRootURL
+        .appendingPathComponent("workspace", isDirectory: true)
+        .path
+    let projectPath = temporaryRootURL
+        .appendingPathComponent("project", isDirectory: true)
+        .path
 
     #expect(
         resolvedAbsoluteFilesystemPath(
             "./Artifacts/output.wav",
-            cwd: "  /tmp/speakswiftly-tests/project  ",
+            cwd: "  \(projectPath)  ",
             currentDirectoryPath: currentDirectoryPath,
-        ) == "/tmp/speakswiftly-tests/project/Artifacts/output.wav",
+        ) == URL(fileURLWithPath: projectPath, isDirectory: true)
+            .appendingPathComponent("Artifacts/output.wav", isDirectory: false)
+            .path,
     )
 
     #expect(
@@ -651,21 +660,26 @@ import Testing
             "../Fixtures/reference.wav",
             cwd: "  ./Runs/Session  ",
             currentDirectoryPath: currentDirectoryPath,
-        ) == "/tmp/speakswiftly-tests/workspace/Runs/Fixtures/reference.wav",
+        ) == URL(fileURLWithPath: currentDirectoryPath, isDirectory: true)
+            .appendingPathComponent("Runs/Fixtures/reference.wav", isDirectory: false)
+            .path,
     )
 
+    let finalPath = temporaryRootURL
+        .appendingPathComponent("nested/../final.wav", isDirectory: false)
+        .path
     #expect(
         resolvedAbsoluteFilesystemPath(
-            "/tmp/speakswiftly-tests/../speakswiftly-tests/final.wav",
+            finalPath,
             cwd: "./ignored",
             currentDirectoryPath: currentDirectoryPath,
-        ) == "/tmp/speakswiftly-tests/final.wav",
+        ) == temporaryRootURL.appendingPathComponent("final.wav", isDirectory: false).path,
     )
 
     #expect(
         resolvedAbsoluteFilesystemPath(
             "   ",
-            cwd: "/tmp/speakswiftly-tests/project",
+            cwd: projectPath,
             currentDirectoryPath: currentDirectoryPath,
         ) == nil,
     )

--- a/Tests/SpeakSwiftlyServerTests/LaunchAgentTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/LaunchAgentTests.swift
@@ -10,7 +10,7 @@ import Testing
     let command = try LaunchAgentCommand.parse(
         arguments: ["promote-live"],
         currentDirectoryPath: repositoryRootURL.path,
-        currentExecutablePath: "/tmp/SpeakSwiftlyServerTool",
+        currentExecutablePath: testToolExecutablePath(in: repositoryRootURL),
     )
 
     switch command.action {
@@ -35,7 +35,7 @@ import Testing
         _ = try LaunchAgentCommand.parse(
             arguments: ["install"],
             currentDirectoryPath: repositoryRootURL.path,
-            currentExecutablePath: "/tmp/SpeakSwiftlyServerTool",
+            currentExecutablePath: testToolExecutablePath(in: repositoryRootURL),
         )
         Issue.record("Expected `launch-agent install` to reject a missing staged executable.")
     } catch let error as LaunchAgentCommandError {
@@ -56,7 +56,7 @@ import Testing
     let command = try LaunchAgentCommand.parse(
         arguments: ["print-plist", "--tool-executable-path", explicitToolURL.path],
         currentDirectoryPath: repositoryRootURL.path,
-        currentExecutablePath: "/tmp/SpeakSwiftlyServerTool",
+        currentExecutablePath: testToolExecutablePath(in: repositoryRootURL),
     )
 
     switch command.action {
@@ -182,7 +182,7 @@ import Testing
     )
     let options = try LaunchAgentOptions(
         label: layout.launchAgentLabel,
-        toolExecutablePath: "/tmp/SpeakSwiftlyServerTool",
+        toolExecutablePath: testToolExecutablePath(in: homeDirectoryURL),
         plistPath: layout.launchAgentPlistURL.path,
         configFilePath: layout.serverConfigFileURL.path,
         requireToolExecutableExists: false,
@@ -268,7 +268,7 @@ import Testing
             "--mcp-path", "rpc",
             "--timeout-seconds", "5",
         ],
-        currentExecutablePath: "/tmp/SpeakSwiftlyServerTool",
+        currentExecutablePath: testToolExecutablePath(),
     )
 
     switch command {
@@ -286,7 +286,7 @@ import Testing
     do {
         _ = try SpeakSwiftlyServerToolCommand.parse(
             arguments: ["wat"],
-            currentExecutablePath: "/tmp/SpeakSwiftlyServerTool",
+            currentExecutablePath: testToolExecutablePath(),
         )
         Issue.record("Expected an unknown top-level command to fail parsing.")
     } catch let error as SpeakSwiftlyServerToolCommandError {
@@ -309,4 +309,10 @@ private func makeLaunchAgentCommandTestRepository() throws -> URL {
             encoding: .utf8,
         )
     return repositoryRootURL
+}
+
+private func testToolExecutablePath(in rootURL: URL? = nil) -> String {
+    (rootURL ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true))
+        .appendingPathComponent("tmp/SpeakSwiftlyServerTool", isDirectory: false)
+        .path
 }

--- a/Tests/SpeakSwiftlyServerTests/MCPCatalogRuntimeTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/MCPCatalogRuntimeTests.swift
@@ -15,7 +15,7 @@ extension ServerTests {
                     mcpPOSTRequest(
                         body: mcpCallToolRequestJSON(
                             name: "generate_speech",
-                            argumentsJSON: #"{"text":"Inspect MCP resources","profile_name":"default","text_profile_id":"mcp-text","request_context":{"source":"mcp","app":"SpeakSwiftlyServerTests","project":"SpeakSwiftlyServer","topic":"catalog-runtime","attributes":{"surface":"mcp"}},"cwd":"./Tests","repo_root":"../SpeakSwiftlyServer","text_format":"cli_output","nested_source_format":"rust_source","source_format":"source_code","qwen_pre_model_text_chunking":true}"#,
+                            argumentsJSON: #"{"text":"Inspect MCP resources","profile_name":"default","text_profile_id":"mcp-text","request_context":{"source":"mcp","app":"SpeakSwiftlyServerTests","project":"SpeakSwiftlyServer","topic":"catalog-runtime","attributes":{"surface":"mcp"}},"cwd":"./Tests","repo_root":".","text_format":"cli_output","nested_source_format":"rust_source","source_format":"source_code","qwen_pre_model_text_chunking":true}"#,
                         ),
                         sessionID: sessionID,
                     ),
@@ -30,7 +30,7 @@ extension ServerTests {
                 queuedSpeechInvocation.normalizationContext
                     == SpeechNormalizationContext(
                         cwd: "./Tests",
-                        repoRoot: "../SpeakSwiftlyServer",
+                        repoRoot: ".",
                         textFormat: .cli,
                         nestedSourceFormat: .rust,
                     ),
@@ -59,7 +59,7 @@ extension ServerTests {
                                 "vibe": "femme",
                                 "reference_audio_path": "./Fixtures/mcp-reference.wav",
                                 "transcript": "Imported from MCP",
-                                "cwd": "/tmp/mcp-clone-cwd",
+                                "cwd": "./mcp-clone-cwd",
                             ],
                         ),
                         sessionID: sessionID,
@@ -74,7 +74,7 @@ extension ServerTests {
             #expect(createCloneInvocation.vibe == .femme)
             #expect(createCloneInvocation.referenceAudioPath == "./Fixtures/mcp-reference.wav")
             #expect(createCloneInvocation.transcript == "Imported from MCP")
-            #expect(createCloneInvocation.cwd == "/tmp/mcp-clone-cwd")
+            #expect(createCloneInvocation.cwd == "./mcp-clone-cwd")
 
             let renameVoiceToolEnvelope = try await mcpEnvelope(
                 from: mcpSurface.handle(

--- a/Tests/SpeakSwiftlyServerTests/MockRuntime+SpeechGeneration.swift
+++ b/Tests/SpeakSwiftlyServerTests/MockRuntime+SpeechGeneration.swift
@@ -80,7 +80,7 @@ extension MockRuntime {
                 ),
                 requestContext: requestContext,
                 sampleRate: 24000,
-                filePath: "/tmp/\(artifactID).wav",
+                filePath: mockArtifactPath("\(artifactID).wav"),
             )
         }
         generatedFiles.append(generatedFile)
@@ -155,7 +155,7 @@ extension MockRuntime {
                     textProfile: item.textProfile,
                     inputTextContext: item.inputTextContext,
                     sampleRate: 24000,
-                    filePath: "/tmp/\(item.artifactID ?? "\(requestID)-artifact-\(index + 1)").wav",
+                    filePath: mockArtifactPath("\(item.artifactID ?? "\(requestID)-artifact-\(index + 1)").wav"),
                 )
             }
         }
@@ -238,4 +238,10 @@ extension MockRuntime {
         }
         return RuntimeRequestHandle(id: requestID, operation: "generate_batch", profileName: profileName, events: events)
     }
+}
+
+private func mockArtifactPath(_ fileName: String) -> String {
+    URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent(fileName, isDirectory: false)
+        .path
 }

--- a/docs/investigations/e2e-marvis-queued-live-investigation.md
+++ b/docs/investigations/e2e-marvis-queued-live-investigation.md
@@ -205,7 +205,7 @@ That focused rerun shifts the problem statement:
 ### Sample evidence from the stalled MCP operator-control lane
 
 - Sample file:
-  - `/tmp/SpeakSwiftlyServerTool_mcp_operator_trace.sample.txt`
+  - `artifacts/SpeakSwiftlyServerTool_mcp_operator_trace.sample.txt`
 - The hot stack was inside `Qwen3TTSModel.generateStream(...)` and MLX eval work, not parked in the MCP transport or server event loop.
 - That means the process was still burning real generation work while the retained request snapshot remained stuck at `preroll_ready`.
 

--- a/docs/releases/v3.1.1-release-and-spi-checklist.md
+++ b/docs/releases/v3.1.1-release-and-spi-checklist.md
@@ -65,7 +65,7 @@ The script will:
 - push the branch and tag
 - create the GitHub release object through `gh` when available
 
-If you intentionally want the release flow to refresh the live per-user service afterward, rerun without `--skip-live-service-refresh` or pass an explicit config path with `--live-service-config-file /absolute/path/to/server.yaml`.
+If you intentionally want the release flow to refresh the live per-user service afterward, rerun without `--skip-live-service-refresh` or pass an explicit config path with `--live-service-config-file <server-config-yaml>`.
 
 ## Suggested Release Notes Shape
 

--- a/docs/releases/v3.1.3-release-checklist.md
+++ b/docs/releases/v3.1.3-release-checklist.md
@@ -80,7 +80,7 @@ Or pass an explicit config path:
 ```bash
 scripts/repo-maintenance/release.sh \
   --version v3.1.3 \
-  --live-service-config-file "/absolute/path/to/server.yaml"
+  --live-service-config-file "<server-config-yaml>"
 ```
 
 The script will:

--- a/scripts/repo-maintenance/lib/common.sh
+++ b/scripts/repo-maintenance/lib/common.sh
@@ -145,19 +145,20 @@ release_artifact_resources_dir() {
 }
 
 find_speak_swiftly_metallib() {
-  deterministic_metallib_path="$REPO_ROOT/../SpeakSwiftly/.local/derived-data/runtime-release/Build/Products/Release/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib"
-  metadata_path="$(speak_swiftly_runtime_root)/SpeakSwiftly.release.json"
-  if [ ! -f "$metadata_path" ]; then
-    [ -f "$deterministic_metallib_path" ] || die "Could not find SpeakSwiftly's published Release runtime metadata at $metadata_path or deterministic Release metallib at $deterministic_metallib_path. Publish and verify the sibling runtime first."
-    printf '%s\n' "$deterministic_metallib_path"
-    return
-  fi
+  bin_path="$1"
 
-  runtime_metallib_path="$(speak_swiftly_runtime_metadata_value "$metadata_path" metallib_path)"
-  [ -n "$runtime_metallib_path" ] || die "SpeakSwiftly runtime metadata at $metadata_path did not include a metallib_path value."
-  runtime_metallib_path="$(rebase_speak_swiftly_runtime_path "$metadata_path" "$runtime_metallib_path")"
-  [ -f "$runtime_metallib_path" ] || die "SpeakSwiftly runtime metadata at $metadata_path pointed at a missing metallib path: $runtime_metallib_path"
-  printf '%s\n' "$runtime_metallib_path"
+  for candidate in \
+    "$bin_path/SpeakSwiftly_SpeakSwiftly.bundle/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib" \
+    "$bin_path/SpeakSwiftly_SpeakSwiftlyCore.bundle/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib" \
+    "$bin_path/Resources/default.metallib"
+  do
+    if [ -f "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+
+  die "Release build completed, but no SpeakSwiftly MLX metallib was found in SwiftPM product directory $bin_path. Expected the SpeakSwiftly package dependency to bundle mlx-swift_Cmlx.bundle in the release build products."
 }
 
 stage_release_artifact() {
@@ -178,7 +179,7 @@ stage_release_artifact() {
   source_tool="$bin_path/SpeakSwiftlyServerTool"
   [ -f "$source_tool" ] || die "Release build completed, but the expected tool executable was not found at $source_tool."
   [ -x "$source_tool" ] || die "Release build completed, but $source_tool is not executable."
-  source_metallib="$(find_speak_swiftly_metallib)"
+  source_metallib="$(find_speak_swiftly_metallib "$bin_path")"
 
   mkdir -p "$tag_dir"
   cp "$source_tool" "$tag_dir/SpeakSwiftlyServerTool"
@@ -194,51 +195,6 @@ stage_release_artifact() {
   log "Staged release artifact at $tag_dir/SpeakSwiftlyServerTool."
   log "Staged metallib resource at $resources_dir/default.metallib."
   log "Updated current release artifact link at $current_link."
-}
-
-speak_swiftly_runtime_root() {
-  printf '%s\n' "$REPO_ROOT/../SpeakSwiftly/.local/xcode"
-}
-
-speak_swiftly_runtime_metadata_path() {
-  configuration="$1"
-  lower_configuration=$(printf '%s' "$configuration" | tr '[:upper:]' '[:lower:]')
-  metadata_path="$(speak_swiftly_runtime_root)/SpeakSwiftly.$lower_configuration.json"
-  [ -f "$metadata_path" ] || die "Could not find SpeakSwiftly's published $configuration runtime metadata at $metadata_path. Publish and verify the sibling runtime first."
-  printf '%s\n' "$metadata_path"
-}
-
-speak_swiftly_runtime_metadata_value() {
-  metadata_path="$1"
-  key="$2"
-  value=$(sed -n "s/^[[:space:]]*\"$key\"[[:space:]]*:[[:space:]]*\"\\(.*\\)\"[[:space:]]*,\{0,1\}[[:space:]]*$/\\1/p" "$metadata_path" | head -n 1)
-  printf '%s\n' "$value"
-}
-
-rebase_speak_swiftly_runtime_path() {
-  metadata_path="$1"
-  runtime_path="$2"
-
-  if [ -f "$runtime_path" ]; then
-    printf '%s\n' "$runtime_path"
-    return 0
-  fi
-
-  metadata_source_root="$(speak_swiftly_runtime_metadata_value "$metadata_path" source_root)"
-  actual_source_root="$(CDPATH= cd -- "$REPO_ROOT/../SpeakSwiftly" && pwd)"
-
-  case "$runtime_path" in
-    "$metadata_source_root"/*)
-      suffix=${runtime_path#"$metadata_source_root"/}
-      rebased_path="$actual_source_root/$suffix"
-      if [ -f "$rebased_path" ]; then
-        printf '%s\n' "$rebased_path"
-        return 0
-      fi
-      ;;
-  esac
-
-  printf '%s\n' "$runtime_path"
 }
 
 run_dispatch_dir() {

--- a/scripts/repo-maintenance/release-publish.sh
+++ b/scripts/repo-maintenance/release-publish.sh
@@ -141,12 +141,12 @@ if [ "$REPO_MAINTENANCE_REFRESH_LIVE_SERVICE" = "true" ]; then
   if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
     log "Would refresh the live LaunchAgent-backed service with $staged_tool using config $REPO_MAINTENANCE_LIVE_SERVICE_CONFIG_FILE."
   else
-    [ -n "$REPO_MAINTENANCE_LIVE_SERVICE_CONFIG_FILE" ] || die "Live service refresh requires a non-empty config file path. Pass --live-service-config-file /absolute/path/to/server.yaml or use --skip-live-service-refresh."
+    [ -n "$REPO_MAINTENANCE_LIVE_SERVICE_CONFIG_FILE" ] || die "Live service refresh requires a non-empty config file path. Pass --live-service-config-file <server-config-yaml> or use --skip-live-service-refresh."
     if [ ! -f "$REPO_MAINTENANCE_LIVE_SERVICE_CONFIG_FILE" ]; then
       if [ "$REPO_MAINTENANCE_LIVE_SERVICE_CONFIG_FILE" = "$default_live_service_config_file" ]; then
         log "Live service config is missing at $REPO_MAINTENANCE_LIVE_SERVICE_CONFIG_FILE; launch-agent install will seed the default Application Support config."
       else
-        die "Live service refresh expected a server config file at $REPO_MAINTENANCE_LIVE_SERVICE_CONFIG_FILE, but that file does not exist. Use the default Application Support config path to allow seeding, pass an existing --live-service-config-file /absolute/path/to/server.yaml, or use --skip-live-service-refresh."
+        die "Live service refresh expected a server config file at $REPO_MAINTENANCE_LIVE_SERVICE_CONFIG_FILE, but that file does not exist. Use the default Application Support config path to allow seeding, pass an existing --live-service-config-file <server-config-yaml>, or use --skip-live-service-refresh."
       fi
     fi
     [ -x "$staged_tool" ] || die "Live service refresh expected the staged release tool at $staged_tool, but it was missing or not executable."

--- a/skills/speak-swiftly-launchagent-setup/SKILL.md
+++ b/skills/speak-swiftly-launchagent-setup/SKILL.md
@@ -18,8 +18,8 @@ Use this skill when the user wants the standalone `SpeakSwiftlyServer` to run as
 
 1. Print the property list first with `xcrun swift run SpeakSwiftlyServerTool launch-agent print-plist`.
 2. Confirm the config file the service should use. The standard live-service path is `~/Library/Application Support/SpeakSwiftlyServer/server.yaml` unless the user explicitly wants another file.
-3. If the staged live artifact is already the intended executable, run `xcrun swift run SpeakSwiftlyServerTool launch-agent install --config-file /absolute/path/to/server.yaml`.
-4. If the user wants the current checkout to become the live service now, run `xcrun swift run SpeakSwiftlyServerTool launch-agent promote-live --config-file /absolute/path/to/server.yaml`.
+3. If the staged live artifact is already the intended executable, run `xcrun swift run SpeakSwiftlyServerTool launch-agent install --config-file <server-config-yaml>`.
+4. If the user wants the current checkout to become the live service now, run `xcrun swift run SpeakSwiftlyServerTool launch-agent promote-live --config-file <server-config-yaml>`.
 5. Verify the result with `xcrun swift run SpeakSwiftlyServerTool healthcheck`.
 
 ## When To Use Each Command


### PR DESCRIPTION
## Summary
- removes SpeakSwiftlyServer release/E2E dependence on an adjacent local SpeakSwiftly checkout
- stages the SpeakSwiftly metallib from the Server package's own SwiftPM build products
- removes tracked machine-local path examples from docs and tests

## Verification
- path audit: no tracked project matches for /Users, /tmp, /var/folders, /absolute/path, ../SpeakSwiftly, .local/xcode, .local/derived-data, or speak-swiftly/SpeakSwiftly outside ignored build/release artifacts
- xcrun swift build
- xcrun swift test
- SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test