### PR TITLE
launchagent: make install stage current artifact

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,19 +89,19 @@ xcrun swift run SpeakSwiftlyServerTool launch-agent print-plist
 xcrun swift run SpeakSwiftlyServerTool healthcheck
 ```
 
-Before any live end-to-end run, stop the LaunchAgent-backed live service first:
+Before any live end-to-end run, make sure the LaunchAgent-backed live service is not holding resident model memory. The current suite still fails fast when that service is loaded, so the historical manual stop command is:
 
 ```bash
 ./.release-artifacts/current/SpeakSwiftlyServerTool launch-agent uninstall
 ```
 
-That matters because the live E2E harness is intentionally a one-speaking-server surface. The helper now fails fast when the LaunchAgent-backed service is still loaded or when a competing `SpeakSwiftlyServerTool serve` process is already running.
+That command removes the installed plist, so reinstall afterward with `xcrun swift run SpeakSwiftlyServerTool launch-agent install` if you use it. The intended next simplification is to replace this destructive preflight with a live-service model unload/reload helper so the service definition stays installed while the test-owned helper has enough memory headroom.
 
 ## Development Expectations
 
 ### Naming Conventions
 
-Keep user-facing lifecycle vocabulary consistent across docs, scripts, and commands. In this repo that means preferring pairs like `install` and `uninstall`, using `promote-live` for staged-to-live promotion, and avoiding alternate verbs for the same operator action unless a compatibility surface already requires them.
+Keep user-facing lifecycle vocabulary consistent across docs, scripts, and commands. In this repo that means preferring pairs like `install` and `uninstall`, treating `install` as the normal all-in-one staged-artifact plus LaunchAgent refresh path, keeping `promote-live` as the explicit staged-to-live promotion spelling, and avoiding alternate verbs for the same operator action unless a compatibility surface already requires them.
 
 Match the current boundary language in the code:
 

--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ xcrun swift run SpeakSwiftlyServerTool serve
 
 Install or refresh the per-user LaunchAgent with a config file:
 
-This command expects the staged tool artifact to already exist at `.release-artifacts/current/SpeakSwiftlyServerTool`. On a clean checkout, build and stage the release artifact first, or pass `--tool-executable-path /path/to/SpeakSwiftlyServerTool` explicitly.
+When the default staged tool path is used, this command first builds and stages the current checkout at `.release-artifacts/current/SpeakSwiftlyServerTool`, refreshes its bundled Metal resource, refreshes the staged ad-hoc signature, and then writes and bootstraps the LaunchAgent. Pass `--tool-executable-path /path/to/SpeakSwiftlyServerTool` only when you intentionally want to install a specific prebuilt executable instead.
 
 ```bash
 xcrun swift run SpeakSwiftlyServerTool launch-agent install \
   --config-file ./server.yaml
 ```
 
-Promote the current checkout into the live LaunchAgent-backed service:
+Promote the current checkout into the live LaunchAgent-backed service explicitly:
 
 ```bash
 xcrun swift run SpeakSwiftlyServerTool launch-agent promote-live \

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentCommands.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentCommands.swift
@@ -178,7 +178,12 @@ package struct LaunchAgentCommand {
                 return try .init(action: .printPlist(LaunchAgentOptions.parse(arguments: Array(arguments.dropFirst()), currentDirectoryPath: currentDirectoryPath, currentExecutablePath: currentExecutablePath)))
 
             case "install":
-                return try .init(action: .install(LaunchAgentOptions.parse(arguments: Array(arguments.dropFirst()), currentDirectoryPath: currentDirectoryPath, currentExecutablePath: currentExecutablePath)))
+                return try .init(action: .install(LaunchAgentOptions.parse(
+                    arguments: Array(arguments.dropFirst()),
+                    currentDirectoryPath: currentDirectoryPath,
+                    currentExecutablePath: currentExecutablePath,
+                    stageDefaultReleaseArtifact: true,
+                )))
 
             case "promote-live":
                 return try .init(action: .promoteLive(LaunchAgentPromoteOptions.parse(

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentOptions+Installation.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentOptions+Installation.swift
@@ -47,16 +47,17 @@ extension LaunchAgentOptions {
     }
 
     func install() throws {
-        try prepareStagedArtifactIfNeeded()
-
         let layout = ServerInstallLayout.defaultForCurrentUser(launchAgentLabel: label)
         try ensureParentDirectory(for: plistPath)
         try FileManager.default.createDirectory(atPath: profileRootPath, withIntermediateDirectories: true)
         try ensureParentDirectory(for: standardOutPath)
         try ensureParentDirectory(for: standardErrorPath)
         try prepareLaunchAgentConfig(layout: layout)
+        let propertyListData = try propertyListData()
 
-        try propertyListData().write(to: URL(fileURLWithPath: plistPath), options: .atomic)
+        try prepareStagedArtifactIfNeeded()
+
+        try propertyListData.write(to: URL(fileURLWithPath: plistPath), options: .atomic)
         try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: plistPath)
 
         let status = LaunchAgentStatusOptions(
@@ -79,14 +80,21 @@ extension LaunchAgentOptions {
     }
 
     private func prepareStagedArtifactIfNeeded() throws {
-        guard case let .promoteCurrentCheckout(repositoryRootPath) = stagedArtifactPolicy else {
-            return
+        let stagingResult: ReleaseArtifactPromotionResult
+        switch stagedArtifactPolicy {
+            case .useExistingExecutable:
+                return
+
+            case let .promoteCurrentCheckout(repositoryRootPath):
+                stagingResult = try ReleaseArtifactPromoter.promoteLive(
+                    repositoryRootPath: repositoryRootPath,
+                    stagedExecutablePath: toolExecutablePath,
+                )
+
+            case let .custom(promote):
+                stagingResult = try promote()
         }
 
-        let stagingResult = try ReleaseArtifactPromoter.promoteLive(
-            repositoryRootPath: repositoryRootPath,
-            stagedExecutablePath: toolExecutablePath,
-        )
         print(
             """
             Staged current release artifact from '\(stagingResult.builtExecutablePath)' to '\(stagingResult.stagedExecutablePath)'.

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentOptions+Installation.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentOptions+Installation.swift
@@ -47,6 +47,8 @@ extension LaunchAgentOptions {
     }
 
     func install() throws {
+        try prepareStagedArtifactIfNeeded()
+
         let layout = ServerInstallLayout.defaultForCurrentUser(launchAgentLabel: label)
         try ensureParentDirectory(for: plistPath)
         try FileManager.default.createDirectory(atPath: profileRootPath, withIntermediateDirectories: true)
@@ -72,6 +74,24 @@ extension LaunchAgentOptions {
             """
             Installed LaunchAgent '\(label)' at '\(plistPath)' and bootstrapped it into '\(userDomain)'.
             Active tool executable: \(toolExecutableActivationSummary())
+            """,
+        )
+    }
+
+    private func prepareStagedArtifactIfNeeded() throws {
+        guard case let .promoteCurrentCheckout(repositoryRootPath) = stagedArtifactPolicy else {
+            return
+        }
+
+        let stagingResult = try ReleaseArtifactPromoter.promoteLive(
+            repositoryRootPath: repositoryRootPath,
+            stagedExecutablePath: toolExecutablePath,
+        )
+        print(
+            """
+            Staged current release artifact from '\(stagingResult.builtExecutablePath)' to '\(stagingResult.stagedExecutablePath)'.
+            Refreshed staged metallib at '\(stagingResult.stagedMetallibPath)'.
+            Refreshed staged code signature for '\(stagingResult.stagedExecutablePath)'.
             """,
         )
     }

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentOptions.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentOptions.swift
@@ -4,6 +4,7 @@ struct LaunchAgentOptions {
     enum StagedArtifactPolicy {
         case useExistingExecutable
         case promoteCurrentCheckout(repositoryRootPath: String)
+        case custom(@Sendable () throws -> ReleaseArtifactPromotionResult)
     }
 
     let label: String

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentOptions.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentOptions.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 struct LaunchAgentOptions {
+    enum StagedArtifactPolicy {
+        case useExistingExecutable
+        case promoteCurrentCheckout(repositoryRootPath: String)
+    }
+
     let label: String
     let toolExecutablePath: String
     let plistPath: String
@@ -12,6 +17,7 @@ struct LaunchAgentOptions {
     let standardErrorPath: String
     let launchctlPath: String
     let userDomain: String
+    let stagedArtifactPolicy: StagedArtifactPolicy
 
     // MARK: - Initialization
 
@@ -28,6 +34,7 @@ struct LaunchAgentOptions {
         launchctlPath: String = LaunchAgentDefaults.launchctlPath,
         userDomain: String = LaunchAgentDefaults.userDomain,
         requireToolExecutableExists: Bool = true,
+        stagedArtifactPolicy: StagedArtifactPolicy = .useExistingExecutable,
     ) throws {
         guard !label.isEmpty else {
             throw LaunchAgentCommandError("\(speakSwiftlyServerToolName) launch-agent support requires a non-empty launchd label.")
@@ -58,6 +65,7 @@ struct LaunchAgentOptions {
         self.standardErrorPath = Self.resolvePath(standardErrorPath)
         self.launchctlPath = launchctlPath
         self.userDomain = userDomain
+        self.stagedArtifactPolicy = stagedArtifactPolicy
     }
 
     static func parse(
@@ -65,6 +73,7 @@ struct LaunchAgentOptions {
         currentDirectoryPath: String,
         currentExecutablePath: String,
         requireToolExecutableExists: Bool = true,
+        stageDefaultReleaseArtifact: Bool = false,
     ) throws -> LaunchAgentOptions {
         var label = LaunchAgentDefaults.label
         let _ = currentExecutablePath
@@ -124,10 +133,26 @@ struct LaunchAgentOptions {
             }
         }
 
+        let usingDefaultStagedArtifact = toolExecutablePathOverride == nil
+        let repositoryRootPath: String? = if usingDefaultStagedArtifact {
+            try resolveRepositoryRoot(startingAt: currentDirectoryPath)
+        } else {
+            nil
+        }
         let toolExecutablePath = try toolExecutablePathOverride ?? resolveDefaultToolExecutablePath(
-            currentDirectoryPath: currentDirectoryPath,
-            mustExist: requireToolExecutableExists,
+            repositoryRootPath: repositoryRootPath ?? currentDirectoryPath,
+            mustExist: requireToolExecutableExists && !stageDefaultReleaseArtifact,
         )
+        let shouldRequireExecutable = if usingDefaultStagedArtifact, stageDefaultReleaseArtifact {
+            false
+        } else {
+            requireToolExecutableExists
+        }
+        let stagedArtifactPolicy: StagedArtifactPolicy = if usingDefaultStagedArtifact, stageDefaultReleaseArtifact {
+            .promoteCurrentCheckout(repositoryRootPath: repositoryRootPath ?? currentDirectoryPath)
+        } else {
+            .useExistingExecutable
+        }
 
         return try .init(
             label: label,
@@ -139,7 +164,8 @@ struct LaunchAgentOptions {
             profileRootPath: resolvePath(profileRootPath, relativeTo: currentDirectoryPath),
             standardOutPath: resolvePath(standardOutPath, relativeTo: currentDirectoryPath),
             standardErrorPath: resolvePath(standardErrorPath, relativeTo: currentDirectoryPath),
-            requireToolExecutableExists: requireToolExecutableExists,
+            requireToolExecutableExists: shouldRequireExecutable,
+            stagedArtifactPolicy: stagedArtifactPolicy,
         )
     }
 
@@ -150,7 +176,14 @@ struct LaunchAgentOptions {
         mustExist: Bool = true,
     ) throws -> String {
         let repositoryRoot = try resolveRepositoryRoot(startingAt: currentDirectoryPath)
-        let stagedReleasePath = LaunchAgentDefaults.stagedReleaseToolExecutablePath(for: repositoryRoot)
+        return try resolveDefaultToolExecutablePath(repositoryRootPath: repositoryRoot, mustExist: mustExist)
+    }
+
+    static func resolveDefaultToolExecutablePath(
+        repositoryRootPath: String,
+        mustExist: Bool = true,
+    ) throws -> String {
+        let stagedReleasePath = LaunchAgentDefaults.stagedReleaseToolExecutablePath(for: repositoryRootPath)
 
         guard mustExist == false || FileManager.default.fileExists(atPath: stagedReleasePath) else {
             throw LaunchAgentCommandError(

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentPromotion.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentPromotion.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 struct LaunchAgentPromoteOptions {
@@ -77,27 +78,124 @@ enum ReleaseArtifactPromoter {
             .appendingPathComponent("Resources", isDirectory: true)
             .appendingPathComponent("default.metallib", isDirectory: false)
 
-        try FileManager.default.createDirectory(at: stagedDirectoryURL, withIntermediateDirectories: true)
-        try replaceItem(
-            at: stagedExecutableURL,
-            with: URL(fileURLWithPath: builtExecutablePath, isDirectory: false),
-            permissions: 0o755,
-        )
         try FileManager.default.createDirectory(
             at: stagedMetallibURL.deletingLastPathComponent(),
             withIntermediateDirectories: true,
         )
-        try replaceItem(
+
+        let preparedExecutableURL = try prepareReplacementItem(
+            at: stagedExecutableURL,
+            with: URL(fileURLWithPath: builtExecutablePath, isDirectory: false),
+            permissions: 0o755,
+            prepareTemporaryItem: refreshAdHocSignature,
+        )
+        defer {
+            try? FileManager.default.removeItem(at: preparedExecutableURL)
+        }
+
+        let preparedMetallibURL = try prepareReplacementItem(
             at: stagedMetallibURL,
             with: builtMetallibURL,
         )
-        try refreshAdHocSignature(for: stagedExecutableURL)
+        defer {
+            try? FileManager.default.removeItem(at: preparedMetallibURL)
+        }
+
+        let metallibBackupURL = try backupItemIfPresent(at: stagedMetallibURL)
+        defer {
+            if let metallibBackupURL {
+                try? FileManager.default.removeItem(at: metallibBackupURL)
+            }
+        }
+
+        try commitPreparedReplacement(preparedMetallibURL, to: stagedMetallibURL)
+        do {
+            try commitPreparedReplacement(preparedExecutableURL, to: stagedExecutableURL)
+        } catch {
+            try rollbackItem(at: stagedMetallibURL, from: metallibBackupURL, after: error)
+            throw error
+        }
 
         return .init(
             builtExecutablePath: builtExecutablePath,
             stagedExecutablePath: stagedExecutableURL.path,
             stagedMetallibPath: stagedMetallibURL.path,
         )
+    }
+
+    static func replaceItem(
+        at destinationURL: URL,
+        with sourceURL: URL,
+        permissions: NSNumber? = nil,
+    ) throws {
+        let temporaryURL = try prepareReplacementItem(
+            at: destinationURL,
+            with: sourceURL,
+            permissions: permissions,
+        )
+        defer {
+            try? FileManager.default.removeItem(at: temporaryURL)
+        }
+
+        try commitPreparedReplacement(temporaryURL, to: destinationURL)
+    }
+
+    private static func prepareReplacementItem(
+        at destinationURL: URL,
+        with sourceURL: URL,
+        permissions: NSNumber? = nil,
+        prepareTemporaryItem: ((URL) throws -> Void)? = nil,
+    ) throws -> URL {
+        let temporaryURL = destinationURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(".\(destinationURL.lastPathComponent).\(UUID().uuidString).tmp", isDirectory: false)
+
+        try FileManager.default.copyItem(at: sourceURL, to: temporaryURL)
+        if let permissions {
+            try FileManager.default.setAttributes([.posixPermissions: permissions], ofItemAtPath: temporaryURL.path)
+        }
+        try prepareTemporaryItem?(temporaryURL)
+
+        return temporaryURL
+    }
+
+    private static func commitPreparedReplacement(_ temporaryURL: URL, to destinationURL: URL) throws {
+        guard rename(temporaryURL.path, destinationURL.path) == 0 else {
+            let failureDescription = String(cString: strerror(errno))
+            throw LaunchAgentCommandError(
+                "\(speakSwiftlyServerToolName) could not atomically replace staged artifact '\(destinationURL.path)' with temporary artifact '\(temporaryURL.path)'. Likely cause: \(failureDescription)",
+            )
+        }
+    }
+
+    private static func backupItemIfPresent(at destinationURL: URL) throws -> URL? {
+        guard FileManager.default.fileExists(atPath: destinationURL.path) else {
+            return nil
+        }
+
+        let backupURL = destinationURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(".\(destinationURL.lastPathComponent).\(UUID().uuidString).backup", isDirectory: false)
+        try FileManager.default.copyItem(at: destinationURL, to: backupURL)
+        return backupURL
+    }
+
+    private static func rollbackItem(
+        at destinationURL: URL,
+        from backupURL: URL?,
+        after replacementError: Error,
+    ) throws {
+        do {
+            if let backupURL {
+                try commitPreparedReplacement(backupURL, to: destinationURL)
+            } else if FileManager.default.fileExists(atPath: destinationURL.path) {
+                try FileManager.default.removeItem(at: destinationURL)
+            }
+        } catch {
+            throw LaunchAgentCommandError(
+                "\(speakSwiftlyServerToolName) could not roll back staged artifact '\(destinationURL.path)' after promotion failed. Promotion error: \(replacementError). Rollback error: \(error).",
+            )
+        }
     }
 
     private static func buildReleaseTool(repositoryRootPath: String) throws {
@@ -155,20 +253,6 @@ enum ReleaseArtifactPromoter {
         throw LaunchAgentCommandError(
             "\(speakSwiftlyServerToolName) completed a release build, but no SpeakSwiftly MLX metallib was found in SwiftPM product directory '\(productsURL.path)'. Expected the SpeakSwiftly package dependency to bundle mlx-swift_Cmlx.bundle in the release build products.",
         )
-    }
-
-    private static func replaceItem(
-        at destinationURL: URL,
-        with sourceURL: URL,
-        permissions: NSNumber? = nil,
-    ) throws {
-        if FileManager.default.fileExists(atPath: destinationURL.path) {
-            try FileManager.default.removeItem(at: destinationURL)
-        }
-        try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
-        if let permissions {
-            try FileManager.default.setAttributes([.posixPermissions: permissions], ofItemAtPath: destinationURL.path)
-        }
     }
 
     private static func refreshAdHocSignature(for executableURL: URL) throws {

--- a/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentPromotion.swift
+++ b/Sources/SpeakSwiftlyServer/LaunchAgent/LaunchAgentPromotion.swift
@@ -53,13 +53,13 @@ struct LaunchAgentPromoteOptions {
     }
 }
 
-private struct ReleaseArtifactPromotionResult {
+struct ReleaseArtifactPromotionResult {
     let builtExecutablePath: String
     let stagedExecutablePath: String
     let stagedMetallibPath: String
 }
 
-private enum ReleaseArtifactPromoter {
+enum ReleaseArtifactPromoter {
     static func promoteLive(
         repositoryRootPath: String,
         stagedExecutablePath: String,

--- a/Tests/SpeakSwiftlyServerE2ETests/SpeakSwiftlyServerE2EServerHelpers.swift
+++ b/Tests/SpeakSwiftlyServerE2ETests/SpeakSwiftlyServerE2EServerHelpers.swift
@@ -95,7 +95,7 @@ extension ServerE2E {
     }
 
     static func randomPort(in range: Range<Int>) -> Int {
-        let shuffledCandidates = Array(range).shuffled()
+        let shuffledCandidates = Array(range).filter { !reservedLiveServicePorts.contains($0) }.shuffled()
         if let availablePort = shuffledCandidates.first(where: isPortAvailable(_:)) {
             return availablePort
         }
@@ -114,6 +114,8 @@ extension ServerE2E {
     }
 
     // MARK: - Port Selection
+
+    private static let reservedLiveServicePorts: Set<Int> = [7337, 7338, 7339]
 
     private static func isPortAvailable(_ port: Int) -> Bool {
 #if canImport(Darwin)

--- a/Tests/SpeakSwiftlyServerTests/LaunchAgentTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/LaunchAgentTests.swift
@@ -28,6 +28,24 @@ import Testing
     }
 }
 
+@Test func `release artifact replacement keeps existing destination when source copy fails`() throws {
+    let temporaryRootURL = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: temporaryRootURL, withIntermediateDirectories: true)
+
+    let destinationURL = temporaryRootURL.appendingPathComponent("SpeakSwiftlyServerTool", isDirectory: false)
+    let missingSourceURL = temporaryRootURL.appendingPathComponent("missing-tool", isDirectory: false)
+    try "existing staged tool".write(to: destinationURL, atomically: true, encoding: .utf8)
+
+    do {
+        try ReleaseArtifactPromoter.replaceItem(at: destinationURL, with: missingSourceURL, permissions: 0o755)
+        Issue.record("Expected replacement to fail when the source artifact is missing.")
+    } catch {
+        let stagedContent = try String(contentsOf: destinationURL, encoding: .utf8)
+        #expect(stagedContent == "existing staged tool")
+    }
+}
+
 @Test func `launch agent install stages default artifact when it is missing`() throws {
     let repositoryRootURL = try makeLaunchAgentCommandTestRepository()
 

--- a/Tests/SpeakSwiftlyServerTests/LaunchAgentTests.swift
+++ b/Tests/SpeakSwiftlyServerTests/LaunchAgentTests.swift
@@ -28,18 +28,32 @@ import Testing
     }
 }
 
-@Test func `launch agent install still rejects missing staged executable by default`() throws {
+@Test func `launch agent install stages default artifact when it is missing`() throws {
     let repositoryRootURL = try makeLaunchAgentCommandTestRepository()
 
-    do {
-        _ = try LaunchAgentCommand.parse(
-            arguments: ["install"],
-            currentDirectoryPath: repositoryRootURL.path,
-            currentExecutablePath: testToolExecutablePath(in: repositoryRootURL),
-        )
-        Issue.record("Expected `launch-agent install` to reject a missing staged executable.")
-    } catch let error as LaunchAgentCommandError {
-        #expect(error.message.contains("could not find the staged release artifact"))
+    let command = try LaunchAgentCommand.parse(
+        arguments: ["install"],
+        currentDirectoryPath: repositoryRootURL.path,
+        currentExecutablePath: testToolExecutablePath(in: repositoryRootURL),
+    )
+
+    switch command.action {
+        case let .install(options):
+            guard case let .promoteCurrentCheckout(repositoryRootPath) = options.stagedArtifactPolicy else {
+                Issue.record("Expected `launch-agent install` to stage the current checkout for the default artifact path.")
+                return
+            }
+
+            #expect(repositoryRootPath == repositoryRootURL.path)
+            #expect(
+                options.toolExecutablePath
+                    == repositoryRootURL
+                    .appendingPathComponent(".release-artifacts/current/SpeakSwiftlyServerTool", isDirectory: false)
+                    .path,
+            )
+
+        default:
+            Issue.record("Expected `launch-agent install` to parse into the install action.")
     }
 }
 

--- a/Tests/SpeakSwiftlyServerToolTests/SpeakSwiftlyServerToolTests.swift
+++ b/Tests/SpeakSwiftlyServerToolTests/SpeakSwiftlyServerToolTests.swift
@@ -49,6 +49,12 @@ import Testing
     #expect(options.toolExecutablePath == stagedToolURL.path)
     #expect(options.configFilePath == tempDirectory.appendingPathComponent("server.yaml").path)
     #expect(options.reloadIntervalSeconds == "2")
+    guard case let .promoteCurrentCheckout(repositoryRootPath) = options.stagedArtifactPolicy else {
+        Issue.record("Expected launch-agent install to stage the current checkout when using the default release artifact.")
+        return
+    }
+
+    #expect(repositoryRootPath == tempDirectory.path)
 }
 
 @Test func `tool parses serve profile root option`() throws {
@@ -89,7 +95,7 @@ import Testing
     )
 }
 
-@Test func `tool rejects install when staged release artifact is missing`() throws {
+@Test func `tool parses install when staged release artifact is missing`() throws {
     let tempDirectory = try makeTemporaryDirectory()
     try FileManager.default.createDirectory(
         at: tempDirectory.appendingPathComponent("Sources/SpeakSwiftlyServerTool", isDirectory: true),
@@ -106,13 +112,26 @@ import Testing
     try "#!/bin/sh\nexit 0\n".write(to: currentToolURL, atomically: true, encoding: .utf8)
     try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: currentToolURL.path)
 
-    #expect(throws: LaunchAgentCommandError.self) {
-        try SpeakSwiftlyServerToolCommand.parse(
-            arguments: ["launch-agent", "install"],
-            currentDirectoryPath: tempDirectory.path,
-            currentExecutablePath: currentToolURL.path,
-        )
+    let command = try SpeakSwiftlyServerToolCommand.parse(
+        arguments: ["launch-agent", "install"],
+        currentDirectoryPath: tempDirectory.path,
+        currentExecutablePath: currentToolURL.path,
+    )
+
+    guard case let .launchAgent(launchAgentCommand) = command,
+          case let .install(options) = launchAgentCommand.action,
+          case let .promoteCurrentCheckout(repositoryRootPath) = options.stagedArtifactPolicy else {
+        Issue.record("Expected launch-agent install to stage the current checkout instead of requiring a preexisting staged executable.")
+        return
     }
+
+    #expect(repositoryRootPath == tempDirectory.path)
+    #expect(
+        options.toolExecutablePath
+            == tempDirectory
+            .appendingPathComponent(".release-artifacts/current/SpeakSwiftlyServerTool", isDirectory: false)
+            .path,
+    )
 }
 
 @Test func `launch agent property list includes serve command and environment overrides`() throws {

--- a/Tests/SpeakSwiftlyServerToolTests/SpeakSwiftlyServerToolTests.swift
+++ b/Tests/SpeakSwiftlyServerToolTests/SpeakSwiftlyServerToolTests.swift
@@ -227,6 +227,49 @@ import Testing
     #expect(launchctlLog.contains("bootstrap gui/501 \(plistURL.path)"))
 }
 
+@Test func `launch agent install validates explicit config before staging default artifact`() throws {
+    let tempDirectory = try makeTemporaryDirectory()
+    let executableURL = tempDirectory.appendingPathComponent("SpeakSwiftlyServerTool")
+    let plistURL = tempDirectory.appendingPathComponent("LaunchAgents/com.example.test.plist")
+    let missingConfigURL = tempDirectory.appendingPathComponent("config/missing-server.yaml", isDirectory: false)
+
+    try "#!/bin/sh\nexit 0\n".write(to: executableURL, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executableURL.path)
+
+    let stagingProbe = StagingProbe()
+    let options = try LaunchAgentOptions(
+        label: "com.example.test",
+        toolExecutablePath: executableURL.path,
+        plistPath: plistURL.path,
+        configFilePath: missingConfigURL.path,
+        workingDirectory: tempDirectory.path,
+        profileRootPath: tempDirectory.appendingPathComponent("runtime/profiles").path,
+        standardOutPath: tempDirectory.appendingPathComponent("logs/stdout.log").path,
+        standardErrorPath: tempDirectory.appendingPathComponent("logs/stderr.log").path,
+        launchctlPath: "/usr/bin/false",
+        userDomain: "gui/501",
+        stagedArtifactPolicy: .custom {
+            stagingProbe.markStaged()
+            return ReleaseArtifactPromotionResult(
+                builtExecutablePath: executableURL.path,
+                stagedExecutablePath: executableURL.path,
+                stagedMetallibPath: executableURL.path,
+            )
+        },
+    )
+
+    do {
+        try options.install()
+        Issue.record("Expected launch-agent install to reject a missing explicit config file before staging.")
+    } catch let error as LaunchAgentCommandError {
+        #expect(error.message.contains("explicit config file"))
+        #expect(error.message.contains(missingConfigURL.path))
+    }
+
+    #expect(stagingProbe.didStageArtifact == false)
+    #expect(FileManager.default.fileExists(atPath: plistURL.path) == false)
+}
+
 @Test func `launch agent install waits for bootout and retries bootstrap race`() throws {
     let tempDirectory = try makeTemporaryDirectory()
     let executableURL = tempDirectory.appendingPathComponent("SpeakSwiftlyServerTool")
@@ -365,4 +408,19 @@ private func makeTemporaryDirectory() throws -> URL {
         .appendingPathComponent(UUID().uuidString, isDirectory: true)
     try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
     return url
+}
+
+private final class StagingProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var staged = false
+
+    var didStageArtifact: Bool {
+        lock.withLock { staged }
+    }
+
+    func markStaged() {
+        lock.withLock {
+            staged = true
+        }
+    }
 }

--- a/docs/maintainers/live-service-reliability-follow-ups.md
+++ b/docs/maintainers/live-service-reliability-follow-ups.md
@@ -108,17 +108,19 @@ This should make "MCP disabled because config never loaded" visible within the f
 
 ### 6. Make staged-artifact promotion and signature handling explicit
 
-Today's live promotion showed that `launch-agent install` is not the same operation as "promote the currently checked-out code into the live service". `launch-agent install` rewrites or refreshes the property list and bootstraps launchd, but it still runs whichever binary already lives at `.release-artifacts/current/SpeakSwiftlyServerTool`.
+Today's live promotion showed that `launch-agent install` is not the same operation as "promote the currently checked-out code into the live service". Older `launch-agent install` rewrote or refreshed the property list and bootstrapped launchd, but still ran whichever binary already lived at `.release-artifacts/current/SpeakSwiftlyServerTool`.
+
+Status update: the default `launch-agent install` path now builds and stages the current checkout before writing and bootstrapping the LaunchAgent. Explicit `--tool-executable-path` installs still use the caller-provided executable without overwriting it.
 
 That leaves one easy operator trap:
 
 - a source-level fix can be merged and validated locally
-- `launch-agent install` can be rerun successfully
-- the live service can still come back on an older staged executable unless the staged artifact is refreshed first
+- an explicit `--tool-executable-path` install can be rerun successfully
+- the live service can still come back on an older custom executable unless that explicit executable is refreshed first
 
 The package should make that boundary explicit and first-class:
 
-- add a supported operator verb for refreshing or promoting the staged executable instead of relying on manual file copies
+- keep the default `install` path as the supported all-in-one refresh path instead of relying on manual file copies
 - document whether staged artifacts must be re-signed after in-place refreshes and encode that behavior in the supported path instead of making it a tribal-knowledge repair
 - emit operator-facing output that names the exact staged executable path and modification time that the LaunchAgent install is about to activate
 - add verification that the live running process, the staged artifact, and the intended source build all agree on the same executable revision
@@ -185,17 +187,19 @@ The remaining follow-through here is mostly discipline:
 - keep the server package live suite transport-owned
 - avoid regrowing playback-heavy or model-specific assertions in this repo unless the server itself adds a new transport contract
 - keep the smoke cases pointed at the actual shipped HTTP and MCP names so release verification still proves the operator surface we publish
+- replace the current destructive LaunchAgent uninstall preflight with a live-service memory-headroom preflight that unloads resident models before tests and reloads them afterward, but only when the live service is reachable and idle enough for that mutation to be safe
 
 ## Suggested Tracking Order
 
 If these follow-ups are tackled incrementally, the highest-value order is:
 
 1. LaunchAgent smoke test with spaced config path plus HTTP and MCP probes.
-2. Staged-artifact promotion hardening, including an explicit promote or update path and any required re-sign behavior.
-3. First-class live service health-check command.
-4. Better startup and config-open logging.
-5. Reusable repo-owned MCP smoke helper.
-6. Config reload architecture decision for LaunchAgent-owned startup files.
+2. Replace destructive E2E uninstall guidance with an idle-aware resident-model unload/reload preflight.
+3. Staged-artifact promotion hardening, including the all-in-one install path and any required re-sign behavior.
+4. First-class live service health-check command.
+5. Better startup and config-open logging.
+6. Reusable repo-owned MCP smoke helper.
+7. Config reload architecture decision for LaunchAgent-owned startup files.
 
 ## Package-Wide Hardening Pass Order
 


### PR DESCRIPTION
## Summary

- make `launch-agent install` build and stage the current checkout before writing and bootstrapping the plist when using the default staged executable
- keep explicit `--tool-executable-path` installs pinned to the caller-provided executable
- reserve known service ports 7337, 7338, and 7339 from live E2E random port selection

## Release

Patch release candidate. This tightens live-service install/recovery behavior without changing the public HTTP or MCP contract.

## Verification

- `xcrun swift test --filter LaunchAgentTests`
- `xcrun swift test --filter SpeakSwiftlyServerToolTests`
- `xcrun swift test`
- `swiftformat --lint --config .swiftformat Tests/SpeakSwiftlyServerE2ETests/SpeakSwiftlyServerE2EServerHelpers.swift`
