### PR TITLE
plugin: point stop hook at 5.0.8 cache path

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -21,7 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/5.0.5/hooks/stop-tts.mjs",
+            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/5.0.8/hooks/stop-tts.mjs",
             "timeout": 15
           },
           {


### PR DESCRIPTION
Fixes the Socket Stop TTS hook command path to target the 5.0.8 cache payload.