### PR TITLE
hooks: add section-aware Stop TTS projection

### DIFF
--- a/docs/codex-hooks-tts.md
+++ b/docs/codex-hooks-tts.md
@@ -19,7 +19,8 @@ testing harness for this checkout.
   `PermissionRequest` probe.
 - `hooks/stop-tts.mjs`
   Reads the Codex `Stop` payload from `stdin`, skips empty or duplicate turns,
-  ignores continuation passes by default, and queues speech through the local
+  ignores continuation passes by default, optionally projects sectioned final
+  replies into a shorter spoken form, and queues speech through the local
   `SpeakSwiftlyServer` HTTP route at `POST /speech/live`.
 - `hooks/permission-request-log.mjs`
   Reads the Codex `PermissionRequest` payload from `stdin` and records a local
@@ -139,6 +140,18 @@ The `Stop` hook script also accepts:
   Defaults to `true`. Skips compact structured assistant payloads such as
   `{"title":"..."}`, `{"suggestions":[...]}`, and `{"exclude":[...]}` because
   those are UI or automation metadata rather than speakable final prose.
+- `CODEX_HOOK_TTS_SKIP_SECTIONS`
+  Comma-separated list of final-reply sections to omit from spoken playback.
+  The hook recognizes top-level `Answer`, `Meaning`, `Evidence`, `Details`,
+  and `Risk` headings written as Markdown headings, bold headings, or plain
+  heading lines. For example, `Evidence,Details` keeps those sections in the
+  written reply while omitting their bodies from the text sent to
+  `POST /speech/live`.
+- `CODEX_HOOK_TTS_SECTION_NOTICE`
+  Controls how skipped section presence is announced in speech. Supported
+  values are `brief`, `verbose`, and `none`; invalid values fall back to
+  `brief`. The default `brief` mode says which configured sections were
+  present but skipped.
 - `CODEX_HOOK_TTS_MAX_SEEN_TURNS`
   Controls how many dedupe keys are retained in the local state file.
 - `CODEX_HOOK_TTS_STATE_LOCK_TIMEOUT_MS`
@@ -189,8 +202,18 @@ failure.
 - Duplicate `Stop` invocations can happen for the same `session_id + turn_id`
   when multiple hook sources match. The hook reserves a turn before posting to
   the speech route so duplicate processes do not queue duplicate audio jobs.
+- In this repository, duplicate `Stop` invocations are especially easy to see
+  because the installed plugin hook, the supported global fallback hook, and the
+  repo-local `.codex/hooks.json` development harness can all point at the same
+  script. Ordinary users usually only need the plugin-managed hook and, when
+  plugin dispatch is not reliable from every working directory, the single
+  global fallback hook. The repo-local `.codex/hooks.json` entry is for
+  checkout-scoped hook development and writes its own logs under `.codex/`.
 - Some assistant messages are compact JSON metadata used by Codex UI or
   automation flows. Those should be logged and skipped, not spoken aloud.
+- Section projection happens before the speech request is submitted. Hook logs
+  include the known sections found in the written reply, which sections were
+  spoken, and which configured sections were skipped.
 - The speech route distinguishes a reachable-but-not-ready runtime from an
   unreachable runtime:
   - HTTP `503` with `SpeakSwiftly is not ready yet...` means the server is up

--- a/hooks/stop-tts.mjs
+++ b/hooks/stop-tts.mjs
@@ -21,10 +21,13 @@ const defaultProfileName = process.env.CODEX_HOOK_TTS_PROFILE_NAME ?? "default-f
 const skipContinuedTurns = (process.env.CODEX_HOOK_TTS_SKIP_CONTINUATIONS ?? "true") !== "false";
 const skipStructuredMessages = (process.env.CODEX_HOOK_TTS_SKIP_STRUCTURED_MESSAGES ?? "true") !== "false";
 const logFullPayload = (process.env.CODEX_HOOK_TTS_LOG_FULL_PAYLOAD ?? "false") === "true";
+const skippedSectionNames = sectionNameSet(process.env.CODEX_HOOK_TTS_SKIP_SECTIONS ?? "");
+const sectionNoticeMode = normalizeSectionNoticeMode(process.env.CODEX_HOOK_TTS_SECTION_NOTICE ?? "brief");
 const maxSeenTurns = Number.parseInt(process.env.CODEX_HOOK_TTS_MAX_SEEN_TURNS ?? "200", 10);
 const stateLockDir = path.join(stateDir, "stop-tts-seen-turns.lock");
 const stateLockTimeoutMs = Number.parseInt(process.env.CODEX_HOOK_TTS_STATE_LOCK_TIMEOUT_MS ?? "3000", 10);
 const stateLockPollMs = Number.parseInt(process.env.CODEX_HOOK_TTS_STATE_LOCK_POLL_MS ?? "50", 10);
+const knownReplySections = ["Answer", "Meaning", "Evidence", "Details", "Risk"];
 
 async function readStdin() {
   const chunks = [];
@@ -135,6 +138,133 @@ function structuredMessageReason(message) {
   }
 
   return null;
+}
+
+function sectionNameSet(value) {
+  return new Set(
+    String(value)
+      .split(",")
+      .map((item) => item.trim().toLowerCase())
+      .filter((item) => item.length > 0),
+  );
+}
+
+function normalizeSectionNoticeMode(value) {
+  const normalized = String(value).trim().toLowerCase();
+  return new Set(["none", "brief", "verbose"]).has(normalized) ? normalized : "brief";
+}
+
+function displaySectionList(sectionNames) {
+  if (sectionNames.length === 0) return "";
+  if (sectionNames.length === 1) return sectionNames[0];
+  if (sectionNames.length === 2) return `${sectionNames[0]} and ${sectionNames[1]}`;
+  return `${sectionNames.slice(0, -1).join(", ")}, and ${sectionNames.at(-1)}`;
+}
+
+function replySectionName(line) {
+  const escapedNames = knownReplySections.join("|");
+  const patterns = [
+    new RegExp(`^\\s{0,3}#{1,6}\\s+(${escapedNames})\\s*#*\\s*$`, "i"),
+    new RegExp(`^\\s{0,3}\\*\\*\\s*(${escapedNames})\\s*\\*\\*\\s*$`, "i"),
+    new RegExp(`^\\s{0,3}(${escapedNames})\\s*$`, "i"),
+  ];
+
+  for (const pattern of patterns) {
+    const match = line.match(pattern);
+    if (match) {
+      const matched = match[1].toLowerCase();
+      return knownReplySections.find((section) => section.toLowerCase() === matched) ?? null;
+    }
+  }
+
+  return null;
+}
+
+function parseReplySections(message) {
+  const lines = message.split(/\r?\n/);
+  const parts = [];
+  let current = { kind: "preamble", name: null, heading: null, lines: [] };
+  let foundSection = false;
+
+  for (const line of lines) {
+    const sectionName = replySectionName(line);
+    if (sectionName) {
+      if (current.lines.some((item) => item.trim().length > 0)) {
+        parts.push(current);
+      }
+      current = { kind: "section", name: sectionName, heading: line.trim(), lines: [] };
+      foundSection = true;
+      continue;
+    }
+
+    current.lines.push(line);
+  }
+
+  if (current.lines.some((item) => item.trim().length > 0)) {
+    parts.push(current);
+  }
+
+  return foundSection ? parts : null;
+}
+
+function sectionNotice(skippedSections, mode) {
+  if (mode === "none" || skippedSections.length === 0) return null;
+  const sectionList = displaySectionList(skippedSections);
+  if (mode === "verbose") {
+    return `${sectionList} ${skippedSections.length === 1 ? "section is" : "sections are"} present in the written reply but skipped for speech.`;
+  }
+  return `Skipped sections present: ${sectionList}.`;
+}
+
+export function speakableMessageProjection(message, options = {}) {
+  const skippedNames = options.skippedSectionNames ?? skippedSectionNames;
+  const noticeMode = options.sectionNoticeMode ?? sectionNoticeMode;
+  const sections = parseReplySections(message);
+
+  if (!sections) {
+    return {
+      text: message,
+      presentSections: [],
+      spokenSections: [],
+      skippedSections: [],
+    };
+  }
+
+  const spokenSections = [];
+  const skippedSections = [];
+  const chunks = [];
+
+  for (const section of sections) {
+    const body = section.lines.join("\n").trim();
+    if (section.kind !== "section") {
+      if (body.length > 0) chunks.push(body);
+      continue;
+    }
+
+    if (skippedNames.has(section.name.toLowerCase())) {
+      skippedSections.push(section.name);
+      continue;
+    }
+
+    spokenSections.push(section.name);
+    if (body.length > 0) {
+      chunks.push(`${section.heading}\n\n${body}`);
+    } else {
+      chunks.push(section.heading);
+    }
+  }
+
+  const notice = sectionNotice(skippedSections, noticeMode);
+  if (notice) chunks.push(notice);
+
+  return {
+    text: chunks.join("\n\n").trim(),
+    presentSections: sections
+      .filter((section) => section.kind === "section")
+      .map((section) => section.name),
+    spokenSections,
+    skippedSections,
+  };
 }
 
 function stringAttribute(value) {
@@ -289,6 +419,25 @@ async function main() {
     }
   }
 
+  const speechProjection = speakableMessageProjection(message);
+  const speechMessage = normalizeMessage(speechProjection.text);
+  if (!speechMessage) {
+    await appendLog({
+      outcome: "skipped",
+      reason: "empty-section-projection",
+      sessionId,
+      turnId,
+      stopHookActive,
+      transcriptPath,
+      cwd,
+      model,
+      presentSections: speechProjection.presentSections,
+      skippedSections: speechProjection.skippedSections,
+      ...fullPayloadLog,
+    });
+    return;
+  }
+
   let response = null;
   try {
     response = await fetch(liveSpeechEndpoint, {
@@ -296,7 +445,7 @@ async function main() {
       headers: {
         "content-type": "application/json",
       },
-      body: JSON.stringify(speechRequestBody(message, payload, defaultProfileName)),
+      body: JSON.stringify(speechRequestBody(speechMessage, payload, defaultProfileName)),
     });
   } catch (error) {
     await appendLog({
@@ -310,7 +459,10 @@ async function main() {
       model,
       profileName: defaultProfileName,
       endpoint: liveSpeechEndpoint,
-      preview: message.slice(0, 160),
+      preview: speechMessage.slice(0, 160),
+      presentSections: speechProjection.presentSections,
+      spokenSections: speechProjection.spokenSections,
+      skippedSections: speechProjection.skippedSections,
       error: error instanceof Error ? { message: error.message, cause: String(error.cause ?? "") } : String(error),
       ...fullPayloadLog,
     });
@@ -333,7 +485,10 @@ async function main() {
       responseBody,
       profileName: defaultProfileName,
       endpoint: liveSpeechEndpoint,
-      preview: message.slice(0, 160),
+      preview: speechMessage.slice(0, 160),
+      presentSections: speechProjection.presentSections,
+      spokenSections: speechProjection.spokenSections,
+      skippedSections: speechProjection.skippedSections,
       ...fullPayloadLog,
     });
     return;
@@ -357,19 +512,24 @@ async function main() {
     endpoint: liveSpeechEndpoint,
     profileName: defaultProfileName,
     request: parsedResponse,
-    preview: message.slice(0, 160),
+    preview: speechMessage.slice(0, 160),
+    presentSections: speechProjection.presentSections,
+    spokenSections: speechProjection.spokenSections,
+    skippedSections: speechProjection.skippedSections,
     ...fullPayloadLog,
   });
 }
 
-main().catch(async (error) => {
-  try {
-    await ensureRuntimePaths();
-    await appendLog({
-      outcome: "error",
-      reason: "unexpected-hook-failure",
-      error: error instanceof Error ? { message: error.message, stack: error.stack } : String(error),
-    });
-  } catch {}
-  process.exitCode = 0;
-});
+if (path.resolve(process.argv[1] ?? "") === scriptPath) {
+  main().catch(async (error) => {
+    try {
+      await ensureRuntimePaths();
+      await appendLog({
+        outcome: "error",
+        reason: "unexpected-hook-failure",
+        error: error instanceof Error ? { message: error.message, stack: error.stack } : String(error),
+      });
+    } catch {}
+    process.exitCode = 0;
+  });
+}

--- a/hooks/stop-tts.test.mjs
+++ b/hooks/stop-tts.test.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { speakableMessageProjection } from "./stop-tts.mjs";
+
+test("speakableMessageProjection skips configured sections and keeps a brief notice", () => {
+  const projection = speakableMessageProjection(
+    [
+      "**Answer**",
+      "",
+      "Yes.",
+      "",
+      "**Meaning**",
+      "",
+      "The hook reads the concise sections.",
+      "",
+      "**Evidence**",
+      "",
+      "Dense command output.",
+      "",
+      "**Details**",
+      "",
+      "A long file list.",
+      "",
+      "**Risk**",
+      "",
+      "No blocker.",
+    ].join("\n"),
+    {
+      skippedSectionNames: new Set(["evidence", "details"]),
+      sectionNoticeMode: "brief",
+    },
+  );
+
+  assert.deepEqual(projection.presentSections, ["Answer", "Meaning", "Evidence", "Details", "Risk"]);
+  assert.deepEqual(projection.spokenSections, ["Answer", "Meaning", "Risk"]);
+  assert.deepEqual(projection.skippedSections, ["Evidence", "Details"]);
+  assert.match(projection.text, /\*\*Answer\*\*/);
+  assert.match(projection.text, /Yes\./);
+  assert.doesNotMatch(projection.text, /Dense command output/);
+  assert.doesNotMatch(projection.text, /A long file list/);
+  assert.match(projection.text, /Skipped sections present: Evidence and Details\./);
+});
+
+test("speakableMessageProjection supports verbose section notices", () => {
+  const projection = speakableMessageProjection("## Answer\n\nDone.\n\n## Evidence\n\nValidated.", {
+    skippedSectionNames: new Set(["evidence"]),
+    sectionNoticeMode: "verbose",
+  });
+
+  assert.equal(
+    projection.text,
+    "## Answer\n\nDone.\n\nEvidence section is present in the written reply but skipped for speech.",
+  );
+});
+
+test("speakableMessageProjection preserves unsectioned messages", () => {
+  const message = "A tiny ordinary reply.";
+  const projection = speakableMessageProjection(message, {
+    skippedSectionNames: new Set(["evidence"]),
+    sectionNoticeMode: "brief",
+  });
+
+  assert.equal(projection.text, message);
+  assert.deepEqual(projection.presentSections, []);
+  assert.deepEqual(projection.spokenSections, []);
+  assert.deepEqual(projection.skippedSections, []);
+});
+
+test("speakableMessageProjection can skip all sections without a spoken notice", () => {
+  const projection = speakableMessageProjection("Answer\n\nHidden.", {
+    skippedSectionNames: new Set(["answer"]),
+    sectionNoticeMode: "none",
+  });
+
+  assert.equal(projection.text, "");
+  assert.deepEqual(projection.presentSections, ["Answer"]);
+  assert.deepEqual(projection.spokenSections, []);
+  assert.deepEqual(projection.skippedSections, ["Answer"]);
+});

--- a/scripts/repo-maintenance/validations/25-codex-plugin.sh
+++ b/scripts/repo-maintenance/validations/25-codex-plugin.sh
@@ -7,4 +7,6 @@ export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/../lib"
 
 log "Checking Codex plugin doctor syntax and focused migration fixtures."
 node --check "$REPO_ROOT/scripts/codex-hooks-doctor.mjs"
+node --check "$REPO_ROOT/hooks/stop-tts.mjs"
 node --test "$REPO_ROOT/scripts/codex-hooks-doctor.test.mjs"
+node --test "$REPO_ROOT/hooks/stop-tts.test.mjs"


### PR DESCRIPTION
## Summary
- add Stop-hook projection for sectioned Codex replies with configurable skipped sections and skip notices
- log present, spoken, and skipped sections for hook troubleshooting
- document the environment knobs and the repo-local hook duplicate-call shape

## Verification
- sh scripts/repo-maintenance/validate-all.sh