### PR TITLE
release: prepare v5.0.5

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "speak-swiftly",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "Codex plugin for local Speak Swiftly speech, playback, runtime operation, and shared MCP access.",
   "author": {
     "name": "Gale",

--- a/docs/releases/v5.0.5-release-notes.md
+++ b/docs/releases/v5.0.5-release-notes.md
@@ -1,0 +1,19 @@
+# v5.0.5 Release Notes
+
+## What Changed
+
+- clarified the patch line around plugin-managed Codex hooks only
+- kept Speak Swiftly hook commands in the shipped plugin payload at `~/.codex/plugins/speak-swiftly/hooks/...`
+
+## Breaking Changes
+
+- None for `SpeakSwiftlyServer` patch consumers.
+
+## Migration And Upgrade Notes
+
+- Upgrade the Speak Swiftly plugin payload and restart Codex so the plugin-managed lifecycle hook configuration reloads.
+- Do not add a user-level `~/.codex/hooks.json` Speak Swiftly hook for normal plugin installs.
+
+## Verification Performed
+
+- Not run.


### PR DESCRIPTION
## Summary
- bump Speak Swiftly plugin manifest to 5.0.5
- add v5.0.5 release notes for plugin-managed hook path clarification

## Verification
- Not run at Gale's request.