### PR TITLE
release: refresh repo-maintenance guidance

### DIFF
--- a/docs/maintainers/release-workflow.md
+++ b/docs/maintainers/release-workflow.md
@@ -16,9 +16,9 @@ Run the standard release flow from a feature branch or worktree:
 scripts/repo-maintenance/release.sh --mode standard --version vX.Y.Z
 ```
 
-The standard flow runs `scripts/repo-maintenance/version-bump.sh` before tagging. That hook updates the checked-in Codex plugin manifest version to match the release version so plugin consumers, marketplace metadata, and GitHub release tags do not drift silently.
+The standard flow runs `scripts/repo-maintenance/version-bump.sh` before the release PR is pushed. That hook updates the checked-in Codex plugin manifest version to match the release version so plugin consumers, marketplace metadata, and GitHub release tags do not drift silently.
 
-The standard flow is a durable repo-maintenance path. It validates the checkout, creates the annotated tag locally, pushes the branch and tag, opens or updates the release PR, watches CI, checks for review comments, merges the PR, fast-forwards local `main`, creates the GitHub release with `gh release create --verify-tag`, and cleans up merged local branches when safe.
+The standard flow is a durable repo-maintenance path. It validates the checkout, pushes the release branch, opens or updates the release PR, watches CI, checks for review comments, merges the PR, fast-forwards local `main`, creates the annotated tag from the reviewed base-branch commit, pushes that tag, creates the GitHub release with `gh release create --verify-tag`, and cleans up merged local branches when safe.
 
 ## Context Rules
 
@@ -90,7 +90,7 @@ scripts/repo-maintenance/release.sh --mode standard --version vX.Y.Z
 ```
 
 4. Let the repo-maintenance validation check run.
-5. Let the script push the branch and tag, open or update the PR, watch CI, check review state, merge, fast-forward `main`, create the GitHub release, and clean up merged branches.
+5. Let the script push the branch, open or update the PR, watch CI, check review state, merge, fast-forward `main`, create and push the annotated tag, create the GitHub release, and clean up merged branches.
 6. Run any post-release live-service refresh or staged-artifact promotion only when that operation is explicitly part of the release task.
 
 ## Validation Shape
@@ -123,7 +123,8 @@ The explicit repo-maintenance profile lives in `scripts/repo-maintenance/config/
 - Standard mode requires a named feature branch or worktree.
 - Standard mode refuses to run from the configured base branch.
 - Standard mode requires a clean worktree before release work starts.
-- Standard mode creates the annotated tag before pushing the branch and tag.
+- Standard mode waits for the release PR to pass CI and review-comment checks before it creates the annotated tag.
+- Standard mode dereferences existing annotated tags before comparing them with `HEAD` so reruns do not confuse the tag object SHA for the tagged commit SHA.
 - Standard mode uses a pull request and watches CI before merge.
 - Standard mode stops on requested changes or unresolved review/discussion comments unless rerun with `--review-comments-addressed` after the comment pass is intentionally complete.
 - Standard mode creates the GitHub release from the pushed tag with `--verify-tag`.

--- a/scripts/repo-maintenance/config/release.env
+++ b/scripts/repo-maintenance/config/release.env
@@ -1,3 +1,9 @@
 # Repo-maintenance release defaults.
 REPO_MAINTENANCE_DEFAULT_RELEASE_MODE=standard
 REPO_MAINTENANCE_RELEASE_BRANCH=main
+
+# GitHub can accept branch, tag, PR, check, review, and release mutations before
+# those surfaces are immediately readable. These defaults keep release scripts
+# explicit about intentional waits instead of failing on transient indexing gaps.
+REPO_MAINTENANCE_GH_WAIT_TIMEOUT_SECONDS=120
+REPO_MAINTENANCE_GH_WAIT_POLL_SECONDS=5

--- a/scripts/repo-maintenance/lib/common.sh
+++ b/scripts/repo-maintenance/lib/common.sh
@@ -38,6 +38,104 @@ load_profile_env() {
   load_env_file "$REPO_MAINTENANCE_ROOT/config/profile.env"
 }
 
+positive_integer_or_default() {
+  value="$1"
+  default_value="$2"
+
+  case "$value" in
+    ''|*[!0-9]*)
+      printf '%s\n' "$default_value"
+      ;;
+    0)
+      printf '%s\n' "$default_value"
+      ;;
+    *)
+      printf '%s\n' "$value"
+      ;;
+  esac
+}
+
+github_wait_timeout() {
+  value="$1"
+  default_timeout="$(positive_integer_or_default "${REPO_MAINTENANCE_GH_WAIT_TIMEOUT_SECONDS:-120}" 120)"
+  positive_integer_or_default "$value" "$default_timeout"
+}
+
+github_wait_poll_seconds() {
+  value="$1"
+  default_poll_seconds="$(positive_integer_or_default "${REPO_MAINTENANCE_GH_WAIT_POLL_SECONDS:-5}" 5)"
+  positive_integer_or_default "$value" "$default_poll_seconds"
+}
+
+wait_for_remote_branch() {
+  branch_name="$1"
+  timeout_seconds="$(github_wait_timeout "${REPO_MAINTENANCE_REMOTE_BRANCH_TIMEOUT_SECONDS:-}")"
+  poll_seconds="$(github_wait_poll_seconds "${REPO_MAINTENANCE_REMOTE_BRANCH_POLL_SECONDS:-}")"
+  elapsed_seconds="0"
+
+  log "Waiting up to ${timeout_seconds}s for remote branch origin/$branch_name to become visible."
+
+  while :; do
+    if git -C "$REPO_ROOT" ls-remote --exit-code --heads origin "$branch_name" >/dev/null 2>&1; then
+      log "Remote branch origin/$branch_name is visible."
+      return 0
+    fi
+
+    if [ "$elapsed_seconds" -ge "$timeout_seconds" ]; then
+      die "Remote branch origin/$branch_name was not visible after ${timeout_seconds}s. Confirm the branch push succeeded and that the origin remote is reachable before rerunning release.sh."
+    fi
+
+    sleep "$poll_seconds"
+    elapsed_seconds=$((elapsed_seconds + poll_seconds))
+  done
+}
+
+wait_for_remote_tag() {
+  tag_name="$1"
+  timeout_seconds="$(github_wait_timeout "${REPO_MAINTENANCE_REMOTE_TAG_TIMEOUT_SECONDS:-}")"
+  poll_seconds="$(github_wait_poll_seconds "${REPO_MAINTENANCE_REMOTE_TAG_POLL_SECONDS:-}")"
+  elapsed_seconds="0"
+
+  log "Waiting up to ${timeout_seconds}s for remote tag $tag_name to become visible."
+
+  while :; do
+    if git -C "$REPO_ROOT" ls-remote --exit-code --tags origin "refs/tags/$tag_name" >/dev/null 2>&1; then
+      log "Remote tag $tag_name is visible."
+      return 0
+    fi
+
+    if [ "$elapsed_seconds" -ge "$timeout_seconds" ]; then
+      die "Remote tag $tag_name was not visible after ${timeout_seconds}s. Confirm the tag push succeeded and that GitHub has indexed the tag before rerunning release.sh."
+    fi
+
+    sleep "$poll_seconds"
+    elapsed_seconds=$((elapsed_seconds + poll_seconds))
+  done
+}
+
+wait_for_github_release() {
+  tag_name="$1"
+  timeout_seconds="$(github_wait_timeout "${REPO_MAINTENANCE_GH_RELEASE_TIMEOUT_SECONDS:-}")"
+  poll_seconds="$(github_wait_poll_seconds "${REPO_MAINTENANCE_GH_RELEASE_POLL_SECONDS:-}")"
+  elapsed_seconds="0"
+
+  log "Waiting up to ${timeout_seconds}s for GitHub release $tag_name to become readable."
+
+  while :; do
+    if gh release view "$tag_name" >/dev/null 2>&1; then
+      log "GitHub release $tag_name is readable."
+      return 0
+    fi
+
+    if [ "$elapsed_seconds" -ge "$timeout_seconds" ]; then
+      die "GitHub release $tag_name was not readable after ${timeout_seconds}s. Confirm release creation succeeded and GitHub has indexed the release before rerunning release.sh."
+    fi
+
+    sleep "$poll_seconds"
+    elapsed_seconds=$((elapsed_seconds + poll_seconds))
+  done
+}
+
 ensure_git_repo() {
   git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "maintain-project-repo must run inside a git worktree rooted at $REPO_ROOT."
 }

--- a/scripts/repo-maintenance/release.sh
+++ b/scripts/repo-maintenance/release.sh
@@ -139,7 +139,8 @@ create_release_tag() {
   tag_sha="$(git -C "$REPO_ROOT" rev-parse -q --verify "refs/tags/$RELEASE_TAG" 2>/dev/null || true)"
 
   if [ -n "$tag_sha" ]; then
-    [ "$tag_sha" = "$head_sha" ] || die "Tag $RELEASE_TAG already exists and does not point at HEAD."
+    tag_commit_sha="$(git -C "$REPO_ROOT" rev-list -n 1 "$RELEASE_TAG")"
+    [ "$tag_commit_sha" = "$head_sha" ] || die "Tag $RELEASE_TAG already exists and does not point at HEAD."
     log "Tag $RELEASE_TAG already points at HEAD."
     return 0
   fi
@@ -153,17 +154,28 @@ create_release_tag() {
   log "Created annotated tag $RELEASE_TAG."
 }
 
-push_branch_and_tag() {
+push_release_branch() {
   branch_name="$1"
 
   if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
-    log "Would push branch $branch_name and tag $RELEASE_TAG to origin."
+    log "Would push branch $branch_name to origin."
     return 0
   fi
 
   git -C "$REPO_ROOT" push -u origin "$branch_name"
+  log "Pushed branch $branch_name."
+  wait_for_remote_branch "$branch_name"
+}
+
+push_release_tag() {
+  if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
+    log "Would push tag $RELEASE_TAG to origin."
+    return 0
+  fi
+
   git -C "$REPO_ROOT" push origin "$RELEASE_TAG"
-  log "Pushed branch $branch_name and tag $RELEASE_TAG."
+  log "Pushed tag $RELEASE_TAG."
+  wait_for_remote_tag "$RELEASE_TAG"
 }
 
 create_or_update_pr() {
@@ -184,11 +196,11 @@ create_or_update_pr() {
 
 - prepares $RELEASE_TAG from branch \`$branch_name\`
 - keeps protected \`$base_branch\` updates behind pull request review and CI
-- release tag \`$RELEASE_TAG\` was created locally before this PR so the reviewed release candidate is preserved exactly
+- release tag \`$RELEASE_TAG\` will be created after CI and the review-comment gate pass, so failed or still-discussed release candidates do not get tagged
 
 ## Review Loop
 
-Before merge, \`scripts/repo-maintenance/release.sh\` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with \`--review-comments-addressed\`.
+Before merge and tagging, \`scripts/repo-maintenance/release.sh\` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with \`--review-comments-addressed\`.
 EOF
 
   pr_number="$(gh pr list --head "$branch_name" --base "$base_branch" --json number --jq '.[0].number // empty' --limit 1)"
@@ -217,11 +229,74 @@ watch_ci() {
     return 0
   fi
 
+  wait_for_initial_pr_checks "$pr_number"
+
   log "Watching CI for PR #$pr_number."
   if ! gh pr checks "$pr_number" --watch; then
     die "CI is not green for PR #$pr_number. Fix the failing checks, push the branch, and rerun release.sh so it can watch CI again."
   fi
   log "CI is green for PR #$pr_number."
+}
+
+wait_for_initial_pr_checks() {
+  pr_number="$1"
+  timeout_seconds="$(github_wait_timeout "${REPO_MAINTENANCE_INITIAL_CHECK_TIMEOUT_SECONDS:-}")"
+  poll_seconds="$(github_wait_poll_seconds "${REPO_MAINTENANCE_INITIAL_CHECK_POLL_SECONDS:-}")"
+  elapsed_seconds="0"
+  last_state="no check data returned yet"
+
+  log "Waiting up to ${timeout_seconds}s for GitHub to report initial checks on PR #$pr_number."
+
+  while :; do
+    last_state="$(gh pr checks "$pr_number" --json name,state,workflow --jq 'map(.name + ":" + .state) | join(", ")' 2>/dev/null || printf 'no checks reported')"
+    check_count="$(gh pr checks "$pr_number" --json name,state,workflow --jq 'length' 2>/dev/null || printf '0')"
+    case "$check_count" in
+      ''|*[!0-9]*)
+        check_count="0"
+        ;;
+    esac
+
+    if [ "$check_count" -gt 0 ]; then
+      log "Found $check_count initial check(s) for PR #$pr_number."
+      return 0
+    fi
+
+    if [ "$elapsed_seconds" -ge "$timeout_seconds" ]; then
+      die "No checks were reported for PR #$pr_number after ${timeout_seconds}s. Last observed state: $last_state. Confirm the GitHub Actions workflow triggers for the release branch, Actions is enabled, and the branch push succeeded before rerunning release.sh."
+    fi
+
+    sleep "$poll_seconds"
+    elapsed_seconds=$((elapsed_seconds + poll_seconds))
+  done
+}
+
+wait_for_pr_review_state() {
+  pr_number="$1"
+  timeout_seconds="$(github_wait_timeout "${REPO_MAINTENANCE_PR_REVIEW_TIMEOUT_SECONDS:-}")"
+  poll_seconds="$(github_wait_poll_seconds "${REPO_MAINTENANCE_PR_REVIEW_POLL_SECONDS:-}")"
+  elapsed_seconds="0"
+  last_state="PR review/comment state has not been read yet"
+
+  log "Waiting up to ${timeout_seconds}s for GitHub review/comment state on PR #$pr_number."
+
+  while :; do
+    last_state="$(gh pr view "$pr_number" --json reviewDecision,comments,reviews --jq '"reviewDecision=" + (.reviewDecision // "") + ", comments=" + ((.comments | length) | tostring) + ", reviews=" + ((.reviews | length) | tostring)' 2>/dev/null || printf 'GitHub did not return PR review/comment state')"
+    case "$last_state" in
+      "GitHub did not return PR review/comment state")
+        ;;
+      *)
+        log "GitHub review/comment state is readable for PR #$pr_number: $last_state."
+        return 0
+        ;;
+    esac
+
+    if [ "$elapsed_seconds" -ge "$timeout_seconds" ]; then
+      die "GitHub review/comment state for PR #$pr_number was not readable after ${timeout_seconds}s. Last observed state: $last_state. Confirm the PR exists and GitHub is returning review data before rerunning release.sh."
+    fi
+
+    sleep "$poll_seconds"
+    elapsed_seconds=$((elapsed_seconds + poll_seconds))
+  done
 }
 
 check_pr_comments() {
@@ -232,8 +307,10 @@ check_pr_comments() {
     return 0
   fi
 
+  wait_for_pr_review_state "$pr_number"
+
   review_decision="$(gh pr view "$pr_number" --json reviewDecision --jq '.reviewDecision // ""')"
-  comment_count="$(gh pr view "$pr_number" --json comments,reviews --jq '([.comments[]?, .reviews[]? | select(.state == "COMMENTED")] | length)')"
+  comment_count="$(gh pr view "$pr_number" --json comments,reviews --jq '([.comments[]?, (.reviews[]? | select(.state == "COMMENTED"))] | length)')"
 
   if [ "$review_decision" = "CHANGES_REQUESTED" ]; then
     gh pr view "$pr_number" --comments
@@ -271,7 +348,7 @@ fast_forward_base_branch() {
     git -C "$REPO_ROOT" pull --ff-only origin "$base_branch"
     log "Fast-forwarded local $base_branch."
   else
-    warn "Could not check out local $base_branch, likely because another worktree owns it. Fast-forward $base_branch from origin/$base_branch in that checkout before cleanup."
+    die "Could not check out local $base_branch, likely because another worktree owns it. Fast-forward $base_branch from origin/$base_branch in that checkout, then rerun release.sh so the release tag is created from the reviewed base branch."
   fi
 }
 
@@ -293,6 +370,7 @@ create_github_release() {
 
   gh release create "$RELEASE_TAG" --verify-tag --generate-notes
   log "Created GitHub release $RELEASE_TAG."
+  wait_for_github_release "$RELEASE_TAG"
 }
 
 cleanup_merged_branches() {
@@ -334,14 +412,15 @@ run_standard_release() {
 
   run_version_bump
   ensure_clean_worktree
-  create_release_tag
-  push_branch_and_tag "$branch_name"
+  push_release_branch "$branch_name"
   create_or_update_pr "$branch_name"
   pr_number="$PR_NUMBER"
   watch_ci "$pr_number"
   check_pr_comments "$pr_number"
   merge_pr "$pr_number"
   fast_forward_base_branch
+  create_release_tag
+  push_release_tag
   create_github_release
   cleanup_merged_branches "$branch_name"
   log "Standard release flow completed successfully for $RELEASE_TAG."

--- a/scripts/repo-maintenance/release/30-push-release.sh
+++ b/scripts/repo-maintenance/release/30-push-release.sh
@@ -13,5 +13,7 @@ if [ "${REPO_MAINTENANCE_DRY_RUN:-false}" = "true" ]; then
 fi
 
 git -C "$REPO_ROOT" push -u origin "$branch_name"
+wait_for_remote_branch "$branch_name"
 git -C "$REPO_ROOT" push origin "$RELEASE_TAG"
+wait_for_remote_tag "$RELEASE_TAG"
 log "Pushed branch $branch_name and tag $RELEASE_TAG."

--- a/scripts/repo-maintenance/release/40-github-release.sh
+++ b/scripts/repo-maintenance/release/40-github-release.sh
@@ -27,3 +27,4 @@ fi
 
 gh release create "$RELEASE_TAG" --verify-tag --generate-notes
 log "Created GitHub release $RELEASE_TAG."
+wait_for_github_release "$RELEASE_TAG"


### PR DESCRIPTION
## Summary

- refresh the checked-in maintain-project-repo toolkit and thin validation workflow
- adopt the managed standard release flow that waits for PR checks/comment state before tagging
- update maintainer release docs to match the new tag timing and annotated-tag dereference behavior

## Issues

Fixes #46

## Validation

- sh scripts/repo-maintenance/validate-all.sh
- sh scripts/repo-maintenance/release.sh --mode standard --version v4.5.3 --skip-validate --skip-version-bump --skip-gh-release --review-comments-addressed --skip-branch-cleanup --dry-run

## Notes

Opened gaelic-ghost/socket#41 because sync-swift-package-guidance currently looks for productivity-skills at a nested apple-dev-skills path instead of the Socket sibling plugin path.