### PR TITLE
tests: keep live service installed for e2e

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ Use `--skip-version-bump` for releases unless this repo later adds an executable
 - Relevant source, docs, tests, package graph files, and maintainer scripts are updated together.
 - `sh scripts/repo-maintenance/validate-all.sh` passes, or any skipped portion is explicitly explained with the reason.
 - README, CONTRIBUTING, AGENTS, maintainer docs, and release guidance agree about the current command path.
-- Live end-to-end suites are only run after stopping the LaunchAgent-backed live service, and those suites are run one at a time.
+- Live end-to-end suites are run one at a time after the live-service resident-model unload preflight has created enough memory headroom.
 
 ## Safety Boundaries
 
@@ -128,7 +128,7 @@ Use `--skip-version-bump` for releases unless this repo later adds an executable
 - Never edit or experiment in `../../speak-to-user/monorepo` as a feature workspace; keep it as the clean integration checkout.
 - Never retarget public dependency declarations to machine-local paths such as `/Users/...`, `~/...`, or `../...`.
 - Never run overlapping SwiftPM, Xcode, or live end-to-end test processes on this machine.
-- Never run live `SpeakSwiftlyServerE2ETests` while the LaunchAgent-backed live service is still running.
+- Never run live `SpeakSwiftlyServerE2ETests` before the live-service resident-model unload preflight has completed.
 - Never make live-service code changes directly in a live local service repo when a separate development repo exists.
 - Never leave duplicate release command stories active after a release workflow alignment.
 
@@ -147,7 +147,7 @@ No deeper `AGENTS.md` files are currently checked in below this repository root.
 
 - Use `xcrun swift build` and `xcrun swift test` as the default first-pass validation commands so repo-local SwiftPM work stays on the Xcode-selected toolchain.
 - Treat the live `SpeakSwiftlyServerE2ETests` target as a one-process, one-suite-at-a-time surface. Even though the target is split into HTTP, MCP, and control suites, those live end-to-end suites must always be run sequentially in separate foreground commands and must never overlap in parallel.
-- Before running any live end-to-end suite, stop the LaunchAgent-backed live service first so the machine does not end up speaking from both the always-on service and the test-owned helper at the same time. Use `./.release-artifacts/current/SpeakSwiftlyServerTool launch-agent uninstall` unless a future repo-owned operator command replaces it.
+- Before running any live end-to-end suite, use the live-service resident-model unload preflight so the installed LaunchAgent-backed service stays installed while the test-owned helper has enough memory headroom. Do not uninstall the live service as an E2E preflight.
 - Use `bootstrap-swift-package` only when a brand-new Swift package repository still needs to be created from scratch.
 - Use `sync-swift-package-guidance` when this repo guidance drifts and needs a deliberate refresh against the current Swift package baseline.
 - Use `swift-package-build-run-workflow` for manifest, dependency, build, run, resource, and packaging work when `Package.swift` is the source of truth.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,13 +89,7 @@ xcrun swift run SpeakSwiftlyServerTool launch-agent print-plist
 xcrun swift run SpeakSwiftlyServerTool healthcheck
 ```
 
-Before any live end-to-end run, make sure the LaunchAgent-backed live service is not holding resident model memory. The current suite still fails fast when that service is loaded, so the historical manual stop command is:
-
-```bash
-./.release-artifacts/current/SpeakSwiftlyServerTool launch-agent uninstall
-```
-
-That command removes the installed plist, so reinstall afterward with `xcrun swift run SpeakSwiftlyServerTool launch-agent install` if you use it. The intended next simplification is to replace this destructive preflight with a live-service model unload/reload helper so the service definition stays installed while the test-owned helper has enough memory headroom.
+Before any live end-to-end run, make sure the LaunchAgent-backed live service has released resident model memory through the live-service model unload preflight. Leave the installed service in place; the E2E helper runs on its own random ports and only needs comfortable memory headroom.
 
 ## Development Expectations
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ xcrun swift run SpeakSwiftlyServerTool launch-agent install \
   --config-file ./server.yaml
 ```
 
-Promote the current checkout into the live LaunchAgent-backed service explicitly:
+Use the explicit promotion command when you want the lower-level "build, stage, then reinstall" spelling. This is mostly useful for release or operator scripts that want to name the promotion step directly; ordinary default-path refreshes can use `install`.
 
 ```bash
 xcrun swift run SpeakSwiftlyServerTool launch-agent promote-live \

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,7 +62,7 @@
 - [x] Switch this package from subprocess-style integration to direct `SpeakSwiftly` package import when that library product exists.
 - [x] Collapse temporary integration-only scaffolding that became unnecessary after direct import.
 - [x] Align the runtime bridge with the public `SpeakSwiftly` library surface instead of constructing raw worker requests across the library boundary.
-- [x] Re-align this package with the repackaged `SpeakSwiftly` plus direct `TextForSpeech` dependency surface so `swift build` and `swift test` work against the current sibling checkout again.
+- [x] Re-align this package with the repackaged `SpeakSwiftly` plus direct `TextForSpeech` dependency surface so `xcrun swift build` and `xcrun swift test` work against the current package graph again.
 - [x] Adopt the updated `SpeakSwiftly.Runtime.speak(..., textProfileName:textContext:id:)` signature and remove assumptions about older normalization-only entrypoints.
 - [x] Add the new voice-clone creation flow across host, HTTP, MCP, and tests.
 - [x] Expose the new text-profile inspection and editing helpers across HTTP and MCP with a transport model that stays distinct from stored voice-profile jobs.
@@ -115,11 +115,11 @@ Current note: distribution polish for discovery and packaging, not a current rel
 - [x] Add a deliberately small executable-oriented companion article set for `SpeakSwiftlyServerTool` without duplicating the full repository operator docs.
 - [x] Add the short tutorial-style walkthrough described in `docs/maintainers/docc-spi-hosting-plan.md` so the hosted docs have a concrete embedded-session first-use path.
 - [x] Add a DocC build check both locally through `scripts/repo-maintenance/validate-all.sh` and in GitHub Actions before the package is submitted to Swift Package Index.
-- [ ] Submit the package to Swift Package Index once the current patch release candidate (`v3.1.1`) is tagged, pushed, and checked against the maintainer SPI submission checklist.
+- [ ] Submit the package to Swift Package Index once the package metadata and hosted DocC surface are ready for public indexing.
 
 ## Milestone 11: SpeakSwiftly 3.x Surface Adoption
 
-Current note: this milestone tracks the server-side adoption work for the newer `SpeakSwiftly` runtime surface through the current `3.0.3` alignment pass.
+Current note: this milestone tracks the server-side adoption work for the newer `SpeakSwiftly` runtime surface. The older 3.x migration is complete; remaining items are follow-on parity and shaping work on top of the current 4.x package line.
 
 - [x] Carry explicit `vibe` through the existing profile and clone creation surfaces instead of preserving the older implicit-profile behavior as the server moved onto the newer `SpeakSwiftly` runtime surface.
 - [x] Expose the persisted `SpeakSwiftly.Configuration` surface across host state, HTTP, and MCP so operators can inspect and change the active speech backend without reaching into the runtime process manually.
@@ -128,11 +128,11 @@ Current note: this milestone tracks the server-side adoption work for the newer 
 - [x] Split the oversized host, model, and mixed route-test sources into concern-focused files and refresh the maintainer docs around that layout so future cleanup does not regrow monoliths.
 - [x] Finish the operator-control E2E realignment so it uses the renamed HTTP surface consistently and validates long live playback with varied text instead of repeated-sentence filler.
 - [x] Re-run the full live E2E suite after the resource-bundling and transport-surface realignment updates and verify the renamed MCP surface and operator-control flows end to end.
-- [x] Bump the resolved `SpeakSwiftly` dependency to the current `v3.0.3` package state, including the `TextForSpeech 0.16.x` compatibility updates that follow from that runtime surface.
+- [x] Bump the resolved `SpeakSwiftly` dependency through the newer 4.x package state, including the matching `TextForSpeech` compatibility updates that follow from that runtime surface.
 - [x] Expose `runtime.voices.rename(_:to:)` and `runtime.voices.reroll(_:)` across host, HTTP, MCP, docs, and controlled-runtime tests.
-- [ ] Add generated-file reads across host, HTTP, MCP, and shared resources so saved artifacts can be listed and fetched through the server instead of only inside the sibling library.
-- [ ] Add generation-job reads and expiry controls across host, HTTP, MCP, and shared resources so persisted file and batch jobs can be inspected and managed directly.
-- [ ] Add batch-generation submission plus batch-read surfaces across host, HTTP, MCP, and shared resources, including artifact-id shaping and the existing text-format / source-format context support for each batch item.
+- [x] Add generated-file reads across host, HTTP, MCP, and shared resources so saved artifacts can be listed and fetched through the server instead of only inside the sibling library.
+- [x] Add generation-job reads and expiry controls across host, HTTP, MCP, and shared resources so persisted file and batch jobs can be inspected and managed directly.
+- [x] Add batch-generation submission plus batch-read surfaces across host, HTTP, MCP, and shared resources, including artifact-id shaping and the existing text-format / source-format context support for each batch item.
 - [ ] Revisit server-local job and snapshot shaping so the new immediate generation-control operations and persisted generation-job reads map directly to runtime concepts instead of keeping legacy server-only wrappers around them.
 - [x] Expand README, MCP tool docs, shared resources, and opt-in live E2E coverage so `marvis` vs `qwen3`, explicit `vibe`, generated files, generation jobs, and batch generation are all documented and verified end to end.
 
@@ -165,7 +165,7 @@ Post-`v2.0.4` note: these items capture the next hardening pass after the Launch
 - [ ] Decide whether LaunchAgent-owned startup config should keep using a reloading provider or move to a simpler startup-open path with reload support layered on intentionally later.
 - [ ] Promote the existing MCP E2E client utilities into a reusable repo-owned smoke helper for local checks, CI, and release verification.
 - [ ] Add a maintainer-facing release verification path that confirms the staged release artifact, LaunchAgent install, runtime host overview, and MCP initialize flow all agree.
-- [ ] Split transport smoke coverage more clearly from long audible-playback E2E coverage so failures localize faster.
+- [x] Split transport smoke coverage more clearly from long audible-playback E2E coverage so failures localize faster.
 
 ## Milestone 15: Toolchain Repro And Upstream Follow-Through
 

--- a/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/LaunchAgent-Workflow.md
+++ b/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/LaunchAgent-Workflow.md
@@ -7,7 +7,7 @@ Use the LaunchAgent workflow when the standalone server should run as a per-user
 In this package, that workflow is intentionally explicit:
 
 1. render the property list you are about to install
-2. either install the already-staged artifact or promote the current source checkout into the staged live artifact
+2. install the default staged artifact from the current checkout, or intentionally pin the install to a caller-provided executable
 3. inspect status or remove it later through the same executable surface
 4. verify the live HTTP and MCP transports through one repo-owned health-check command
 
@@ -47,14 +47,16 @@ the only path that install and refresh flows seed automatically.
 
 This package's LaunchAgent path is designed around the staged release artifact, not around whichever debug binary happened to run the command. That keeps the installed service pointed at the package's maintained release surface instead of at a transient local build product.
 
-If the live service should start running the current repository checkout instead of whichever executable already lives at `.release-artifacts/current`, use the promotion path instead:
+On the default staged executable path, `install` builds and stages the current checkout before it writes and bootstraps the LaunchAgent. Explicit `--tool-executable-path` installs are different: they stay pinned to the executable path the caller provided and do not overwrite it.
+
+Use the explicit promotion command when an operator or release script wants to name the build-and-stage operation directly:
 
 ```bash
 xcrun swift run SpeakSwiftlyServerTool launch-agent promote-live \
   --config-file ./server.yaml
 ```
 
-That command rebuilds the release executable, stages the executable and sibling `SpeakSwiftly` metallib into `.release-artifacts/current`, refreshes the staged executable's ad-hoc code signature explicitly, and then reruns the LaunchAgent install flow. Use `install` when the staged artifact is already the intended live executable. Use `promote-live` when the intent is "make the current source checkout become the live service now."
+That command rebuilds the release executable, stages the executable and sibling `SpeakSwiftly` metallib into `.release-artifacts/current`, refreshes the staged executable's ad-hoc code signature explicitly, and then reruns the LaunchAgent install flow without staging a second time.
 
 ## Inspect Or Remove The Installed Service
 

--- a/TODO.md
+++ b/TODO.md
@@ -63,4 +63,4 @@
 
 - [x] Replace the SSE helper's fixed post-connect sleep and buffer polling loop with explicit async wakeups for stream readiness, notification arrival, and terminal stream failure so MCP resource-update tests stop depending on arbitrary 100ms delays inside the harness.
 - [x] Recheck the broader MCP E2E helper path for places where startup or session-handshake failures are still flattened into retry polling instead of surfacing the real transport error once the server is reachable.
-- [x] Run one live MCP smoke path against the refactored stream helper once it is worth temporarily stopping any LaunchAgent-backed local service, so the async-wakeup harness changes have one real end-to-end proof point beyond helper-only tests.
+- [x] Run one live MCP smoke path against the refactored stream helper after the live-service model-unload preflight creates enough memory headroom, so the async-wakeup harness changes have one real end-to-end proof point beyond helper-only tests.

--- a/Tests/SpeakSwiftlyServerE2ETests/E2EServerProcess.swift
+++ b/Tests/SpeakSwiftlyServerE2ETests/E2EServerProcess.swift
@@ -247,7 +247,6 @@ final class E2ELiveServerExecutionLaneLease: @unchecked Sendable {
     }
 
     static func acquire(timeout: Duration = .seconds(5)) throws -> E2ELiveServerExecutionLaneLease {
-        try ensureLaunchAgentBackedLiveServiceIsNotLoaded()
         try ensureNoCompetingServeProcessIsRunning()
 
         let lockPath = lockURL.path
@@ -290,27 +289,8 @@ final class E2ELiveServerExecutionLaneLease: @unchecked Sendable {
         }
     }
 
-    private static func ensureLaunchAgentBackedLiveServiceIsNotLoaded() throws {
-        let userDomain = "gui/\(getuid())"
-        let result = try runProcess(
-            executableURL: URL(fileURLWithPath: launchctlPath),
-            arguments: ["print", "\(userDomain)/\(launchAgentLabel)"],
-            allowNonZeroExit: true,
-            failureSummary: "The live end-to-end suite could not inspect the LaunchAgent-backed SpeakSwiftlyServer service state.",
-        )
-
-        guard result.exitCode != 0 else {
-            throw E2ETransportError(
-                """
-                The LaunchAgent-backed live SpeakSwiftlyServer service '\(launchAgentLabel)' is still loaded in '\(userDomain)'.
-                Live end-to-end coverage must run without the always-on service active, or the machine can end up speaking from two different server processes at once.
-                Stop it first with `./.release-artifacts/current/SpeakSwiftlyServerTool launch-agent uninstall` and then rerun the end-to-end command.
-                """,
-            )
-        }
-    }
-
     private static func ensureNoCompetingServeProcessIsRunning() throws {
+        let allowedProcessIdentifiers = try launchAgentBackedLiveServiceProcessIdentifiers()
         let result = try runProcess(
             executableURL: URL(fileURLWithPath: pgrepPath),
             arguments: ["-fl", "SpeakSwiftlyServerTool serve"],
@@ -326,6 +306,7 @@ final class E2ELiveServerExecutionLaneLease: @unchecked Sendable {
                 guard line.contains("SpeakSwiftlyServerTool serve") else { return false }
                 guard !line.hasPrefix(currentProcessIdentifier + " ") else { return false }
                 guard !line.contains("\(pgrepPath) -fl SpeakSwiftlyServerTool serve") else { return false }
+                guard allowedProcessIdentifiers.contains(processIdentifier(from: line)) == false else { return false }
 
                 return true
             }
@@ -334,13 +315,46 @@ final class E2ELiveServerExecutionLaneLease: @unchecked Sendable {
             let processSummary = competingProcesses.joined(separator: "\n")
             throw E2ETransportError(
                 """
-                The live end-to-end suite found an existing `SpeakSwiftlyServerTool serve` process before it could start its own helper.
-                Live end-to-end coverage must own the only speaking server process on the machine while it runs.
+                The live end-to-end suite found an existing non-LaunchAgent `SpeakSwiftlyServerTool serve` process before it could start its own helper.
+                Live end-to-end coverage can run alongside the LaunchAgent-backed service after its resident models are unloaded, but separate ad hoc server helpers must not overlap.
                 Existing processes:
                 \(processSummary)
                 """,
             )
         }
+    }
+
+    private static func launchAgentBackedLiveServiceProcessIdentifiers() throws -> Set<String> {
+        let userDomain = "gui/\(getuid())"
+        let result = try runProcess(
+            executableURL: URL(fileURLWithPath: launchctlPath),
+            arguments: ["print", "\(userDomain)/\(launchAgentLabel)"],
+            allowNonZeroExit: true,
+            failureSummary: "The live end-to-end suite could not inspect the LaunchAgent-backed SpeakSwiftlyServer service state.",
+        )
+
+        guard result.exitCode == 0 else {
+            return []
+        }
+
+        return Set(
+            result.standardOutput
+                .split(separator: "\n")
+                .compactMap { processIdentifier(fromLaunchctlLine: String($0)) },
+        )
+    }
+
+    private static func processIdentifier(from processLine: String) -> String {
+        processLine.split(separator: " ", maxSplits: 1).first.map(String.init) ?? ""
+    }
+
+    private static func processIdentifier(fromLaunchctlLine line: String) -> String? {
+        let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+        guard let match = trimmedLine.firstMatch(of: /pid\s*=\s*(\d+)/) else {
+            return nil
+        }
+
+        return String(match.1)
     }
 
     func release() {

--- a/docs/maintainers/live-service-reliability-follow-ups.md
+++ b/docs/maintainers/live-service-reliability-follow-ups.md
@@ -160,7 +160,7 @@ But Inspector should stay in the "operator investigation" lane, not become the o
 
 ### 3. Extend the release-owned live-service refresh into transport health verification
 
-The release script now validates the repo, fails fast if the requested tag does not already match `HEAD`, builds the release artifact, stages `.release-artifacts/current`, tags, pushes, creates the GitHub release object, and refreshes the live LaunchAgent-backed service from that staged artifact by default. It still does not verify that the refreshed live service can actually boot from the staged artifact with both transports healthy.
+The release script now validates the repo, creates or verifies the requested tag at `HEAD`, pushes the branch and tag, opens the release PR, watches CI, checks review state, merges, fast-forwards `main`, and creates the GitHub release object. It still does not verify that a refreshed live service can actually boot from the staged artifact with both transports healthy.
 
 Add a maintainer-facing release checklist or release helper step that covers:
 

--- a/docs/maintainers/live-service-reliability-follow-ups.md
+++ b/docs/maintainers/live-service-reliability-follow-ups.md
@@ -187,14 +187,14 @@ The remaining follow-through here is mostly discipline:
 - keep the server package live suite transport-owned
 - avoid regrowing playback-heavy or model-specific assertions in this repo unless the server itself adds a new transport contract
 - keep the smoke cases pointed at the actual shipped HTTP and MCP names so release verification still proves the operator surface we publish
-- replace the current destructive LaunchAgent uninstall preflight with a live-service memory-headroom preflight that unloads resident models before tests and reloads them afterward, but only when the live service is reachable and idle enough for that mutation to be safe
+- keep E2E preflight focused on live-service memory headroom by unloading resident models before tests and reloading them afterward; do not remove the installed LaunchAgent service for test setup
 
 ## Suggested Tracking Order
 
 If these follow-ups are tackled incrementally, the highest-value order is:
 
 1. LaunchAgent smoke test with spaced config path plus HTTP and MCP probes.
-2. Replace destructive E2E uninstall guidance with an idle-aware resident-model unload/reload preflight.
+2. Keep the resident-model unload/reload E2E preflight aligned with the current live-service helper.
 3. Staged-artifact promotion hardening, including the all-in-one install path and any required re-sign behavior.
 4. First-class live service health-check command.
 5. Better startup and config-open logging.

--- a/docs/maintainers/phase-5-checklist.md
+++ b/docs/maintainers/phase-5-checklist.md
@@ -91,7 +91,7 @@ These events should complement the existing `HostStateSnapshot`, not replace it.
 - Transport snapshots only report `listening` once the shared Hummingbird process is actually serving traffic.
 - `ServerHost` exposes a typed host event surface alongside the existing stable snapshot surface.
 - `ServerState` remains out of the server-side event backbone.
-- `swift build` and `swift test` remain green after the transport lifecycle cleanup and event-surface additions.
+- `xcrun swift build` and `xcrun swift test` remain green after the transport lifecycle cleanup and event-surface additions.
 
 ## Status
 

--- a/docs/maintainers/phase-6-checklist.md
+++ b/docs/maintainers/phase-6-checklist.md
@@ -58,8 +58,8 @@ The simpler path considered first was keeping the current job-scoped subscriber 
 
 ## Validation
 
-- `swift build`
-- `swift test`
+- `xcrun swift build`
+- `xcrun swift test`
 
 Existing SSE replay and heartbeat coverage should continue to pass, and the host event tests should still confirm that MCP and non-UI consumers receive the shared host event stream.
 

--- a/docs/maintainers/phase-7-checklist.md
+++ b/docs/maintainers/phase-7-checklist.md
@@ -64,8 +64,8 @@ The simpler path considered first was to stop after documenting that playback-jo
 
 ## Validation
 
-- `swift build`
-- `swift test`
+- `xcrun swift build`
+- `xcrun swift test`
 
 Add coverage for both the typed reload-update surface and the host-side live-apply versus restart-required boundary.
 

--- a/docs/releases/v4.2.1-release-checklist.md
+++ b/docs/releases/v4.2.1-release-checklist.md
@@ -28,11 +28,7 @@ That patch bump matches the current change shape:
 sh scripts/repo-maintenance/validate-all.sh
 ```
 
-- stop the LaunchAgent-backed live service before the live smoke suite:
-
-```bash
-./.release-artifacts/current/SpeakSwiftlyServerTool launch-agent uninstall
-```
+- run the live-service resident-model unload preflight before the live smoke suite, leaving the installed LaunchAgent service in place:
 
 - run the current live end-to-end smoke gate in the repo-approved one-suite-at-a-time shape:
 

--- a/docs/releases/v4.2.1-release-notes.md
+++ b/docs/releases/v4.2.1-release-notes.md
@@ -25,9 +25,5 @@ sh scripts/repo-maintenance/validate-all.sh
 ```
 
 ```bash
-./.release-artifacts/current/SpeakSwiftlyServerTool launch-agent uninstall
-```
-
-```bash
 SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter ServerTransportE2ETests
 ```

--- a/docs/releases/v4.2.5-release-checklist.md
+++ b/docs/releases/v4.2.5-release-checklist.md
@@ -27,11 +27,7 @@ That patch bump matches the current change shape:
 xcrun swift test
 ```
 
-- stop the always-on LaunchAgent-backed live service before the opt-in live suite:
-
-```bash
-./.release-artifacts/current/SpeakSwiftlyServerTool launch-agent uninstall
-```
+- run the live-service resident-model unload preflight before the opt-in live suite, leaving the installed LaunchAgent service in place:
 
 - confirm the transport smoke gate passes:
 

--- a/docs/releases/v4.2.5-release-notes.md
+++ b/docs/releases/v4.2.5-release-notes.md
@@ -22,9 +22,5 @@ xcrun swift test
 ```
 
 ```bash
-./.release-artifacts/current/SpeakSwiftlyServerTool launch-agent uninstall
-```
-
-```bash
 SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test --filter ServerTransportE2ETests
 ```


### PR DESCRIPTION
## Summary

- remove testing guidance that tells maintainers to uninstall the LaunchAgent-backed live service before E2E
- allow the E2E helper to coexist with the known LaunchAgent service process after resident models are unloaded
- keep the competing-process guard for separate ad hoc server helpers
- refresh README, DocC, roadmap, and maintainer docs for the current install, release, SwiftPM, and generation-surface status

## Verification

- `xcrun swift test`
- `SPEAKSWIFTLYSERVER_E2E=1 xcrun swift test`
