### PR TITLE
release: prepare v5.0.7

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "speak-swiftly",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "description": "Codex plugin for local Speak Swiftly speech, playback, runtime operation, and shared MCP access.",
   "author": {
     "name": "Gale",


### PR DESCRIPTION
## Release

- prepares v5.0.7 from branch `release/v5.0.7`
- keeps protected `main` updates behind pull request review and CI
- release tag `v5.0.7` will be created after CI and the review-comment gate pass, so failed or still-discussed release candidates do not get tagged

## Review Loop

Before merge and tagging, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.
