### PR TITLE
docs: add isolated plugin install testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,8 @@ For Codex plugin or hook changes, keep end-user behavior plugin-managed and use 
 node scripts/codex-hooks-doctor.mjs
 ```
 
+When testing Codex marketplace add, remove, or upgrade behavior, keep Gale's personal Codex scope reserved for stable production installs. Use [docs/maintainers/plugin-install-testing.md](./docs/maintainers/plugin-install-testing.md) to run local checkout and Git-backed tests with a temporary `CODEX_HOME`, remove the test marketplace before cleanup, and leave Socket catalog-reference tests to the `socket` checkout.
+
 Before any live end-to-end run, make sure the LaunchAgent-backed live service has released resident model memory through the live-service model unload preflight. Leave the installed service in place; the E2E helper runs on its own random ports and only needs comfortable memory headroom.
 
 ## Development Expectations

--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ node scripts/codex-hooks-doctor.mjs
 
 The doctor checks whether the plugin manifest declares hooks, whether a legacy global `~/.codex/hooks.json` entry is still pointing at this checkout, whether the live service is reachable, and whether the hook voice profile matches the runtime voice-profile inventory. The doctor also covers legacy `speak-swiftly-server` plugin ids and duplicate marketplace enablement, preferring the Socket marketplace when both catalogs are installed. Run `node scripts/codex-hooks-doctor.mjs --repair-plan` to print the dry-run repair plan; the command reports the intended config change without mutating user config.
 
+For install-surface testing, use [docs/maintainers/plugin-install-testing.md](./docs/maintainers/plugin-install-testing.md). Keep personal production Codex installs untouched by running local checkout and Git-backed marketplace tests with a temporary `CODEX_HOME`, removing the test marketplace before cleanup. Run detailed Speak Swiftly payload tests from this repository; run Socket catalog-reference tests from the `socket` checkout.
+
 The first plugin pass ships focused skills for:
 
 - broad MCP orientation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -217,6 +217,7 @@ Swift package directly.
 - [x] Add migration notes for old `speak-swiftly-server` installs from either marketplace, including how to enable `speak-swiftly` and when the old entry is safe to disable or remove.
 - [x] Update `scripts/codex-hooks-doctor.mjs` so it detects legacy `speak-swiftly-server` installs, duplicate installs or enablement from both marketplaces, plugin-managed hook state, live service reachability, and expected voice-profile availability.
 - [x] Add a doctor dry-run repair plan that prefers the Socket marketplace when both catalogs are configured: keep `speak-swiftly@socket` enabled, then report duplicate standalone-marketplace or legacy enablement before any future config mutation.
+- [x] Document isolated repo-scope install testing in `docs/maintainers/plugin-install-testing.md` so local checkout and Git-backed marketplace tests do not mutate Gale's personal production Codex installs.
 - [ ] Decide whether the current `socket/plugins/SpeakSwiftlyServer` subtree should remain as a pull-only source mirror after Socket lists the remote plugin payload, or whether future `socket` releases can rely on this standalone repository plus the remote marketplace entry.
 
 Current Socket-side state:

--- a/docs/maintainers/plugin-install-testing.md
+++ b/docs/maintainers/plugin-install-testing.md
@@ -1,0 +1,113 @@
+# Plugin Install Testing
+
+Use this guide when testing the standalone SpeakSwiftlyServer Codex marketplace
+and plugin payload without touching personal production Codex installs.
+
+## Safety Model
+
+Gale's personal Codex scope should stay reserved for stable production installs.
+Marketplace add, remove, and upgrade tests should use an isolated temporary
+`CODEX_HOME` so test marketplaces, caches, and config do not rewrite
+`~/.codex/config.toml` or the production plugin cache.
+
+This repository owns the canonical `speak-swiftly` plugin payload:
+
+- `.codex-plugin/plugin.json`
+- `.agents/plugins/marketplace.json`
+- `.mcp.json`
+- `hooks/`
+- `skills/`
+- `scripts/codex-hooks-doctor.mjs`
+
+Run payload install tests from this checkout. The `socket` repository should
+only prove that its marketplace lists this same repository by Git-backed
+reference.
+
+## Local Checkout Test
+
+Run this from the `SpeakSwiftlyServer` checkout when validating branch-local
+plugin payload or marketplace changes:
+
+```bash
+SPEAK_SWIFTLY_SERVER_REPO="$(pwd)"
+TEST_CODEX_HOME="$(mktemp -d /private/tmp/speak-swiftly-codex-home.XXXXXX)"
+
+CODEX_HOME="$TEST_CODEX_HOME" codex plugin marketplace add "$SPEAK_SWIFTLY_SERVER_REPO"
+
+jq '.plugins[] | select(.name == "speak-swiftly")' \
+  "$SPEAK_SWIFTLY_SERVER_REPO/.agents/plugins/marketplace.json"
+
+jq '{name, version, displayName: .interface.displayName, mcpServers, hooks, skills}' \
+  "$SPEAK_SWIFTLY_SERVER_REPO/.codex-plugin/plugin.json"
+
+CODEX_HOME="$TEST_CODEX_HOME" codex plugin marketplace remove speak-swiftly-server-local
+test ! -s "$TEST_CODEX_HOME/config.toml"
+rm -rf "$TEST_CODEX_HOME"
+```
+
+Expected result:
+
+- Codex reports an added marketplace named `speak-swiftly-server-local` from
+  the local checkout.
+- The repo-local marketplace entry contains `name: speak-swiftly` and
+  `source.path: ./`.
+- The plugin manifest declares `name: speak-swiftly`, display name
+  `Speak Swiftly`, `mcpServers: ./.mcp.json`, `hooks: ./hooks/hooks.json`, and
+  `skills: ./skills/`.
+- Removing `speak-swiftly-server-local` leaves no configured marketplace in the
+  temporary Codex home.
+
+## Git-Backed Test
+
+Run this after the branch has landed in GitHub state that users can fetch:
+
+```bash
+TEST_CODEX_HOME="$(mktemp -d /private/tmp/speak-swiftly-codex-home.XXXXXX)"
+
+CODEX_HOME="$TEST_CODEX_HOME" codex plugin marketplace add gaelic-ghost/SpeakSwiftlyServer
+CODEX_HOME="$TEST_CODEX_HOME" codex plugin marketplace upgrade speak-swiftly-server-local
+
+jq '.plugins[] | select(.name == "speak-swiftly")' \
+  "$TEST_CODEX_HOME/.tmp/marketplaces/speak-swiftly-server-local/.agents/plugins/marketplace.json"
+
+jq '{name, version, displayName: .interface.displayName, mcpServers, hooks, skills}' \
+  "$TEST_CODEX_HOME/.tmp/marketplaces/speak-swiftly-server-local/.codex-plugin/plugin.json"
+
+CODEX_HOME="$TEST_CODEX_HOME" codex plugin marketplace remove speak-swiftly-server-local
+test ! -s "$TEST_CODEX_HOME/config.toml"
+rm -rf "$TEST_CODEX_HOME"
+```
+
+Expected result:
+
+- Codex reports `source_type = "git"` for
+  `marketplaces.speak-swiftly-server-local`.
+- `upgrade speak-swiftly-server-local` succeeds.
+- The cached marketplace entry contains `name: speak-swiftly` and
+  `source.path: ./`.
+- The cached plugin manifest declares the expected `Speak Swiftly` payload
+  paths.
+- Removing `speak-swiftly-server-local` leaves no configured marketplace in the
+  temporary Codex home.
+
+The current Codex CLI registers both local and Git-backed
+`gaelic-ghost/SpeakSwiftlyServer` marketplaces as
+`speak-swiftly-server-local`. Use the marketplace name Codex reports instead of
+guessing from the repository name.
+
+## Socket Catalog Test
+
+Socket owns the catalog test for its broader marketplace. Run Socket-side tests
+from the `socket` checkout, not here. The Socket test should prove that its
+marketplace entry named `speak-swiftly` points at
+`https://github.com/gaelic-ghost/SpeakSwiftlyServer.git` with `ref: main`.
+
+Do not copy this plugin payload into Socket for testing. The whole point of the
+catalog split is that this repository remains the one payload source of truth.
+
+## Session Availability
+
+These commands prove the marketplace and cached plugin files. They do not prove
+that an already-running Codex session has refreshed its visible plugin tools and
+skills. For that final check, start a fresh Codex session after the add or
+upgrade and inspect the Plugin Directory or the model-visible tool list.


### PR DESCRIPTION
## Summary
- document temporary CODEX_HOME marketplace install tests for SpeakSwiftlyServer
- clarify that this repo owns Speak Swiftly payload validation while Socket owns catalog-reference tests
- link the testing guide from README, CONTRIBUTING, and ROADMAP

## Verification
- git diff --check
- node scripts/codex-hooks-doctor.mjs --repair-plan