### PR TITLE
release: prepare v4.3.12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This root file governs the standalone Swift Package Manager repository for `Spea
 - Keep `Package.resolved` aligned with dependency changes from normal SwiftPM resolution.
 - Treat tagged GitHub releases as the distribution surface for consumers and downstream submodule adoption.
 - Keep the checked-in `maintain-project-repo` toolkit as the local-first maintainer surface for validation, sync, release, and CI wiring.
+- Default user-facing Codex plugin install and update examples to `codex plugin marketplace add gaelic-ghost/SpeakSwiftlyServer --ref main` and `codex plugin marketplace upgrade SpeakSwiftlyServer`. Keep manual local clone marketplace instructions scoped to development, unpublished testing, or fallback cases.
 
 ### Where To Look First
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,16 @@ The app-managed install layout is centered on one per-user location under `~/Lib
 
 This repository is also packaged as a repo-local Codex plugin through [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json). The plugin points at the checked-in [`.mcp.json`](./.mcp.json) connection for the local `speak_swiftly` MCP server and the tracked [skills](./skills/) bundle that teaches Codex how to use the surface intentionally.
 
-The plugin can be installed from a standalone clone without using `socket`. The repo-local marketplace lives at [`.agents/plugins/marketplace.json`](./.agents/plugins/marketplace.json), and its single plugin entry points at this repository root with `source.path` set to `./` because the root directory is also the plugin root. From a local clone, restart Codex and install `speak-swiftly-server` from the repo marketplace. For a personal install, copy or clone this repository wherever you keep personal plugin payloads and add an entry for it to `~/.agents/plugins/marketplace.json`. For a Git-tracked marketplace install, use Codex's documented [`codex plugin marketplace add`](https://developers.openai.com/codex/plugins/build#add-a-marketplace-from-the-cli) flow against this repository.
+The plugin can be installed without using `socket` through Codex's Git-backed marketplace flow. The repo-local marketplace lives at [`.agents/plugins/marketplace.json`](./.agents/plugins/marketplace.json), and its single plugin entry points at this repository root with `source.path` set to `./` because the root directory is also the plugin root.
+
+Prefer the official Git-backed install and update path:
+
+```bash
+codex plugin marketplace add gaelic-ghost/SpeakSwiftlyServer --ref main
+codex plugin marketplace upgrade SpeakSwiftlyServer
+```
+
+After Codex adds or upgrades the marketplace, install or enable `speak-swiftly-server` from the plugin directory. Manual local clone marketplaces and personal copied-payload entries are development, unpublished-testing, and fallback paths rather than the default user install story.
 
 The first plugin pass ships focused skills for:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,6 +5,7 @@
 - [x] Document the app-managed install and configuration contract the macOS app will rely on.
 - [x] Decide and document how app-managed installs own logs, profile roots, and cache paths.
 - [x] Trim the roadmap so the remaining unchecked items are clearly split between shipped work and active follow-up work.
+- [x] Default Codex plugin install and update docs to the Git-backed marketplace add/upgrade path, with manual local clone marketplaces kept as development and fallback guidance.
 
 ## Milestone 1: Bootstrap And Repo Hygiene
 


### PR DESCRIPTION
## Release

- prepares v4.3.12 from branch `release/plugin-install-v4.3.12`
- keeps protected `main` updates behind pull request review and CI
- release tag `v4.3.12` was created locally before this PR so the reviewed release candidate is preserved exactly

## Review Loop

Before merge, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.
