### PR TITLE
release: prepare v5.0.2

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "speak-swiftly",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Codex plugin for local Speak Swiftly speech, playback, runtime operation, and shared MCP access.",
   "author": {
     "name": "Gale",

--- a/.github/workflows/validate-repo-maintenance.yml
+++ b/.github/workflows/validate-repo-maintenance.yml
@@ -17,6 +17,14 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: Report selected Xcode
         run: xcode-select --print-path
+      - name: Install project Swift toolchain
+        run: |
+          curl -O https://download.swift.org/swiftly/darwin/swiftly.pkg
+          installer -pkg swiftly.pkg -target CurrentUserHomeDirectory
+          ~/.swiftly/bin/swiftly init --quiet-shell-followup
+          . "${SWIFTLY_HOME_DIR:-$HOME/.swiftly}/env.sh"
+          swiftly install --use "$(cat .swift-version)"
+          echo "TOOLCHAINS=swift" >> "$GITHUB_ENV"
       - name: Report Swift toolchain
         run: xcrun swift --version
       - name: Install Swift repo-maintenance tools

--- a/.github/workflows/validate-repo-maintenance.yml
+++ b/.github/workflows/validate-repo-maintenance.yml
@@ -14,12 +14,12 @@ jobs:
     name: validate
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
-      - name: Select latest stable Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
-      - name: Show Swift version
+      - uses: actions/checkout@v6.0.2
+      - name: Report selected Xcode
+        run: xcode-select --print-path
+      - name: Report Swift toolchain
         run: xcrun swift --version
-      - name: Run remote CI validation
-        run: bash scripts/repo-maintenance/validate-ci.sh
+      - name: Install Swift repo-maintenance tools
+        run: brew install swiftformat swiftlint
+      - name: Run repo-maintenance validation
+        run: bash scripts/repo-maintenance/validate-all.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,9 @@ This root file governs the standalone Swift Package Manager repository for `Spea
 - Keep HTTP, MCP, LaunchAgent, and release workflow changes paired with operator-facing docs in the same change.
 - Keep source files small and role-focused; split shared support into explicit helper or extension files instead of growing mixed-responsibility entry points.
 - Use feature branches for normal repo work. Treat `main` as the protected release branch unless Gale explicitly says to work there for a specific task.
+- Treat a feature branch as a local isolation and checkpoint surface, not automatic permission to publish, open a pull request, or start watching remote CI.
+- Do not push a branch, open a pull request, enable auto-merge, or begin GitHub CI watch just because a local change exists. Do those remote handoff steps only when Gale asks for a PR/push/release, when the repo-owned release script is intentionally running a release, or when Gale explicitly asks for review handoff.
+- For ordinary implementation and docs changes, finish the local pass first: inspect the diff, run the relevant local validation, explain the result, and wait for a remote handoff request unless the active task already asked for one.
 
 ### Source of Truth
 
@@ -74,11 +77,13 @@ Use the repo-owned maintainer gate for complete validation:
 sh scripts/repo-maintenance/validate-all.sh
 ```
 
-Use the lighter remote CI lane when checking the GitHub workflow path locally:
+Use the remote CI wrapper lane when checking the GitHub workflow path locally:
 
 ```bash
 sh scripts/repo-maintenance/validate-ci.sh
 ```
+
+The GitHub Actions workflow itself runs the full maintainer gate through `sh scripts/repo-maintenance/validate-all.sh`; `validate-ci.sh` remains a local compatibility wrapper for checking CI-oriented repo-maintenance wiring.
 
 Use the default SwiftPM package lane for ordinary source work:
 
@@ -107,9 +112,11 @@ Run repo-maintenance sync and release entrypoints:
 ```bash
 sh scripts/repo-maintenance/sync-shared.sh
 sh scripts/repo-maintenance/release.sh --mode standard --version vX.Y.Z
+sh scripts/repo-maintenance/release.sh --mode standard --version vX.Y.Z --remote-ci-mode defer
 ```
 
 The release flow runs `scripts/repo-maintenance/version-bump.sh` so version-bearing repo surfaces move with the release before the tag is created.
+Use `--remote-ci-mode defer` when full local validation has already run and the remote CI wait is long enough that Codex should resume from a thread wakeup instead of holding a shell process open just to poll GitHub.
 
 ## Review and Delivery
 
@@ -118,6 +125,7 @@ The release flow runs `scripts/repo-maintenance/version-bump.sh` so version-bear
 - Summarize what changed, which repo surfaces moved, and why those surfaces needed to move together.
 - Call out whether validation used the full maintainer gate or a narrower SwiftPM check.
 - Mention docs updates when behavior changed for HTTP, MCP, LaunchAgent, embedding, release, or plugin consumers.
+- Do not describe local work as PR-ready unless the branch has actually reached a requested review or release handoff point.
 - For release work, make sure `scripts/repo-maintenance/release.sh` is the documented entrypoint unless a historical release note is intentionally describing an older flow.
 
 ### Definition of Done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,7 @@ scripts/repo-maintenance/release.sh --mode standard --version vX.Y.Z
 
 Run standard mode from a feature branch or worktree. It validates the checkout, creates the annotated tag, pushes the branch and tag, opens or updates the release PR, watches CI, checks review state, merges the PR, fast-forwards local `main`, creates the GitHub release, and cleans up merged branches when safe.
 
-The release flow runs `scripts/repo-maintenance/version-bump.sh` before tagging so version-bearing repo surfaces move with the release. Run live-service refresh or staged-artifact promotion only when that operation is explicitly part of the release task.
+The release flow runs `scripts/repo-maintenance/version-bump.sh` before tagging so version-bearing repo surfaces move with the release. After the release PR is merged, local `main` is fast-forwarded, the annotated tag is pushed, and the GitHub release exists, the standard flow refreshes the LaunchAgent-backed live service from the synced `main` checkout and runs the HTTP plus MCP healthcheck. Use `--skip-live-service-update` only when this machine should not be touched by that release.
 
 For the detailed contract and edge cases, use [docs/maintainers/release-workflow.md](./docs/maintainers/release-workflow.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,8 @@ Choose work from the current repo state rather than from stale assumptions. Use 
 
 For substantial changes, work on a feature branch instead of local `main`. When a task already has active release or bug-fix context on a branch, keep the follow-on work stacked on that line unless maintainers explicitly want a separate branch.
 
+A feature branch is the local work surface, not an automatic publishing step. Push the branch or open a pull request only when the maintainer asks for remote review, asks for a push, asks for a release, or intentionally runs the repo-owned release workflow. For ordinary local implementation or documentation passes, finish the coherent local change, run the relevant local validation, inspect the diff, and report the status before starting any GitHub handoff.
+
 ### Making Changes
 
 Use the `xcrun` SwiftPM path intentionally in this repository:
@@ -56,7 +58,7 @@ Keep work bounded and coherent:
 
 ### Asking For Review
 
-Before asking for review, make sure the affected docs are in sync, the local validation path for the change has run, and any release-relevant or operator-facing behavior changes are called out plainly. For release work, use the documented branch-to-`main` split instead of trying to tag directly from a feature branch.
+Before asking for review, make sure the affected docs are in sync, the local validation path for the change has run, and any release-relevant or operator-facing behavior changes are called out plainly. Do not open a pull request just because local edits exist; treat pull requests as explicit review or release handoffs. For release work, use the documented branch-to-`main` split instead of trying to tag directly from a feature branch.
 
 ## Local Setup
 
@@ -201,6 +203,14 @@ scripts/repo-maintenance/release.sh --mode standard --version vX.Y.Z
 Run standard mode from a feature branch or worktree. It validates the checkout, creates the annotated tag, pushes the branch and tag, opens or updates the release PR, watches CI, checks review state, merges the PR, fast-forwards local `main`, creates the GitHub release, and cleans up merged branches when safe.
 
 The release flow runs `scripts/repo-maintenance/version-bump.sh` before tagging so version-bearing repo surfaces move with the release. After the release PR is merged, local `main` is fast-forwarded, the annotated tag is pushed, and the GitHub release exists, the standard flow refreshes the LaunchAgent-backed live service from the synced `main` checkout and runs the HTTP plus MCP healthcheck. Use `--skip-live-service-update` only when this machine should not be touched by that release.
+
+Use deferred remote CI when full local validation has already passed and GitHub's check wait would otherwise keep a Codex shell process open just to poll:
+
+```bash
+scripts/repo-maintenance/release.sh --mode standard --version vX.Y.Z --remote-ci-mode defer
+```
+
+Deferred mode still performs the local release preparation, branch push, pull request creation, and initial check discovery. The release is not complete until the same thread resumes after CI settles and reruns the standard release command to finish review checks, merge, tagging, GitHub release creation, live-service update, and cleanup.
 
 For the detailed contract and edge cases, use [docs/maintainers/release-workflow.md](./docs/maintainers/release-workflow.md).
 

--- a/README.md
+++ b/README.md
@@ -67,20 +67,18 @@ Run the server directly in the foreground:
 xcrun swift run SpeakSwiftlyServerTool serve
 ```
 
-Install or refresh the per-user LaunchAgent with a config file:
+Install or refresh the per-user LaunchAgent:
 
 When the default staged tool path is used, this command first builds and stages the current checkout at `.release-artifacts/current/SpeakSwiftlyServerTool`, refreshes its bundled Metal resource, refreshes the staged ad-hoc signature, and then writes and bootstraps the LaunchAgent. Pass `--tool-executable-path /path/to/SpeakSwiftlyServerTool` only when you intentionally want to install a specific prebuilt executable instead.
 
 ```bash
-xcrun swift run SpeakSwiftlyServerTool launch-agent install \
-  --config-file ./server.yaml
+xcrun swift run SpeakSwiftlyServerTool launch-agent install
 ```
 
 Use the explicit promotion command when you want the lower-level "build, stage, then reinstall" spelling. This is mostly useful for release or operator scripts that want to name the promotion step directly; ordinary default-path refreshes can use `install`.
 
 ```bash
-xcrun swift run SpeakSwiftlyServerTool launch-agent promote-live \
-  --config-file ./server.yaml
+xcrun swift run SpeakSwiftlyServerTool launch-agent promote-live
 ```
 
 Inspect or remove the installed LaunchAgent:
@@ -139,7 +137,7 @@ The short version for a fresh checkout is:
 - use `sh scripts/repo-maintenance/validate-all.sh` for the full local maintainer gate
 - let GitHub Actions run the lighter remote CI gate from `scripts/repo-maintenance/validate-ci.sh`
 - use `node scripts/codex-hooks-doctor.mjs` when changing the Codex plugin or hook surface
-- use `scripts/repo-maintenance/release.sh --mode standard --version vX.Y.Z` for the aligned release flow
+- use `scripts/repo-maintenance/release.sh --mode standard --version vX.Y.Z` for the aligned release flow, including the post-release live-service update from synced local `main`
 - use `scripts/repo-maintenance/config/profile.env` to confirm the active `swift-package` maintainer profile
 
 ### Setup
@@ -305,6 +303,8 @@ codex plugin marketplace upgrade SpeakSwiftlyServer
 ```
 
 After Codex adds or upgrades the marketplace, restart Codex, open the plugin directory in the Codex GUI, choose the `SpeakSwiftlyServer` marketplace, and install or enable the Speak Swiftly plugin there. The plugin identity is `speak-swiftly`, with display name `Speak Swiftly`; older installs may still appear as `speak-swiftly-server` until they are upgraded or disabled. Manual local clone marketplaces and personal copied-payload entries are development, unpublished-testing, and fallback paths rather than the default user install story.
+
+Marketplace installation gives Codex the plugin payload: skills, MCP registration for `http://127.0.0.1:7337/mcp`, and lifecycle hooks. It does not by itself start the native Swift service. For a first run, ask Codex to set up Speak Swiftly on the machine, or run the LaunchAgent install command above from the installed plugin checkout. The install command builds and stages the current plugin checkout, seeds `~/Library/Application Support/SpeakSwiftlyServer/server.yaml` when it is missing, bootstraps the per-user LaunchAgent, and then `healthcheck` verifies HTTP plus MCP.
 
 The [`socket`](https://github.com/gaelic-ghost/socket) repository is Gale's plugin superproject and marketplace catalog. The catalog split keeps this repository as the canonical Speak Swiftly plugin payload while letting the Socket marketplace list that same payload by Git-backed reference. Socket's marketplace entry uses the root Git source for this repository, not a copied `socket/plugins/speak-swiftly` payload. Installing from the Git-backed socket marketplace is useful when you want Speak Swiftly plus Gale's other Codex plugins available from one marketplace:
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,32 @@ The goal is to give macOS and near-future Apple-platform apps one small, typed l
 
 ## Quick Start
 
-`SpeakSwiftlyServer` currently targets macOS 15.0 and Swift 6.3. Build the
-package with Xcode's selected Swift toolchain:
+`SpeakSwiftlyServer` currently targets macOS 15.0 and Swift 6.3.
+
+For Codex users, install or update the managed plugin first:
+
+```bash
+codex plugin marketplace add gaelic-ghost/SpeakSwiftlyServer
+codex plugin marketplace upgrade SpeakSwiftlyServer
+```
+
+If you use Gale's broader Socket marketplace instead, install or update that catalog:
+
+```bash
+codex plugin marketplace add gaelic-ghost/socket
+codex plugin marketplace upgrade socket
+```
+
+After adding or upgrading the marketplace, restart Codex, enable `Speak Swiftly` in the Plugin Directory, then set up or refresh the native service from the installed plugin checkout:
+
+```bash
+xcrun swift run SpeakSwiftlyServerTool launch-agent install
+xcrun swift run SpeakSwiftlyServerTool healthcheck
+```
+
+Plugin install/update and native service install/update are separate. The Codex marketplace gives agents the skills, MCP registration, and hooks; the LaunchAgent command builds and refreshes the local Swift service those plugin surfaces call.
+
+For source checkouts, build the package with Xcode's selected Swift toolchain:
 
 ```bash
 xcrun swift build
@@ -135,9 +159,10 @@ The short version for a fresh checkout is:
 
 - use `xcrun swift test` for the normal package-development loop
 - use `sh scripts/repo-maintenance/validate-all.sh` for the full local maintainer gate
-- let GitHub Actions run the lighter remote CI gate from `scripts/repo-maintenance/validate-ci.sh`
+- let GitHub Actions run the `validate` check through `scripts/repo-maintenance/validate-all.sh`
 - use `node scripts/codex-hooks-doctor.mjs` when changing the Codex plugin or hook surface
 - use `scripts/repo-maintenance/release.sh --mode standard --version vX.Y.Z` for the aligned release flow, including the post-release live-service update from synced local `main`
+- use `scripts/repo-maintenance/release.sh --mode standard --version vX.Y.Z --remote-ci-mode defer` only when full local validation has passed and the remote CI wait should resume through a Codex wakeup instead of a long-running poll
 - use `scripts/repo-maintenance/config/profile.env` to confirm the active `swift-package` maintainer profile
 
 ### Setup
@@ -295,32 +320,11 @@ This repository is also packaged as a repo-local Codex plugin through [`.codex-p
 
 The plugin can be installed without using `socket` through Codex's Git-backed marketplace flow. The repo-local marketplace lives at [`.agents/plugins/marketplace.json`](./.agents/plugins/marketplace.json), and its single plugin entry points at this repository root with `source.path` set to `./` because the root directory is also the plugin root.
 
-Prefer the official Git-backed install and update path:
+The plugin install and update commands are in [Quick Start](#quick-start). The plugin identity is `speak-swiftly`, with display name `Speak Swiftly`; older installs may still appear as `speak-swiftly-server` until they are upgraded or disabled. Manual local clone marketplaces and personal copied-payload entries are development, unpublished-testing, and fallback paths rather than the default user install story.
 
-```bash
-codex plugin marketplace add gaelic-ghost/SpeakSwiftlyServer
-codex plugin marketplace upgrade SpeakSwiftlyServer
-```
+Marketplace installation gives Codex the plugin payload: skills, MCP registration for `http://127.0.0.1:7337/mcp`, and lifecycle hooks. It does not by itself start, install, or update the native Swift service. The native service step also lives in [Quick Start](#quick-start) so users and agents see it before digging into plugin details.
 
-After Codex adds or upgrades the marketplace, restart Codex, open the plugin directory in the Codex GUI, choose the `SpeakSwiftlyServer` marketplace, and install or enable the Speak Swiftly plugin there. The plugin identity is `speak-swiftly`, with display name `Speak Swiftly`; older installs may still appear as `speak-swiftly-server` until they are upgraded or disabled. Manual local clone marketplaces and personal copied-payload entries are development, unpublished-testing, and fallback paths rather than the default user install story.
-
-Marketplace installation gives Codex the plugin payload: skills, MCP registration for `http://127.0.0.1:7337/mcp`, and lifecycle hooks. It does not by itself start the native Swift service. For a first run, ask Codex to set up Speak Swiftly on the machine, or run the LaunchAgent install command above from the installed plugin checkout. The install command builds and stages the current plugin checkout, seeds `~/Library/Application Support/SpeakSwiftlyServer/server.yaml` when it is missing, bootstraps the per-user LaunchAgent, and then `healthcheck` verifies HTTP plus MCP.
-
-That means there are two install/update surfaces:
-
-- Codex plugin install or update: `codex plugin marketplace add ...` and `codex plugin marketplace upgrade ...` refresh the Codex-managed plugin checkout, skills, MCP registration, and hooks.
-- Native service install or update: `xcrun swift run SpeakSwiftlyServerTool launch-agent install` refreshes the per-user LaunchAgent-backed Swift service that the plugin talks to.
-
-After a marketplace upgrade, the safest explicit update path is to ask Codex to "refresh the Speak Swiftly live service" or run the LaunchAgent install command from the upgraded plugin checkout. The hook scripts intentionally log unreachable-service failures instead of silently installing or changing `launchd` during a final-reply hook.
-
-The [`socket`](https://github.com/gaelic-ghost/socket) repository is Gale's plugin superproject and marketplace catalog. The catalog split keeps this repository as the canonical Speak Swiftly plugin payload while letting the Socket marketplace list that same payload by Git-backed reference. Socket's marketplace entry uses the root Git source for this repository, not a copied `socket/plugins/speak-swiftly` payload. Installing from the Git-backed socket marketplace is useful when you want Speak Swiftly plus Gale's other Codex plugins available from one marketplace:
-
-```bash
-codex plugin marketplace add gaelic-ghost/socket
-codex plugin marketplace upgrade socket
-```
-
-After adding `socket`, restart Codex, open the plugin directory in the Codex GUI, choose the `Socket` marketplace, and install or enable `Speak Swiftly` plus any companion plugins you want. Use an explicit ref such as `gaelic-ghost/SpeakSwiftlyServer@vX.Y.Z` only when you want a pinned reproducible install rather than the release-aligned default branch.
+The [`socket`](https://github.com/gaelic-ghost/socket) repository is Gale's plugin superproject and marketplace catalog. The catalog split keeps this repository as the canonical Speak Swiftly plugin payload while letting the Socket marketplace list that same payload by Git-backed reference. Socket's marketplace entry uses the root Git source for this repository, not a copied `socket/plugins/speak-swiftly` payload. Use an explicit ref such as `gaelic-ghost/SpeakSwiftlyServer@vX.Y.Z` only when you want a pinned reproducible install rather than the release-aligned default branch.
 
 If both the standalone `SpeakSwiftlyServer` marketplace and the broader `socket` marketplace are configured, prefer the Socket catalog entry. The doctor detects duplicate enablement across both marketplaces and reports a dry-run repair plan that keeps `speak-swiftly@socket` active while disabling or removing duplicate standalone enablement after confirmation. During migration, the duplicate scan accounts for both the current `speak-swiftly` id and the legacy `speak-swiftly-server` id in each marketplace.
 

--- a/README.md
+++ b/README.md
@@ -306,6 +306,13 @@ After Codex adds or upgrades the marketplace, restart Codex, open the plugin dir
 
 Marketplace installation gives Codex the plugin payload: skills, MCP registration for `http://127.0.0.1:7337/mcp`, and lifecycle hooks. It does not by itself start the native Swift service. For a first run, ask Codex to set up Speak Swiftly on the machine, or run the LaunchAgent install command above from the installed plugin checkout. The install command builds and stages the current plugin checkout, seeds `~/Library/Application Support/SpeakSwiftlyServer/server.yaml` when it is missing, bootstraps the per-user LaunchAgent, and then `healthcheck` verifies HTTP plus MCP.
 
+That means there are two install/update surfaces:
+
+- Codex plugin install or update: `codex plugin marketplace add ...` and `codex plugin marketplace upgrade ...` refresh the Codex-managed plugin checkout, skills, MCP registration, and hooks.
+- Native service install or update: `xcrun swift run SpeakSwiftlyServerTool launch-agent install` refreshes the per-user LaunchAgent-backed Swift service that the plugin talks to.
+
+After a marketplace upgrade, the safest explicit update path is to ask Codex to "refresh the Speak Swiftly live service" or run the LaunchAgent install command from the upgraded plugin checkout. The hook scripts intentionally log unreachable-service failures instead of silently installing or changing `launchd` during a final-reply hook.
+
 The [`socket`](https://github.com/gaelic-ghost/socket) repository is Gale's plugin superproject and marketplace catalog. The catalog split keeps this repository as the canonical Speak Swiftly plugin payload while letting the Socket marketplace list that same payload by Git-backed reference. Socket's marketplace entry uses the root Git source for this repository, not a copied `socket/plugins/speak-swiftly` payload. Installing from the Git-backed socket marketplace is useful when you want Speak Swiftly plus Gale's other Codex plugins available from one marketplace:
 
 ```bash

--- a/docs/maintainers/live-service-reliability-follow-ups.md
+++ b/docs/maintainers/live-service-reliability-follow-ups.md
@@ -158,18 +158,18 @@ npx -y @modelcontextprotocol/inspector --transport http --server-url http://127.
 
 But Inspector should stay in the "operator investigation" lane, not become the only regression tool. Automated coverage should continue to live in Swift tests and repo-owned smoke helpers so releases do not depend on browser-driven tooling.
 
-### 3. Extend the release-owned live-service refresh into transport health verification
+### 3. Keep release-owned live-service refresh tied to transport health verification
 
-The release script now validates the repo, creates or verifies the requested tag at `HEAD`, pushes the branch and tag, opens the release PR, watches CI, checks review state, merges, fast-forwards `main`, and creates the GitHub release object. It still does not verify that a refreshed live service can actually boot from the staged artifact with both transports healthy.
+Status: implemented in the standard release path. The release script now validates the repo, opens and merges the release PR, fast-forwards local `main`, creates and publishes the versioned tag, creates the GitHub release object, updates the LaunchAgent-backed live service from the synced local `main` checkout, and runs `SpeakSwiftlyServerTool healthcheck`.
 
-Add a maintainer-facing release checklist or release helper step that covers:
+Keep this release-owned check covering:
 
 - LaunchAgent install using the staged release artifact
-- runtime host overview probe
+- HTTP runtime overview probe
 - MCP initialize probe
 - verification that the staged release artifact and live LaunchAgent agree on the intended config path
 
-This does not have to block every local release immediately, but it should become the standard post-tag validation path for the live accessibility service.
+Use `--skip-live-service-update` only when the current machine should not be updated by that release or when another checkout will perform the live promotion.
 
 ### 4. Tighten E2E separation between transport coverage and playback-heavy runtime coverage
 

--- a/docs/maintainers/plugin-install-testing.md
+++ b/docs/maintainers/plugin-install-testing.md
@@ -112,7 +112,7 @@ that an already-running Codex session has refreshed its visible plugin tools and
 skills. For that final check, start a fresh Codex session after the add or
 upgrade and inspect the Plugin Directory or the model-visible tool list.
 
-## End-User First Run
+## End-User First Run And Updates
 
 Marketplace installation and native service installation are separate by design.
 The marketplace gives Codex the `speak-swiftly` plugin payload: skills, MCP
@@ -133,8 +133,27 @@ xcrun swift run SpeakSwiftlyServerTool launch-agent install
 xcrun swift run SpeakSwiftlyServerTool healthcheck
 ```
 
-For updates, `codex plugin marketplace upgrade ...` refreshes the Codex-managed
-plugin checkout and metadata. The native service should then be refreshed from
-that upgraded checkout with the same LaunchAgent install command. Hook scripts
-must log unreachable-service failures instead of silently mutating launchd from a
-final-reply hook.
+The expected update path is:
+
+1. Upgrade the marketplace that owns the enabled plugin:
+
+```bash
+codex plugin marketplace upgrade SpeakSwiftlyServer
+# or
+codex plugin marketplace upgrade socket
+```
+
+2. Start a fresh Codex session so agents see the upgraded skills, hooks, and MCP
+   registration.
+3. Ask Codex to "refresh the Speak Swiftly live service" or run the LaunchAgent
+   install command from the upgraded plugin checkout:
+
+```bash
+xcrun swift run SpeakSwiftlyServerTool launch-agent install
+xcrun swift run SpeakSwiftlyServerTool healthcheck
+```
+
+Hook scripts must log unreachable-service failures instead of silently mutating
+launchd from a final-reply hook. If auto-install or auto-update support becomes
+available in the Codex plugin platform later, revisit this section before using
+that behavior.

--- a/docs/maintainers/plugin-install-testing.md
+++ b/docs/maintainers/plugin-install-testing.md
@@ -111,3 +111,30 @@ These commands prove the marketplace and cached plugin files. They do not prove
 that an already-running Codex session has refreshed its visible plugin tools and
 skills. For that final check, start a fresh Codex session after the add or
 upgrade and inspect the Plugin Directory or the model-visible tool list.
+
+## End-User First Run
+
+Marketplace installation and native service installation are separate by design.
+The marketplace gives Codex the `speak-swiftly` plugin payload: skills, MCP
+registration for `http://127.0.0.1:7337/mcp`, and lifecycle hooks. It does not
+silently install, restart, or update the per-user LaunchAgent-backed Swift
+service.
+
+The expected first-run path is:
+
+1. Add or upgrade the `SpeakSwiftlyServer` marketplace, or add or upgrade the
+   broader `socket` marketplace and enable `Speak Swiftly` from there.
+2. Start a fresh Codex session so the managed plugin payload is visible.
+3. Ask Codex to "set up Speak Swiftly on this machine" or run the LaunchAgent
+   install command from the installed plugin checkout:
+
+```bash
+xcrun swift run SpeakSwiftlyServerTool launch-agent install
+xcrun swift run SpeakSwiftlyServerTool healthcheck
+```
+
+For updates, `codex plugin marketplace upgrade ...` refreshes the Codex-managed
+plugin checkout and metadata. The native service should then be refreshed from
+that upgraded checkout with the same LaunchAgent install command. Hook scripts
+must log unreachable-service failures instead of silently mutating launchd from a
+final-reply hook.

--- a/docs/maintainers/release-workflow.md
+++ b/docs/maintainers/release-workflow.md
@@ -20,6 +20,14 @@ The standard flow runs `scripts/repo-maintenance/version-bump.sh` before the rel
 
 The standard flow is a durable repo-maintenance path. It validates the checkout, pushes the release branch, opens or updates the release PR, watches CI, checks for review comments, merges the PR, fast-forwards local `main`, creates the annotated tag from the reviewed base-branch commit, pushes that tag, creates the GitHub release with `gh release create --verify-tag`, updates the local LaunchAgent-backed live service from the synced `main` checkout, healthchecks HTTP and MCP, and cleans up merged local branches when safe.
 
+When full local validation has already run and the remote CI wait is expected to be long, use deferred remote CI mode:
+
+```bash
+scripts/repo-maintenance/release.sh --mode standard --version vX.Y.Z --remote-ci-mode defer
+```
+
+Deferred mode still validates locally, pushes the branch, opens or updates the release PR, and waits until GitHub reports initial checks. It then pauses so Codex can use a native thread Timer/Wakeup or heartbeat automation and resume in the same thread after CI settles instead of leaving a shell process open to poll GitHub.
+
 ## Context Rules
 
 ### Feature Branch Or Worktree
@@ -69,6 +77,7 @@ Key flags:
 - `--skip-gh-release`
 - `--skip-live-service-update`
 - `--review-comments-addressed`
+- `--remote-ci-mode <full|defer>`
 - `--skip-branch-cleanup`
 - `--dry-run`
 
@@ -83,9 +92,9 @@ Purpose:
 
 Purpose:
 
-- one remote CI validation entrypoint
-- the command CI calls through `.github/workflows/validate-repo-maintenance.yml`
-- a lighter remote gate covering repo-maintenance structure, plugin metadata, CI wiring, package build, and package tests
+- local compatibility wrapper for checking CI-oriented repo-maintenance wiring
+- useful when maintainers want a narrower CI-shape check without running the full local maintainer gate
+- not the current GitHub Actions entrypoint
 
 ## Expected Flow
 
@@ -101,6 +110,14 @@ scripts/repo-maintenance/release.sh --mode standard --version vX.Y.Z
 5. Let the script push the branch, open or update the PR, watch CI, check review state, merge, fast-forward `main`, create and push the annotated tag, create the GitHub release, update the live LaunchAgent-backed service from synced local `main`, run `SpeakSwiftlyServerTool healthcheck`, and clean up merged branches.
 6. Use `--skip-live-service-update` only when the release is intentionally metadata-only for this machine or when a maintainer will refresh the live service from a different checkout.
 
+For deferred remote CI:
+
+1. Run full local validation before the release command.
+2. Run the standard release command with `--remote-ci-mode defer`.
+3. Let the script stop after branch push, PR creation, and initial check discovery.
+4. Use a native Codex thread Timer/Wakeup or heartbeat automation to resume after CI settles.
+5. Rerun the standard release command without `--remote-ci-mode defer` to finish review checks, merge, tag, GitHub release creation, live-service update, and cleanup.
+
 ## Validation Shape
 
 The repository uses one authoritative GitHub validation workflow: `.github/workflows/validate-repo-maintenance.yml`.
@@ -108,14 +125,12 @@ The repository uses one authoritative GitHub validation workflow: `.github/workf
 That workflow runs:
 
 ```bash
-bash scripts/repo-maintenance/validate-ci.sh
+bash scripts/repo-maintenance/validate-all.sh
 ```
 
-The remote CI dispatcher covers the managed toolkit checks plus the Swift package build and test lane. It intentionally skips DocC, CLI smoke, SwiftFormat, and SwiftLint so pull requests do not need Homebrew tool installation or the full local release gate on every remote run.
+The GitHub workflow uses the same full maintainer gate as local release validation. It installs the SwiftFormat and SwiftLint tools before running the gate, then executes the managed toolkit checks and repo-specific package checks under `scripts/repo-maintenance/validations/`, including build, test, DocC, CLI smoke, SwiftFormat, and SwiftLint.
 
-The local validation dispatcher remains the full maintainer gate. It covers the managed toolkit checks and the repo-specific Swift package checks under `scripts/repo-maintenance/validations/`, including build, test, DocC, CLI smoke, SwiftFormat, and SwiftLint.
-
-Keep new required local validation inside `validate-all.sh` unless it belongs specifically to the lighter GitHub gate.
+Keep new required validation inside `validate-all.sh` unless it belongs specifically to a local CI-wrapper compatibility check.
 
 ## Defaults
 
@@ -125,6 +140,7 @@ Current defaults:
 
 - default release mode: `standard`
 - release branch: `main`
+- remote CI mode: `full`
 
 The explicit repo-maintenance profile lives in `scripts/repo-maintenance/config/profile.env` and is currently `swift-package`.
 
@@ -133,6 +149,7 @@ The explicit repo-maintenance profile lives in `scripts/repo-maintenance/config/
 - Standard mode requires a named feature branch or worktree.
 - Standard mode refuses to run from the configured base branch.
 - Standard mode requires a clean worktree before release work starts.
+- Standard mode can defer remote CI after initial check discovery with `--remote-ci-mode defer`; deferred mode is a pause point, not a completed release.
 - Standard mode waits for the release PR to pass CI and review-comment checks before it creates the annotated tag.
 - Standard mode dereferences existing annotated tags before comparing them with `HEAD` so reruns do not confuse the tag object SHA for the tagged commit SHA.
 - Standard mode uses a pull request and watches CI before merge.

--- a/docs/maintainers/release-workflow.md
+++ b/docs/maintainers/release-workflow.md
@@ -18,7 +18,7 @@ scripts/repo-maintenance/release.sh --mode standard --version vX.Y.Z
 
 The standard flow runs `scripts/repo-maintenance/version-bump.sh` before the release PR is pushed. That hook updates the checked-in Codex plugin manifest version to match the release version so plugin consumers, marketplace metadata, and GitHub release tags do not drift silently.
 
-The standard flow is a durable repo-maintenance path. It validates the checkout, pushes the release branch, opens or updates the release PR, watches CI, checks for review comments, merges the PR, fast-forwards local `main`, creates the annotated tag from the reviewed base-branch commit, pushes that tag, creates the GitHub release with `gh release create --verify-tag`, and cleans up merged local branches when safe.
+The standard flow is a durable repo-maintenance path. It validates the checkout, pushes the release branch, opens or updates the release PR, watches CI, checks for review comments, merges the PR, fast-forwards local `main`, creates the annotated tag from the reviewed base-branch commit, pushes that tag, creates the GitHub release with `gh release create --verify-tag`, updates the local LaunchAgent-backed live service from the synced `main` checkout, healthchecks HTTP and MCP, and cleans up merged local branches when safe.
 
 ## Context Rules
 
@@ -67,6 +67,7 @@ Key flags:
 - `--skip-validate`
 - `--skip-version-bump`
 - `--skip-gh-release`
+- `--skip-live-service-update`
 - `--review-comments-addressed`
 - `--skip-branch-cleanup`
 - `--dry-run`
@@ -97,8 +98,8 @@ scripts/repo-maintenance/release.sh --mode standard --version vX.Y.Z
 ```
 
 4. Let the repo-maintenance validation check run.
-5. Let the script push the branch, open or update the PR, watch CI, check review state, merge, fast-forward `main`, create and push the annotated tag, create the GitHub release, and clean up merged branches.
-6. Run any post-release live-service refresh or staged-artifact promotion only when that operation is explicitly part of the release task.
+5. Let the script push the branch, open or update the PR, watch CI, check review state, merge, fast-forward `main`, create and push the annotated tag, create the GitHub release, update the live LaunchAgent-backed service from synced local `main`, run `SpeakSwiftlyServerTool healthcheck`, and clean up merged branches.
+6. Use `--skip-live-service-update` only when the release is intentionally metadata-only for this machine or when a maintainer will refresh the live service from a different checkout.
 
 ## Validation Shape
 
@@ -137,4 +138,6 @@ The explicit repo-maintenance profile lives in `scripts/repo-maintenance/config/
 - Standard mode uses a pull request and watches CI before merge.
 - Standard mode stops on requested changes or unresolved review/discussion comments unless rerun with `--review-comments-addressed` after the comment pass is intentionally complete.
 - Standard mode creates the GitHub release from the pushed tag with `--verify-tag`.
+- Standard mode updates the LaunchAgent-backed live service only after local `main` has been fast-forwarded and the versioned GitHub release exists.
+- Standard mode immediately runs the server healthcheck after the live-service update so HTTP and MCP startup failures block the release handoff.
 - Submodule mode leaves parent repository pointer updates to a separate follow-up commit.

--- a/scripts/repo-maintenance/config/release.env
+++ b/scripts/repo-maintenance/config/release.env
@@ -1,9 +1,16 @@
 # Repo-maintenance release defaults.
 REPO_MAINTENANCE_DEFAULT_RELEASE_MODE=standard
 REPO_MAINTENANCE_RELEASE_BRANCH=main
+REPO_MAINTENANCE_REMOTE_CI_MODE=full
 
 # GitHub can accept branch, tag, PR, check, review, and release mutations before
 # those surfaces are immediately readable. These defaults keep release scripts
 # explicit about intentional waits instead of failing on transient indexing gaps.
 REPO_MAINTENANCE_GH_WAIT_TIMEOUT_SECONDS=120
 REPO_MAINTENANCE_GH_WAIT_POLL_SECONDS=5
+
+# Keep full local validation as the default release gate. For repositories whose
+# GitHub CI is intentionally heavy, use --remote-ci-mode defer so release.sh
+# pauses after branch push, PR creation, and initial check discovery. Codex can
+# then use a native thread Timer/Wakeup or heartbeat automation to resume later
+# instead of leaving a long-running shell process open just to poll GitHub.

--- a/scripts/repo-maintenance/release.sh
+++ b/scripts/repo-maintenance/release.sh
@@ -18,6 +18,7 @@ base_branch="${REPO_MAINTENANCE_RELEASE_BRANCH:-main}"
 review_comments_addressed="false"
 skip_branch_cleanup="false"
 dry_run="false"
+remote_ci_mode="${REPO_MAINTENANCE_REMOTE_CI_MODE:-full}"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -53,6 +54,10 @@ while [ "$#" -gt 0 ]; do
       review_comments_addressed="true"
       shift
       ;;
+    --remote-ci-mode)
+      remote_ci_mode="${2:-}"
+      shift 2
+      ;;
     --skip-branch-cleanup)
       skip_branch_cleanup="true"
       shift
@@ -64,7 +69,7 @@ while [ "$#" -gt 0 ]; do
     -h|--help)
       cat <<'USAGE'
 Usage:
-  release.sh --mode standard --version <vX.Y.Z> [--base-branch main] [--skip-validate] [--skip-version-bump] [--skip-gh-release] [--skip-live-service-update] [--review-comments-addressed] [--skip-branch-cleanup] [--dry-run]
+  release.sh --mode standard --version <vX.Y.Z> [--base-branch main] [--skip-validate] [--skip-version-bump] [--skip-gh-release] [--skip-live-service-update] [--review-comments-addressed] [--remote-ci-mode full|defer] [--skip-branch-cleanup] [--dry-run]
   release.sh --mode submodule --version <vX.Y.Z> [--skip-validate] [--skip-gh-release] [--dry-run]
 USAGE
       exit 0
@@ -81,6 +86,7 @@ export REPO_MAINTENANCE_RELEASE_MODE="$mode"
 export RELEASE_TAG="$release_tag"
 export REPO_MAINTENANCE_SKIP_GH_RELEASE="$skip_gh_release"
 export REPO_MAINTENANCE_DRY_RUN="$dry_run"
+export REPO_MAINTENANCE_REMOTE_CI_MODE="$remote_ci_mode"
 
 ensure_clean_worktree() {
   status_output="$(git -C "$REPO_ROOT" status --porcelain)"
@@ -101,6 +107,16 @@ ensure_semver_tag() {
   esac
 }
 
+ensure_remote_ci_mode() {
+  case "$REPO_MAINTENANCE_REMOTE_CI_MODE" in
+    full|defer)
+      ;;
+    *)
+      die "Remote CI mode must be either full or defer. Use full to watch GitHub checks in this script, or defer to pause after initial check discovery and continue from a Codex wakeup."
+      ;;
+  esac
+}
+
 current_branch() {
   git -C "$REPO_ROOT" symbolic-ref --quiet --short HEAD || true
 }
@@ -115,9 +131,15 @@ ensure_branch_release_context() {
 run_version_bump() {
   release_version="${RELEASE_TAG#v}"
   version_bump_script="$SELF_DIR/version-bump.sh"
+  head_subject="$(git -C "$REPO_ROOT" log -1 --format=%s 2>/dev/null || true)"
 
   if [ "$skip_version_bump" = "true" ]; then
     log "Skipping repo version bump because --skip-version-bump was requested."
+    return 0
+  fi
+
+  if [ "$head_subject" = "release: bump versions for $RELEASE_TAG" ]; then
+    log "Version bump commit for $RELEASE_TAG is already at HEAD; continuing the release resume path."
     return 0
   fi
 
@@ -234,13 +256,30 @@ watch_ci() {
     return 0
   fi
 
-  wait_for_initial_pr_checks "$pr_number"
-
   log "Watching CI for PR #$pr_number."
   if ! gh pr checks "$pr_number" --watch; then
     die "CI is not green for PR #$pr_number. Fix the failing checks, push the branch, and rerun release.sh so it can watch CI again."
   fi
   log "CI is green for PR #$pr_number."
+}
+
+defer_remote_ci_if_requested() {
+  pr_number="$1"
+  branch_name="$2"
+
+  [ "$REPO_MAINTENANCE_REMOTE_CI_MODE" = "defer" ] || return 1
+
+  if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
+    log "Would defer remote CI after PR #$pr_number reports initial checks."
+    return 0
+  fi
+
+  pr_url="$(gh pr view "$pr_number" --json url --jq '.url')"
+  log "Remote CI mode is defer, so release.sh is pausing after local validation, branch push, PR creation, and initial check discovery."
+  log "Release is not complete yet. Let GitHub finish CI for PR #$pr_number, then continue from branch $branch_name with:"
+  log "  bash scripts/repo-maintenance/release.sh --mode standard --version $RELEASE_TAG"
+  log "Codex should use a native thread Timer/Wakeup or heartbeat automation for this wait when available, then resume by checking $pr_url and rerunning the command above instead of leaving a shell script open to poll GitHub."
+  return 0
 }
 
 wait_for_initial_pr_checks() {
@@ -425,6 +464,7 @@ run_standard_release() {
   ensure_git_repo
   ensure_gh_cli
   ensure_semver_tag
+  ensure_remote_ci_mode
   branch_name="$(ensure_branch_release_context)"
   ensure_clean_worktree
 
@@ -437,6 +477,11 @@ run_standard_release() {
   push_release_branch "$branch_name"
   create_or_update_pr "$branch_name"
   pr_number="$PR_NUMBER"
+  wait_for_initial_pr_checks "$pr_number"
+  if defer_remote_ci_if_requested "$pr_number" "$branch_name"; then
+    log "Standard release flow paused before remote CI watch for $RELEASE_TAG."
+    return 0
+  fi
   watch_ci "$pr_number"
   check_pr_comments "$pr_number"
   merge_pr "$pr_number"

--- a/scripts/repo-maintenance/release.sh
+++ b/scripts/repo-maintenance/release.sh
@@ -13,6 +13,7 @@ release_tag=""
 skip_validate="false"
 skip_gh_release="false"
 skip_version_bump="false"
+skip_live_service_update="false"
 base_branch="${REPO_MAINTENANCE_RELEASE_BRANCH:-main}"
 review_comments_addressed="false"
 skip_branch_cleanup="false"
@@ -40,6 +41,10 @@ while [ "$#" -gt 0 ]; do
       skip_version_bump="true"
       shift
       ;;
+    --skip-live-service-update)
+      skip_live_service_update="true"
+      shift
+      ;;
     --base-branch)
       base_branch="${2:-}"
       shift 2
@@ -59,7 +64,7 @@ while [ "$#" -gt 0 ]; do
     -h|--help)
       cat <<'USAGE'
 Usage:
-  release.sh --mode standard --version <vX.Y.Z> [--base-branch main] [--skip-validate] [--skip-version-bump] [--skip-gh-release] [--review-comments-addressed] [--skip-branch-cleanup] [--dry-run]
+  release.sh --mode standard --version <vX.Y.Z> [--base-branch main] [--skip-validate] [--skip-version-bump] [--skip-gh-release] [--skip-live-service-update] [--review-comments-addressed] [--skip-branch-cleanup] [--dry-run]
   release.sh --mode submodule --version <vX.Y.Z> [--skip-validate] [--skip-gh-release] [--dry-run]
 USAGE
       exit 0
@@ -373,6 +378,23 @@ create_github_release() {
   wait_for_github_release "$RELEASE_TAG"
 }
 
+update_live_service() {
+  if [ "$skip_live_service_update" = "true" ]; then
+    log "Skipping live-service update because --skip-live-service-update was requested."
+    return 0
+  fi
+
+  if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
+    log "Would update the live LaunchAgent-backed service from synced local $base_branch, then run SpeakSwiftlyServerTool healthcheck."
+    return 0
+  fi
+
+  log "Updating the live LaunchAgent-backed service from synced local $base_branch."
+  xcrun swift run SpeakSwiftlyServerTool launch-agent install
+  xcrun swift run SpeakSwiftlyServerTool healthcheck
+  log "Updated and healthchecked the live LaunchAgent-backed service for $RELEASE_TAG."
+}
+
 cleanup_merged_branches() {
   release_branch_name="$1"
 
@@ -422,6 +444,7 @@ run_standard_release() {
   create_release_tag
   push_release_tag
   create_github_release
+  update_live_service
   cleanup_merged_branches "$branch_name"
   log "Standard release flow completed successfully for $RELEASE_TAG."
 }

--- a/scripts/repo-maintenance/validations/30-ci-wrapper.sh
+++ b/scripts/repo-maintenance/validations/30-ci-wrapper.sh
@@ -12,4 +12,4 @@ if [ ! -f "$workflow_path" ]; then
   exit 0
 fi
 
-grep -Fq "scripts/repo-maintenance/validate-ci.sh" "$workflow_path" || die "Expected $workflow_path to call scripts/repo-maintenance/validate-ci.sh."
+grep -Fq "scripts/repo-maintenance/validate-all.sh" "$workflow_path" || die "Expected $workflow_path to call scripts/repo-maintenance/validate-all.sh."

--- a/skills/speak-swiftly-launchagent-setup/SKILL.md
+++ b/skills/speak-swiftly-launchagent-setup/SKILL.md
@@ -12,6 +12,7 @@ Use this skill when the user wants the standalone `SpeakSwiftlyServer` to run as
 - Use the supported `SpeakSwiftlyServerTool launch-agent ...` commands instead of hand-editing property lists or calling `launchctl` directly.
 - Read the repo operator guidance in [README.md](../../README.md) first, then [LaunchAgent-Workflow.md](../../Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/LaunchAgent-Workflow.md) when the user needs the full setup model.
 - If the user is asking about Codex access to the running service, remember that the installed plugin already handles the Codex-side MCP registration through [`.mcp.json`](../../.mcp.json). The setup work here is about getting the live server healthy at `http://127.0.0.1:7337/mcp`, not about hand-editing Codex config files.
+- If the user installed Speak Swiftly through the `SpeakSwiftlyServer` or `socket` marketplace, treat the installed plugin cache as the source checkout for first-run setup and service refresh. Marketplace install or upgrade refreshes the Codex-managed plugin payload, but it does not silently install or restart the native LaunchAgent-backed service.
 - Phrase the setup outcome in user terms like "set up SpeakSwiftly on this machine," "install the background service," "make the local service reachable from Codex," or "fix the LaunchAgent install," because those are the kinds of requests this skill should trigger on.
 
 ## Normal Setup Flow
@@ -41,6 +42,7 @@ Use this skill when the user wants the standalone `SpeakSwiftlyServer` to run as
 
 - Treat `healthcheck` as the primary verification path because it probes `GET /healthz`, reads `GET /overview`, and sends a real MCP `initialize` request to `/mcp`.
 - If the HTTP process is healthy but Codex still cannot use the MCP surface, do not jump straight to telling the user to edit Codex config. First check whether the server is actually exposing `/mcp`. The plugin install should already handle the Codex-side connection; the remaining failure is usually that MCP is disabled in the server config or environment. The MCP endpoint exists only when `APP_MCP_ENABLED=true` or the config file enables MCP.
+- If a marketplace user says the plugin is installed but Speak Swiftly still does not speak, check whether the LaunchAgent-backed service is installed and healthy before changing plugin config. The hook path records `speech-route-unreachable` when the plugin is present but the native service is not running.
 - If the user wants to understand whether the live background service is using the staged artifact or a different executable, rely on `launch-agent status`, install output, and the printed plist rather than inferring from filesystem timestamps alone.
 - If the user needs queue, playback, or backend control after the service is already installed, switch to `$speak-swiftly-runtime-operator` instead of stretching this skill into runtime operations.
 - If the question is about using the live MCP surface from Codex after setup, switch to `$speak-swiftly-mcp`.

--- a/skills/speak-swiftly-launchagent-setup/SKILL.md
+++ b/skills/speak-swiftly-launchagent-setup/SKILL.md
@@ -13,6 +13,7 @@ Use this skill when the user wants the standalone `SpeakSwiftlyServer` to run as
 - Read the repo operator guidance in [README.md](../../README.md) first, then [LaunchAgent-Workflow.md](../../Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/LaunchAgent-Workflow.md) when the user needs the full setup model.
 - If the user is asking about Codex access to the running service, remember that the installed plugin already handles the Codex-side MCP registration through [`.mcp.json`](../../.mcp.json). The setup work here is about getting the live server healthy at `http://127.0.0.1:7337/mcp`, not about hand-editing Codex config files.
 - If the user installed Speak Swiftly through the `SpeakSwiftlyServer` or `socket` marketplace, treat the installed plugin cache as the source checkout for first-run setup and service refresh. Marketplace install or upgrade refreshes the Codex-managed plugin payload, but it does not silently install or restart the native LaunchAgent-backed service.
+- For marketplace users, make the update sequence explicit: upgrade the owning marketplace, start a fresh Codex session, run `launch-agent install` from the upgraded plugin checkout, then run `healthcheck`. Do not imply that plugin upgrade alone updates the running native service.
 - Phrase the setup outcome in user terms like "set up SpeakSwiftly on this machine," "install the background service," "make the local service reachable from Codex," or "fix the LaunchAgent install," because those are the kinds of requests this skill should trigger on.
 
 ## Normal Setup Flow

--- a/skills/speak-swiftly-launchagent-setup/SKILL.md
+++ b/skills/speak-swiftly-launchagent-setup/SKILL.md
@@ -17,19 +17,19 @@ Use this skill when the user wants the standalone `SpeakSwiftlyServer` to run as
 ## Normal Setup Flow
 
 1. Print the property list first with `xcrun swift run SpeakSwiftlyServerTool launch-agent print-plist`.
-2. Confirm the config file the service should use. The standard live-service path is `~/Library/Application Support/SpeakSwiftlyServer/server.yaml` unless the user explicitly wants another file.
-3. If the staged live artifact is already the intended executable, run `xcrun swift run SpeakSwiftlyServerTool launch-agent install --config-file <server-config-yaml>`.
-4. If the user wants the current checkout to become the live service now, run `xcrun swift run SpeakSwiftlyServerTool launch-agent promote-live --config-file <server-config-yaml>`.
+2. Confirm whether the user wants the default config. The standard live-service path is `~/Library/Application Support/SpeakSwiftlyServer/server.yaml`, and the install command seeds it automatically when it is missing.
+3. Run `xcrun swift run SpeakSwiftlyServerTool launch-agent install` for the normal all-in-one path. With the default staged artifact path, this builds and stages the current checkout, refreshes the LaunchAgent property list, and bootstraps the service.
+4. If the user explicitly wants a custom config file, pass `--config-file <server-config-yaml>` and make sure that file already exists.
 5. Verify the result with `xcrun swift run SpeakSwiftlyServerTool healthcheck`.
 
 ## When To Use Each Command
 
 - `launch-agent print-plist`:
   Use before install work or when the user wants to inspect exactly what will be staged into `~/Library/LaunchAgents`.
-- `launch-agent install --config-file ...`:
-  Use when the staged release artifact under `.release-artifacts/current` is already the executable the user wants `launchd` to boot.
-- `launch-agent promote-live --config-file ...`:
-  Use when the intent is "make this checkout become the live service now." This rebuilds and stages the release artifact first, then refreshes the LaunchAgent install.
+- `launch-agent install`:
+  Use for the normal "make this checkout become the live service now" path. With the default executable path, this rebuilds and stages the release artifact first, then refreshes the LaunchAgent install.
+- `launch-agent promote-live`:
+  Use only when a script or operator flow wants the lower-level promotion spelling explicitly. It performs the same current-checkout staging step before refreshing the LaunchAgent install.
 - `launch-agent status`:
   Use when the user wants to inspect the installed state, label, plist location, or staged executable details.
 - `launch-agent uninstall`:


### PR DESCRIPTION
## Release

- prepares v5.0.2 from branch `runtime/live-service-auto-update`
- keeps protected `main` updates behind pull request review and CI
- release tag `v5.0.2` will be created after CI and the review-comment gate pass, so failed or still-discussed release candidates do not get tagged

## Review Loop

Before merge and tagging, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.
