### PR TITLE
release: prepare v4.3.13

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This root file governs the standalone Swift Package Manager repository for `Spea
 - Keep `Package.resolved` aligned with dependency changes from normal SwiftPM resolution.
 - Treat tagged GitHub releases as the distribution surface for consumers and downstream submodule adoption.
 - Keep the checked-in `maintain-project-repo` toolkit as the local-first maintainer surface for validation, sync, release, and CI wiring.
-- Default user-facing Codex plugin install and update examples to `codex plugin marketplace add gaelic-ghost/SpeakSwiftlyServer --ref main` and `codex plugin marketplace upgrade SpeakSwiftlyServer`. Keep manual local clone marketplace instructions scoped to development, unpublished testing, or fallback cases.
+- Default user-facing Codex plugin install and update examples to `codex plugin marketplace add gaelic-ghost/SpeakSwiftlyServer` and `codex plugin marketplace upgrade SpeakSwiftlyServer`. Also mention `codex plugin marketplace add gaelic-ghost/socket` when users want SpeakSwiftlyServer plus Gale's other Codex plugins from one marketplace. Keep explicit refs scoped to pinned reproducible installs and manual local clone marketplace instructions scoped to development, unpublished testing, or fallback cases.
 
 ### Where To Look First
 

--- a/README.md
+++ b/README.md
@@ -269,11 +269,20 @@ The plugin can be installed without using `socket` through Codex's Git-backed ma
 Prefer the official Git-backed install and update path:
 
 ```bash
-codex plugin marketplace add gaelic-ghost/SpeakSwiftlyServer --ref main
+codex plugin marketplace add gaelic-ghost/SpeakSwiftlyServer
 codex plugin marketplace upgrade SpeakSwiftlyServer
 ```
 
-After Codex adds or upgrades the marketplace, install or enable `speak-swiftly-server` from the plugin directory. Manual local clone marketplaces and personal copied-payload entries are development, unpublished-testing, and fallback paths rather than the default user install story.
+After Codex adds or upgrades the marketplace, restart Codex, open the plugin directory in the Codex GUI, choose the `SpeakSwiftlyServer` marketplace, and install or enable `speak-swiftly-server` there. Manual local clone marketplaces and personal copied-payload entries are development, unpublished-testing, and fallback paths rather than the default user install story.
+
+The [`socket`](https://github.com/gaelic-ghost/socket) repository is Gale's plugin superproject and marketplace catalog. Installing from the Git-backed socket marketplace is useful when you want SpeakSwiftlyServer plus Gale's other Codex plugins available from one marketplace:
+
+```bash
+codex plugin marketplace add gaelic-ghost/socket
+codex plugin marketplace upgrade socket
+```
+
+After adding `socket`, restart Codex, open the plugin directory in the Codex GUI, choose the `Socket` marketplace, and install or enable `speak-swiftly-server` plus any companion plugins you want. Use an explicit ref such as `gaelic-ghost/SpeakSwiftlyServer@vX.Y.Z` only when you want a pinned reproducible install rather than the release-aligned default branch.
 
 The first plugin pass ships focused skills for:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,6 +6,7 @@
 - [x] Decide and document how app-managed installs own logs, profile roots, and cache paths.
 - [x] Trim the roadmap so the remaining unchecked items are clearly split between shipped work and active follow-up work.
 - [x] Default Codex plugin install and update docs to the Git-backed marketplace add/upgrade path, with manual local clone marketplaces kept as development and fallback guidance.
+- [x] Point default plugin install docs at the release-aligned branch without an explicit ref, document the optional `socket` marketplace path, and add Codex GUI follow-through guidance.
 
 ## Milestone 1: Bootstrap And Repo Hygiene
 


### PR DESCRIPTION
## Release

- prepares v4.3.13 from branch `release/plugin-install-v4.3.13`
- keeps protected `main` updates behind pull request review and CI
- release tag `v4.3.13` was created locally before this PR so the reviewed release candidate is preserved exactly

## Review Loop

Before merge, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.
