### PR TITLE
release: prepare v4.3.11

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -8,7 +8,7 @@
       "name": "speak-swiftly-server",
       "source": {
         "source": "local",
-        "path": "."
+        "path": "./"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ The app-managed install layout is centered on one per-user location under `~/Lib
 
 This repository is also packaged as a repo-local Codex plugin through [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json). The plugin points at the checked-in [`.mcp.json`](./.mcp.json) connection for the local `speak_swiftly` MCP server and the tracked [skills](./skills/) bundle that teaches Codex how to use the surface intentionally.
 
+The plugin can be installed from a standalone clone without using `socket`. The repo-local marketplace lives at [`.agents/plugins/marketplace.json`](./.agents/plugins/marketplace.json), and its single plugin entry points at this repository root with `source.path` set to `./` because the root directory is also the plugin root. From a local clone, restart Codex and install `speak-swiftly-server` from the repo marketplace. For a personal install, copy or clone this repository wherever you keep personal plugin payloads and add an entry for it to `~/.agents/plugins/marketplace.json`. For a Git-tracked marketplace install, use Codex's documented [`codex plugin marketplace add`](https://developers.openai.com/codex/plugins/build#add-a-marketplace-from-the-cli) flow against this repository.
+
 The first plugin pass ships focused skills for:
 
 - broad MCP orientation


### PR DESCRIPTION
## Release

- prepares v4.3.11 from branch `release/plugin-install-v4.3.11`
- keeps protected `main` updates behind pull request review and CI
- release tag `v4.3.11` was created locally before this PR so the reviewed release candidate is preserved exactly

## Review Loop

Before merge, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.
