### PR TITLE
docs: audit skills against current surfaces

### DIFF
--- a/API.md
+++ b/API.md
@@ -100,8 +100,11 @@ Runtime model selection is startup-only as well. Persisted runtime configuration
 - `GET /requests/{request_id}`
 - `GET /requests/{request_id}/events`
 - `GET /generation/queue`
+- `DELETE /generation/queue`
+- `DELETE /generation/requests/{request_id}`
 - `GET /generation/jobs`
 - `GET /generation/jobs/{job_id}`
+- `DELETE /generation/jobs/{job_id}`
 - `GET /generation/files`
 - `GET /generation/files/{artifact_id}`
 - `GET /generation/batches`
@@ -137,6 +140,8 @@ The `/text-profiles` route family is synchronous and state-oriented rather than 
 The queue and playback control routes are immediate control operations rather than long-running requests.
 
 - `GET /generation/queue` and `GET /playback/queue` expose the generation and playback queues separately so the HTTP layer matches the runtime's split control surface.
+- `DELETE /generation/queue` clears queued generation work and returns the number of cancelled queued requests.
+- `DELETE /generation/requests/{request_id}` cancels one active or queued generation request and returns the cancelled request ID.
 - `GET /playback/state`, `POST /playback/pause`, and `POST /playback/resume` expose the current playback state and let clients control it directly.
 - `DELETE /playback/queue` clears queued playback work and returns the number of cancelled queued requests.
 - `DELETE /playback/requests/{request_id}` cancels one active or queued request and returns the cancelled request ID.
@@ -211,7 +216,10 @@ The MCP surface is optional and mounts on the same shared Hummingbird process at
 - `pause_playback`
 - `resume_playback`
 - `get_playback_state`
+- `clear_generation_queue`
 - `clear_playback_queue`
+- `cancel_generation`
+- `cancel_playback`
 - `cancel_request`
 
 `generate_speech` accepts `qwen_pre_model_text_chunking` as an opt-in boolean for Qwen live playback. `set_staged_config` changes persisted next-start runtime choices with `speech_backend`, optional `qwen_resident_model`, and optional `marvis_resident_policy`. `switch_speech_backend` queues live runtime work and returns an accepted request payload; read `speak://runtime/overview`, `speak://runtime/status`, or `speak://requests/{request_id}` to observe the pending and active backend state.

--- a/docs/maintainers/skills-surface-audit.md
+++ b/docs/maintainers/skills-surface-audit.md
@@ -1,0 +1,57 @@
+# Skills Surface Audit
+
+Last audited: 2026-05-02
+
+This note records the repo-local Codex skill surface audit against the current `SpeakSwiftlyServer` package, HTTP API, MCP catalog, plugin metadata, and operator documentation.
+
+## Current Skill Set
+
+The checked-in plugin exposes five focused skills under `skills/`:
+
+- `speak-swiftly-mcp`: orientation and routing for the local `speak_swiftly` MCP server.
+- `speak-swiftly-runtime-operator`: runtime, queue, playback, request, backend, and model-residency operations.
+- `speak-swiftly-voice-workflows`: voice-profile creation and editing, live speech, retained files, retained batches, and artifact inspection.
+- `speak-swiftly-text-profiles`: text-normalization style, stored profile, replacement, and persistence workflows.
+- `speak-swiftly-launchagent-setup`: supported LaunchAgent setup, promotion, inspection, uninstall, and healthcheck flow.
+
+The root plugin manifest at `.codex-plugin/plugin.json` points at `./skills/` and `./.mcp.json`. The local marketplace entry at `.agents/plugins/marketplace.json` points at the repository root because the root is the plugin root.
+
+## Source-Of-Truth Surfaces Checked
+
+- `Package.swift` confirms this is the SwiftPM source of truth for the `SpeakSwiftlyServer` library, `SpeakSwiftlyServerTool` executable, and test targets.
+- `Sources/SpeakSwiftlyServer/MCP/MCPToolCatalog.swift` is the MCP tool catalog source of truth.
+- `Sources/SpeakSwiftlyServer/MCP/MCPResources.swift` is the MCP resource and resource-template source of truth.
+- `Sources/SpeakSwiftlyServer/MCP/MCPPrompts.swift` is the MCP prompt source of truth.
+- `Sources/SpeakSwiftlyServer/HTTP/` is the HTTP route source of truth.
+- `API.md` is the dense public transport inventory.
+- `README.md` is the concise public operator and plugin install entrypoint.
+
+## Alignment Result
+
+The skill set is conceptually aligned with the current project shape. The five-skill split still maps cleanly onto the real product surfaces: broad MCP orientation, LaunchAgent service setup, runtime operation, voice workflows, and text-profile authoring.
+
+The skill-referenced MCP tool names, prompt names, and `speak://` resource families are present in the current source catalog. The runtime skill already names the current generation/playback split controls, including `clear_generation_queue`, `cancel_generation`, and `cancel_playback`. The voice skill names the retained generation job, file, and batch inspection tools now exposed by the MCP catalog.
+
+## Drift Fixed In This Pass
+
+- `API.md` did not list the current generation-side HTTP clear/cancel routes even though `HTTPGenerationRoutes.swift` exposes `DELETE /generation/queue` and `DELETE /generation/requests/{request_id}`.
+- `API.md` did not list `DELETE /generation/jobs/{job_id}` even though the route backs retained job expiry.
+- `API.md` did not list the current MCP `clear_generation_queue`, `cancel_generation`, and `cancel_playback` tools even though the MCP catalog and runtime skill already use them.
+- `speak-swiftly-voice-workflows` mentioned explicit text-format fields but did not call out the current `qwen_pre_model_text_chunking` live-speech option from the MCP catalog and API notes.
+
+## Healthy Constraints To Preserve
+
+- Keep `.mcp.json` pointed at the LaunchAgent default service URL, `http://127.0.0.1:7337/mcp`; direct foreground runs default to `7338`, and embedded app-owned sessions default to `7339`.
+- Keep skills focused on MCP/operator behavior. Do not turn them into general package-maintenance docs; `AGENTS.md`, `README.md`, `API.md`, and maintainer docs own that broader guidance.
+- Keep destructive queue and profile operations behind exact-id or exact-name confirmation guidance.
+- Trust the current MCP source files over older prose when a tool, resource, prompt, or request field appears to disagree.
+
+## Next Audit Checklist
+
+When the HTTP or MCP surface changes again, compare:
+
+1. `MCPToolCatalog.swift` tool names against every backticked MCP tool name in `skills/*/SKILL.md`.
+2. `MCPResources.swift` resources and templates against every `speak://...` URI in `skills/*/SKILL.md`.
+3. `MCPPrompts.swift` prompt names against every prompt name in `skills/*/SKILL.md`.
+4. `Sources/SpeakSwiftlyServer/HTTP/*.swift` route registrations against the HTTP inventory in `API.md`.
+5. `.mcp.json`, `skills/*/agents/openai.yaml`, and README plugin-install wording for service URL and install-flow agreement.

--- a/skills/speak-swiftly-voice-workflows/SKILL.md
+++ b/skills/speak-swiftly-voice-workflows/SKILL.md
@@ -28,6 +28,7 @@ Use this skill for voice selection, voice creation, and speech-generation work o
 - Use `generate_batch` when the user wants multiple generated files under one voice profile.
 - Pass `text_profile_id` only when the user explicitly wants a stored normalization profile on that request.
 - Pass `text_format`, `nested_source_format`, or `source_format` when the input is code, structured output, or other content where automatic detection is likely to misread intent.
+- Pass `qwen_pre_model_text_chunking` only when the user explicitly wants Qwen live playback to chunk before model generation; omitted requests keep the runtime's normal single-pass live path.
 
 ## Tracking
 


### PR DESCRIPTION
## Summary
- record a maintainer audit of the five repo-local SpeakSwiftly skills against the current plugin, HTTP, and MCP surfaces
- update API.md for generation clear/cancel routes, retained job expiry, and current MCP queue-cancel tools
- mention qwen_pre_model_text_chunking in the voice workflow skill

## Verification
- sh scripts/repo-maintenance/validate-all.sh
- git diff --check