### PR TITLE
release: prepare v5.0.12

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "speak-swiftly",
-  "version": "5.0.11",
+  "version": "5.0.12",
   "description": "Codex plugin for local Speak Swiftly speech, playback, runtime operation, and shared MCP access.",
   "author": {
     "name": "Gale",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,14 @@ This root file governs the standalone Swift Package Manager repository for `Spea
 - Keep package resources under the owning target tree and load them through `Bundle.module`.
 - Keep transport-local shaping at the HTTP and MCP edges. If `SpeakSwiftly` or `TextForSpeech` can express a concept directly, prefer deleting server-local inference over adding another translation path.
 
+### Documentation Ownership
+
+- Keep `README.md` nontechnical and focused on end users, evaluators, integrators, and agents deciding whether and how to use `Speak Swiftly`.
+- Keep `README.md` contributor handoff limited to a short link to `CONTRIBUTING.md` and `AGENTS.md`; do not reintroduce maintainer setup, release, validation, embedding, configuration, or plugin-debugging procedures there.
+- Keep contributor-facing and maintainer-facing workflow detail in `CONTRIBUTING.md` or a linked document under `docs/maintainers/`.
+- Keep agent-facing maintainer rules in this `AGENTS.md` file when the rule changes how Codex should edit, validate, release, or route work in this repository.
+- Preserve the README `Overview > What This Project Is` and `Overview > Motivation` subsections as user-authored prose. Use `TBD` as the placeholder until Gale provides replacement text.
+
 ### Codex Plugin Hooks
 
 - Treat plugin-managed hooks as the required end-user path for Speak Swiftly Codex TTS. Do not add `~/.codex/hooks.json` as a repair path for normal installs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ This root file governs the standalone Swift Package Manager repository for `Spea
 
 ### Codex Plugin Hooks
 
+- This repository supports the Socket-managed Codex plugin path only. Do not add or maintain Claude Code, Anthropic, `.claude`, or `.claude-plugin` support surfaces here; if historical Claude-specific support appears in tracked docs, scripts, manifests, or examples, remove it instead of keeping parity.
 - Treat plugin-managed hooks as the required end-user path for Speak Swiftly Codex TTS. Do not add `~/.codex/hooks.json` as a repair path for normal installs.
 - Current Codex builds require both `features.codex_hooks = true` and `features.plugin_hooks = true` before installed plugin lifecycle hooks become runnable. `codex_hooks` enables the hook system; `plugin_hooks` enables hooks loaded from installed plugins.
 - If the installed plugin manifest and `hooks/hooks.json` are correct but no `Stop` row appears in `~/.codex/speak-swiftly-server/hooks/logs/stop-tts.jsonl`, check `features.plugin_hooks` before changing hook commands, adding global hooks, or blaming the live service.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,6 +201,8 @@ If callers do not pass `EmbeddedServer.Options(port:)`, the embedded host defaul
 
 This repository is the canonical payload source for the Socket-managed `Speak Swiftly` Codex plugin. The root `.codex-plugin/plugin.json` points at the checked-in `.mcp.json` connection, the tracked `skills/` bundle, and the plugin-managed `hooks/hooks.json` file.
 
+This repo does not maintain Claude Code or Anthropic plugin parity. Keep plugin work focused on the Socket-managed Codex path, and remove tracked Claude-specific docs, manifests, scripts, or examples if they appear.
+
 Default user-facing install and update examples should use the Socket marketplace entry:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,10 @@ Practical contributor and maintainer guide for working on `SpeakSwiftlyServer`, 
 - [Contribution Workflow](#contribution-workflow)
 - [Local Setup](#local-setup)
 - [Development Expectations](#development-expectations)
+- [Maintainer Reference](#maintainer-reference)
 - [Pull Request Expectations](#pull-request-expectations)
 - [Communication](#communication)
+- [Documentation Map](#documentation-map)
 - [License and Contribution Terms](#license-and-contribution-terms)
 
 ## Overview
@@ -32,7 +34,7 @@ This guide is for contributors and maintainers making source, docs, test, releas
 
 ### Choosing Work
 
-Choose work from the current repo state rather than from stale assumptions. Use [README.md](./README.md) for the product and operator story, [ROADMAP.md](./ROADMAP.md) for planned work, the active maintainer docs under [docs/maintainers](./docs/maintainers/) when the task touches current architecture or workflow, the historical release records under [docs/releases](./docs/releases/) when you need prior release context, and [docs/investigations](./docs/investigations/) when you need past incident or debugging context.
+Choose work from the current repo state rather than from stale assumptions. Use [README.md](./README.md) for the product and agent-facing story, [ROADMAP.md](./ROADMAP.md) for planned work, the active maintainer docs under [docs/maintainers](./docs/maintainers/) when the task touches current architecture or workflow, the historical release records under [docs/releases](./docs/releases/) when you need prior release context, and [docs/investigations](./docs/investigations/) when you need past incident or debugging context.
 
 For substantial changes, work on a feature branch instead of local `main`. When a task already has active release or bug-fix context on a branch, keep the follow-on work stacked on that line unless maintainers explicitly want a separate branch.
 
@@ -68,12 +70,31 @@ The concrete runtime config surfaces in this repo are:
 
 - [`server.yaml`](./server.yaml) for local config examples
 - `APP_CONFIG_FILE` for YAML-backed configuration
+- `APP_NAME`
+- `APP_ENVIRONMENT`
+- `APP_DEFAULT_VOICE_PROFILE_NAME`
+- `APP_HOST`
+- `APP_PORT`
+- `APP_SSE_HEARTBEAT_SECONDS`
+- `APP_COMPLETED_JOB_TTL_SECONDS`
+- `APP_COMPLETED_JOB_MAX_COUNT`
+- `APP_JOB_PRUNE_INTERVAL_SECONDS`
+- `APP_HTTP_ENABLED`
+- `APP_HTTP_HOST`
+- `APP_HTTP_PORT`
+- `APP_HTTP_SSE_HEARTBEAT_SECONDS`
+- `APP_MCP_ENABLED`
+- `APP_MCP_PATH`
+- `APP_MCP_SERVER_NAME`
+- `APP_MCP_TITLE`
 - `SPEAKSWIFTLY_PROFILE_ROOT` for the runtime-owned profile and persistence root
 - the staged release artifact under `.release-artifacts/current/` for LaunchAgent-owned runs
 
-The shared server supports the same environment variables documented in [README.md](./README.md#configuration), including the `APP_*` transport settings and `SPEAKSWIFTLY_PROFILE_ROOT`.
+If `APP_CONFIG_FILE` points at a YAML file, the server loads it through the package's Foundation URL-backed YAML provider and `swift-configuration`; environment variables take precedence over YAML, and YAML takes precedence over built-in defaults. Missing config files fail startup loudly. LaunchAgent install and refresh paths seed the default `~/Library/Application Support/SpeakSwiftlyServer/server.yaml` from the bundled template when that canonical file is missing.
 
-The default build and unit-test loop does not require secrets or a running LaunchAgent. Use `server.yaml` only when you want to run the executable or inspect LaunchAgent-owned behavior locally.
+The app-managed install layout is centered on one per-user location under `~/Library/Application Support/SpeakSwiftlyServer`, with logs in `~/Library/Logs/SpeakSwiftlyServer`. The package exposes that layout through `AppManagedInstallLayout.swift`.
+
+The default build and unit-test loop does not require secrets or a running LaunchAgent. Use `server.yaml` only when you want to run the executable, inspect configuration loading, or inspect LaunchAgent-owned behavior locally.
 
 ### Runtime Behavior
 
@@ -166,25 +187,45 @@ curl -X POST http://127.0.0.1:7337/models/reload
 
 This suite is a transport-owned smoke pass, not a second copy of SpeakSwiftly's broader worker end-to-end coverage. Keep this repo's live E2E focused on proving the shipped server can boot the published runtime, answer over HTTP and MCP, deliver MCP resource updates, and retain completed request state.
 
-## Pull Request Expectations
+## Maintainer Reference
 
-Summarize what changed, why it changed, and what reviewers should pay attention to first. For release work, make sure the branch-side candidate preparation is complete before handing it off to `main` for the final publish step.
+### Embedding
 
-## Communication
+The supported public embedding surface is `EmbeddedServer`, defined in `Sources/SpeakSwiftlyServer/Host/ServerState.swift`. App code owns that one observable object directly, calls `liftoff()`, binds UI to its observable properties, and uses the same object for runtime controls, playback controls, voice-profile actions, and direct live speech submission through `queueLiveSpeech(...)`.
 
-Raise uncertainty early when a task starts pushing on architecture, release semantics, or live-service behavior. If the clean path needs wider scope than the original request, say so before the change sprawls. If a behavior changed across docs, HTTP, MCP, LaunchAgent, or embedding surfaces, mention that explicitly instead of assuming reviewers will reconstruct it from the diff.
+Embedded app callers should pass `SpeakSwiftly.RequestContext` directly when the app has richer caller, project, or origin metadata than the server can infer. HTTP and MCP speech surfaces add transport defaults for that context automatically.
 
-## Documentation Map
+If callers do not pass `EmbeddedServer.Options(port:)`, the embedded host defaults to `127.0.0.1:7339`. If callers pass `EmbeddedServer.Options(runtimeProfileRootURL:)`, the server treats that as its profile-store root and bridges it at startup into the broader persistence root expected by the current pinned `SpeakSwiftly` runtime, while keeping the server's own runtime-configuration snapshot aligned with the same on-disk state.
 
-- [README.md](./README.md) is the product and operator-facing entrypoint.
-- [API.md](./API.md) is the detailed HTTP and MCP contract reference.
-- [docs/maintainers/source-layout.md](./docs/maintainers/source-layout.md) is the maintainer map for the current source split.
-- [docs/maintainers/release-workflow.md](./docs/maintainers/release-workflow.md) is the current `maintain-project-repo` release contract.
-- [docs/maintainers](./docs/maintainers/) holds active maintainer-facing architecture, workflow, and cleanup notes.
-- [docs/releases](./docs/releases/) holds historical release notes and release checklists.
-- [docs/investigations](./docs/investigations/) holds historical investigations and incident writeups.
+### Codex Plugin
 
-## Monorepo and Submodule Handoff
+This repository is the canonical payload source for the Socket-managed `Speak Swiftly` Codex plugin. The root `.codex-plugin/plugin.json` points at the checked-in `.mcp.json` connection, the tracked `skills/` bundle, and the plugin-managed `hooks/hooks.json` file.
+
+Default user-facing install and update examples should use the Socket marketplace entry:
+
+```bash
+codex plugin marketplace add gaelic-ghost/socket
+codex plugin marketplace upgrade socket
+```
+
+The plugin identity is `speak-swiftly`, with display name `Speak Swiftly`; older standalone installs may still appear as `speak-swiftly-server` until upgraded or disabled. Do not use a repo-local marketplace file from this checkout for normal installs. Socket is the supported marketplace entrypoint for end users.
+
+Marketplace installation gives Codex the plugin payload: skills, MCP registration for `http://127.0.0.1:7337/mcp`, and lifecycle hooks. It does not by itself start, install, or update the native Swift service.
+
+End users should start with plugin-managed hook setup rather than copying repo-local `.codex` files into their own Codex home. User-level `~/.codex/hooks.json` Speak Swiftly entries are duplicate or legacy repair targets, not the healthy default path.
+
+Current Codex builds require both `features.codex_hooks = true` and `features.plugin_hooks = true` before installed plugin lifecycle hooks become runnable. `codex_hooks` enables the hook system generally; `plugin_hooks` enables hook sources loaded from installed plugins.
+
+Use the hook doctor as the first audit surface for installed plugin metadata, duplicate user-level hooks, live runtime reachability, and recent hook logs:
+
+```bash
+node scripts/codex-hooks-doctor.mjs
+node scripts/codex-hooks-doctor.mjs --repair-plan
+```
+
+For install-surface testing, use [docs/maintainers/plugin-install-testing.md](./docs/maintainers/plugin-install-testing.md). Keep personal production Codex installs untouched by running manifest and payload checks from this repository; run actual marketplace add, upgrade, and catalog-reference tests from the `socket` checkout.
+
+### Monorepo and Submodule Handoff
 
 - Treat `../../speak-to-user/monorepo/packages/SpeakSwiftlyServer` as the integration submodule copy, not the primary development home.
 - Treat the local `../../speak-to-user/monorepo` checkout as a clean base checkout that stays on `main` and stays clean.
@@ -192,7 +233,7 @@ Raise uncertainty early when a task starts pushing on architecture, release sema
 - For monorepo work, create a dedicated `git worktree`, do the work there, open a pull request, and then delete the merged worktree and branch afterward.
 - When `speak-to-user` adopts a new server version, prefer updating the submodule pointer to a tagged `SpeakSwiftlyServer` release instead of an arbitrary branch tip.
 
-## Release Workflow
+### Release Workflow
 
 Use the repo-maintenance release entrypoint intentionally:
 
@@ -213,6 +254,24 @@ scripts/repo-maintenance/release.sh --mode standard --version vX.Y.Z --remote-ci
 Deferred mode still performs the local release preparation, branch push, pull request creation, and initial check discovery. The release is not complete until the same thread resumes after CI settles and reruns the standard release command to finish review checks, merge, tagging, GitHub release creation, live-service update, and cleanup.
 
 For the detailed contract and edge cases, use [docs/maintainers/release-workflow.md](./docs/maintainers/release-workflow.md).
+
+## Pull Request Expectations
+
+Summarize what changed, why it changed, and what reviewers should pay attention to first. For release work, make sure the branch-side candidate preparation is complete before handing it off to `main` for the final publish step.
+
+## Communication
+
+Raise uncertainty early when a task starts pushing on architecture, release semantics, or live-service behavior. If the clean path needs wider scope than the original request, say so before the change sprawls. If a behavior changed across docs, HTTP, MCP, LaunchAgent, or embedding surfaces, mention that explicitly instead of assuming reviewers will reconstruct it from the diff.
+
+## Documentation Map
+
+- [README.md](./README.md) is the product and agent-facing entrypoint.
+- [API.md](./API.md) is the detailed HTTP and MCP contract reference.
+- [docs/maintainers/source-layout.md](./docs/maintainers/source-layout.md) is the maintainer map for the current source split.
+- [docs/maintainers/release-workflow.md](./docs/maintainers/release-workflow.md) is the current `maintain-project-repo` release contract.
+- [docs/maintainers](./docs/maintainers/) holds active maintainer-facing architecture, workflow, and cleanup notes.
+- [docs/releases](./docs/releases/) holds historical release notes and release checklists.
+- [docs/investigations](./docs/investigations/) holds historical investigations and incident writeups.
 
 ## License and Contribution Terms
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SpeakSwiftlyServer
 
-Local speech for Codex and Apple-platform tools, packaged as a small server plus the `Speak Swiftly` plugin payload.
+Local speech synthesis for Codex and all kinds of macOS apps. Packaged as a small server, plus the `Speak Swiftly` Codex Plugin and Hook.
 
 ## Table of Contents
 
@@ -28,10 +28,15 @@ TBD
 
 ## Quick Start
 
-Install or update the Socket marketplace entry, then restart Codex and enable `Speak Swiftly` in the Plugin Directory.
+Add or upgrade the Socket marketplace entry to your Codex. Then, restart Codex and enable `Speak Swiftly` in the Plugin Directory under Socket.
 
+Add Socket:
 ```bash
 codex plugin marketplace add gaelic-ghost/socket
+```
+
+Upgrade Socket and Enabled Plugins:
+```bash
 codex plugin marketplace upgrade socket
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Local speech for Codex and Apple-platform tools, packaged as a small server plus
 
 ### Status
 
-This project is actively available and stable enough to try.
+`SpeakSwiftlyServer` is active, maintained, and used by Gale daily.
 
 ### What This Project Is
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SpeakSwiftlyServer
 
-Standalone Swift package for hosting the local `SpeakSwiftly` runtime behind an app-friendly HTTP API, an optional MCP surface, and a small embedded Apple-platform API.
+Local speech for Codex and Apple-platform tools, packaged as a small server plus the `Speak Swiftly` plugin payload.
 
 ## Table of Contents
 
@@ -11,9 +11,6 @@ Standalone Swift package for hosting the local `SpeakSwiftly` runtime behind an 
 - [Repo Structure](#repo-structure)
 - [Release Notes](#release-notes)
 - [License](#license)
-- [Embedding](#embedding)
-- [Configuration](#configuration)
-- [Codex Plugin](#codex-plugin)
 
 ## Overview
 
@@ -23,182 +20,52 @@ This project is actively available and stable enough to try.
 
 ### What This Project Is
 
-`SpeakSwiftlyServer` is the standalone Swift Package Manager home for the local `SpeakSwiftly` server layer. It ships one reusable library target for embedding and one executable target, `SpeakSwiftlyServerTool`, for running the shared localhost service, LaunchAgent maintenance commands, and health checks.
-
-The package exposes three user-facing surfaces:
-
-- a localhost HTTP API for app and operator control
-- an optional MCP surface where resources are the preferred read path and tools queue or mutate work
-- a small embedded Apple-platform API centered on the public `EmbeddedServer` observable model
+TBD
 
 ### Motivation
 
-The goal is to give macOS and near-future Apple-platform apps one small, typed local speech-service layer without adding a second runtime stack or forcing every consumer to rebuild the same transport and lifecycle glue around `SpeakSwiftly`.
+TBD
 
 ## Quick Start
 
-`SpeakSwiftlyServer` currently targets macOS 15.0 and Swift 6.3.
-
-For Codex users, install or update the managed plugin through Gale's broader
-Socket marketplace:
+Install or update the Socket marketplace entry, then restart Codex and enable `Speak Swiftly` in the Plugin Directory.
 
 ```bash
 codex plugin marketplace add gaelic-ghost/socket
 codex plugin marketplace upgrade socket
 ```
 
-After adding or upgrading Socket, restart Codex, enable `Speak Swiftly` in the Plugin Directory, then set up or refresh the native service from the installed plugin checkout:
+After the plugin is enabled, install or refresh the local speech service:
 
 ```bash
 xcrun swift run SpeakSwiftlyServerTool launch-agent install
 xcrun swift run SpeakSwiftlyServerTool healthcheck
 ```
 
-Plugin install/update and native service install/update are separate. The Codex marketplace gives agents the skills, MCP registration, and hooks; the LaunchAgent command builds and refreshes the local Swift service those plugin surfaces call.
-
-For source checkouts, build the package with Xcode's selected Swift toolchain:
-
-```bash
-xcrun swift build
-```
-
-Run the shared server executable locally:
-
-```bash
-xcrun swift run SpeakSwiftlyServerTool
-```
-
-Check the current operator surface:
-
-```bash
-xcrun swift run SpeakSwiftlyServerTool help
-xcrun swift run SpeakSwiftlyServerTool healthcheck --base-url http://127.0.0.1:7338
-```
-
-For contributor setup, validation, release workflow, and live end-to-end coverage, use [CONTRIBUTING.md](./CONTRIBUTING.md).
+The plugin and the local service are separate on purpose. The plugin gives Codex the skills, MCP connection, and speech hooks. The local service is the native Swift process that actually speaks.
 
 ## Usage
 
-Run the server directly in the foreground:
+Once the service is healthy, agents can use `Speak Swiftly` to:
 
-```bash
-xcrun swift run SpeakSwiftlyServerTool serve
-```
+- speak final replies through the local voice service
+- inspect the runtime, voice profiles, text profiles, and recent requests
+- queue speech, cancel queued work, clear completed work, and control playback
+- choose between the built-in `swift-signal` and `swift-anchor` voices
 
-Install or refresh the per-user LaunchAgent:
+The normal end-user path is plugin-managed. Do not copy repo-local hook files into a Codex home directory for ordinary setup.
 
-When the default staged tool path is used, this command first builds and stages the current checkout at `.release-artifacts/current/SpeakSwiftlyServerTool`, refreshes its bundled Metal resource, refreshes the staged ad-hoc signature, and then writes and bootstraps the LaunchAgent. Pass `--tool-executable-path /path/to/SpeakSwiftlyServerTool` only when you intentionally want to install a specific prebuilt executable instead.
-
-```bash
-xcrun swift run SpeakSwiftlyServerTool launch-agent install
-```
-
-Use the explicit promotion command when you want the lower-level "build, stage, then reinstall" spelling. This is mostly useful for release or operator scripts that want to name the promotion step directly; ordinary default-path refreshes can use `install`.
-
-```bash
-xcrun swift run SpeakSwiftlyServerTool launch-agent promote-live
-```
-
-Inspect or remove the installed LaunchAgent:
-
-```bash
-xcrun swift run SpeakSwiftlyServerTool launch-agent status
-xcrun swift run SpeakSwiftlyServerTool launch-agent uninstall
-```
-
-The package uses distinct default localhost ports by entrypoint:
-
-- direct executable startup defaults to `127.0.0.1:7338`
-- LaunchAgent installs default to `127.0.0.1:7337`
-- embedded app-owned sessions default to `127.0.0.1:7339`
-
-### Startup-Installed Default Voices
-
-The built-in default voice pair is `swift-signal` and `swift-anchor`. `swift-signal` is the bright,
-crisp, responsive default voice; `swift-anchor` is the grounded, steady, reassuring default voice.
-
-These defaults are package-owned seed voices, not Gale's personal saved profiles. When the runtime
-first becomes ready, the server installs missing seed voices into the active profile store and leaves
-the active default voice selection unchanged. If a user already has a profile with one of those names,
-startup uses a `-builtin` fallback such as `swift-signal-builtin` for the package-owned copy instead
-of overwriting the user's profile.
-
-For ordinary users and app consumers, built-ins are list-and-select voices: they show up in the
-profile list and can be selected as the default or passed as `profile_name` on one request. Their seed
-source text, voice-design prompt, and provenance stay behind the explicit maintainer/tool surface so
-the built-ins remain consistent out of the box instead of becoming another editable profile template.
-
-Short generated preview clips live under [docs/media/default-voices](./docs/media/default-voices/):
-
-| Voice | Demo Audio | Format | Transcript |
-| --- | --- | --- | --- |
-| `swift-signal` | [Listen to `swift-signal.wav`](./docs/media/default-voices/swift-signal.wav) | WAV, mono, 24 kHz, ~6.72s | Swift Signal demo. A bright built-in voice for clear technical guidance, quick checks, and confident next steps. |
-| `swift-anchor` | [Listen to `swift-anchor.wav`](./docs/media/default-voices/swift-anchor.wav) | WAV, mono, 24 kHz, ~8.00s | Swift Anchor demo. A grounded built-in voice for longer explanations, calm reviews, and steady operator guidance. |
-
-The full transport contract lives in [API.md](./API.md).
+For the detailed HTTP and MCP contract, see [API.md](./API.md).
 
 ## Development
 
-The contributor and maintainer workflow lives in [CONTRIBUTING.md](./CONTRIBUTING.md). This section is only the product README's short handoff for people who want to build or validate the package locally before making changes.
-
-Use that guide for:
-
-- local setup and runtime expectations
-- validation commands
-- live end-to-end coverage
-- pull request and release workflow
-- monorepo and submodule handoff rules
-
-The short version for a fresh checkout is:
-
-- use `xcrun swift test` for the normal package-development loop
-- use `sh scripts/repo-maintenance/validate-all.sh` for the full local maintainer gate
-- let GitHub Actions run the `validate` check through `scripts/repo-maintenance/validate-all.sh`
-- use `node scripts/codex-hooks-doctor.mjs` when changing the Codex plugin or hook surface
-- use `scripts/repo-maintenance/release.sh --mode standard --version vX.Y.Z` for the aligned release flow, including the post-release live-service update from synced local `main`
-- use `scripts/repo-maintenance/release.sh --mode standard --version vX.Y.Z --remote-ci-mode defer` only when full local validation has passed and the remote CI wait should resume through a Codex wakeup instead of a long-running poll
-- use `scripts/repo-maintenance/config/profile.env` to confirm the active `swift-package` maintainer profile
-
-### Setup
-
-Resolve package dependencies with the Xcode-selected Swift toolchain:
-
-```bash
-xcrun swift package resolve
-```
-
-Install the local tools used by the full maintainer gate when you are running it outside CI:
-
-```bash
-brew install swiftformat swiftlint
-```
-
-### Workflow
-
-Use a feature branch for normal repo work. Keep Swift package changes grounded in `Package.swift`, keep source and docs updates together when public behavior changes, and use [CONTRIBUTING.md](./CONTRIBUTING.md) for pull request, live-service, and monorepo handoff rules.
-
-### Validation
-
-Run the full local maintainer gate before handing off a complete change:
-
-```bash
-sh scripts/repo-maintenance/validate-all.sh
-```
-
-For a narrower package-development loop, run:
-
-```bash
-xcrun swift build
-xcrun swift test
-```
+For local setup, validation, contribution workflow, release workflow, LaunchAgent details, embedding notes, plugin-maintainer guidance, and repo-specific maintainer rules, see [CONTRIBUTING.md](./CONTRIBUTING.md) and [AGENTS.md](./AGENTS.md).
 
 ## Repo Structure
 
 ```text
 .
 ├── Sources/
-│   ├── SpeakSwiftlyServer/
-│   └── SpeakSwiftlyServerTool/
 ├── Tests/
 ├── docs/
 ├── hooks/
@@ -206,139 +73,13 @@ xcrun swift test
 ├── .codex-plugin/
 ├── API.md
 ├── CONTRIBUTING.md
-├── Package.swift
-└── README.md
+└── Package.swift
 ```
-
-- `Sources/SpeakSwiftlyServer/` contains the reusable library target.
-- `Sources/SpeakSwiftlyServerTool/` contains the unified executable wrapper.
-- `Tests/` contains unit, integration, and a small opt-in live E2E smoke suite.
-- `docs/` contains maintainer-facing supporting documentation.
-- `hooks/` and `skills/` contain the plugin-managed Codex hook and skill surfaces.
-- `.codex-plugin/` contains the Codex plugin manifest for this repository.
 
 ## Release Notes
 
-Tagged release notes live in [GitHub Releases](https://github.com/gaelic-ghost/SpeakSwiftlyServer/releases) and the repo keeps matching historical release notes and release checklists under [docs/releases](./docs/releases/). Investigations and incident writeups live under [docs/investigations](./docs/investigations/).
+Tagged release notes live in [GitHub Releases](https://github.com/gaelic-ghost/SpeakSwiftlyServer/releases). Historical release notes and checklists live under [docs/releases](./docs/releases/).
 
 ## License
 
 See [LICENSE](./LICENSE).
-
-## Embedding
-
-The supported public embedding surface is `EmbeddedServer`, defined in [Sources/SpeakSwiftlyServer/Host/ServerState.swift](./Sources/SpeakSwiftlyServer/Host/ServerState.swift). App code owns that one observable object directly, calls `liftoff()`, binds UI to its observable properties, and uses the same object for runtime controls, playback controls, voice-profile actions, and direct live speech submission through `queueLiveSpeech(...)`, including the shared `SpeakSwiftly.RequestContext` metadata model when one request needs caller-origin details. HTTP and MCP speech surfaces add transport defaults for this context automatically; embedded app callers should still pass `RequestContext` directly when the app has richer caller or project metadata than the server can infer.
-
-```swift
-import SpeakSwiftlyServer
-import SwiftUI
-
-@main
-struct ExampleApp: App {
-    @State private var server = EmbeddedServer(
-        options: .init(
-            port: 7811,
-            runtimeProfileRootURL: FileManager.default
-                .urls(for: .applicationSupportDirectory, in: .userDomainMask)
-                .first?
-                .appendingPathComponent("ExampleApp/SpeakSwiftlyRuntime", isDirectory: true)
-        )
-    )
-
-    var body: some Scene {
-        WindowGroup {
-            ContentView(server: server)
-                .task {
-                    try? await server.liftoff()
-                }
-        }
-    }
-}
-```
-
-If you do not pass `EmbeddedServer.Options(port:)`, the embedded host defaults to `127.0.0.1:7339`. If you pass `EmbeddedServer.Options(runtimeProfileRootURL:)`, the server treats that as its profile-store root and bridges it at startup into the broader persistence root expected by the current pinned `SpeakSwiftly` runtime, while keeping the server's own runtime-configuration snapshot aligned with the same on-disk state.
-
-## Configuration
-
-The shared server supports these environment variables:
-
-- `APP_CONFIG_FILE`
-- `APP_NAME`
-- `APP_ENVIRONMENT`
-- `APP_DEFAULT_VOICE_PROFILE_NAME`
-- `APP_HOST`
-- `APP_PORT`
-- `APP_SSE_HEARTBEAT_SECONDS`
-- `APP_COMPLETED_JOB_TTL_SECONDS`
-- `APP_COMPLETED_JOB_MAX_COUNT`
-- `APP_JOB_PRUNE_INTERVAL_SECONDS`
-- `APP_HTTP_ENABLED`
-- `APP_HTTP_HOST`
-- `APP_HTTP_PORT`
-- `APP_HTTP_SSE_HEARTBEAT_SECONDS`
-- `APP_MCP_ENABLED`
-- `APP_MCP_PATH`
-- `APP_MCP_SERVER_NAME`
-- `APP_MCP_TITLE`
-- `SPEAKSWIFTLY_PROFILE_ROOT`
-
-If `APP_CONFIG_FILE` points at a YAML file, the server loads it through the package's Foundation URL-backed YAML provider and [swift-configuration](https://github.com/apple/swift-configuration), with environment variables taking precedence over YAML and YAML taking precedence over built-in defaults. Missing config files fail startup loudly. LaunchAgent install and refresh paths seed the default `~/Library/Application Support/SpeakSwiftlyServer/server.yaml` from the bundled template when that canonical file is missing.
-
-```yaml
-app:
-  name: speak-swiftly-server
-  environment: development
-  host: 127.0.0.1
-  port: 7338
-  sseHeartbeatSeconds: 10
-  completedJobTTLSeconds: 900
-  completedJobMaxCount: 200
-  jobPruneIntervalSeconds: 60
-  http:
-    enabled: true
-    host: 127.0.0.1
-    port: 7338
-    sseHeartbeatSeconds: 10
-  mcp:
-    enabled: false
-    path: /mcp
-    serverName: speak-swiftly-mcp
-    title: Speak Swiftly
-```
-
-The app-managed install layout is centered on one per-user location under `~/Library/Application Support/SpeakSwiftlyServer`, with logs in `~/Library/Logs/SpeakSwiftlyServer`. The package exposes that layout directly through [AppManagedInstallLayout.swift](./Sources/SpeakSwiftlyServer/AppManagedInstallLayout.swift).
-
-## Codex Plugin
-
-This repository is the canonical payload source for the Socket-managed `Speak Swiftly` Codex plugin. The root [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json) points at the checked-in [`.mcp.json`](./.mcp.json) connection for the local `speak_swiftly` MCP server, the tracked [skills](./skills/) bundle that teaches Codex how to use the surface intentionally, and the plugin-managed [hooks](./hooks/hooks.json) that can speak final Codex replies through the local service.
-
-The plugin install and update commands are in [Quick Start](#quick-start). The plugin identity is `speak-swiftly`, with display name `Speak Swiftly`; older standalone installs may still appear as `speak-swiftly-server` until they are upgraded or disabled. Do not use a repo-local marketplace file from this checkout for normal installs. Socket is the supported marketplace entrypoint for end users.
-
-Marketplace installation gives Codex the plugin payload: skills, MCP registration for `http://127.0.0.1:7337/mcp`, and lifecycle hooks. It does not by itself start, install, or update the native Swift service. The native service step also lives in [Quick Start](#quick-start) so users and agents see it before digging into plugin details.
-
-The [`socket`](https://github.com/gaelic-ghost/socket) repository is Gale's plugin superproject and marketplace catalog. The catalog split keeps this repository as the canonical Speak Swiftly plugin payload while letting the Socket marketplace list that same payload by Git-backed reference. Socket's marketplace entry uses the root Git source for this repository, not a copied `socket/plugins/speak-swiftly` payload. Use an explicit ref such as `gaelic-ghost/SpeakSwiftlyServer@vX.Y.Z` only in Socket metadata when you want a pinned reproducible install rather than the release-aligned default branch.
-
-If both the standalone `SpeakSwiftlyServer` marketplace and the broader `socket` marketplace are configured, prefer the Socket catalog entry. The doctor detects duplicate enablement across both marketplaces and reports a dry-run repair plan that keeps `speak-swiftly@socket` active while disabling or removing duplicate standalone enablement after confirmation. During migration, the duplicate scan accounts for both the current `speak-swiftly` id and the legacy `speak-swiftly-server` id in each marketplace.
-
-End users should start with the plugin-managed hook setup rather than copying repo-local `.codex` files into their own Codex home. The plugin-managed hook commands use the Socket marketplace cache path at `~/.codex/plugins/cache/socket/speak-swiftly/5.0.11/hooks/...` instead of relying on the session working directory. Do not add stale standalone `SpeakSwiftlyServer` cache commands or a user-level `~/.codex/hooks.json` Speak Swiftly hook for normal installs; those are duplicate or legacy repair targets, not fallback paths. The plugin can also register the logging-only `PermissionRequest` probe at `hooks/permission-request-log.mjs`; it records approval-prompt payloads for investigation without approving, rejecting, printing, or queueing speech. The repo-local `.codex/` files remain a development harness for testing hook payloads and notification behavior from this checkout.
-
-Current Codex builds require both `features.codex_hooks = true` and `features.plugin_hooks = true` before installed plugin lifecycle hooks become runnable. `codex_hooks` enables the hook system generally; `plugin_hooks` enables hook sources loaded from installed plugins.
-
-To inspect the installed hook and voice surfaces, run:
-
-```bash
-node scripts/codex-hooks-doctor.mjs
-```
-
-The doctor checks whether the plugin manifest declares hooks, whether both required hook feature flags are enabled, whether any user-level `~/.codex/hooks.json` Stop hook duplicates plugin-managed TTS, whether the permission-request probe is centralized, whether any global hook still uses the repo-local development harness, whether the live service is reachable, and whether the hook voice profile matches the runtime voice-profile inventory. The doctor also covers legacy `speak-swiftly-server` plugin ids and duplicate marketplace enablement, preferring the Socket marketplace when both catalogs are installed. Run `node scripts/codex-hooks-doctor.mjs --repair-plan` to print the dry-run repair plan; the command reports the intended config change without mutating user config.
-
-For install-surface testing, use [docs/maintainers/plugin-install-testing.md](./docs/maintainers/plugin-install-testing.md). Keep personal production Codex installs untouched by running manifest and payload checks from this repository; run actual marketplace add, upgrade, and catalog-reference tests from the `socket` checkout.
-
-The first plugin pass ships focused skills for:
-
-- broad MCP orientation
-- LaunchAgent setup and maintenance
-- Codex hook setup, permission-request probing, and final-reply TTS troubleshooting
-- runtime, playback, and queue control
-- voice workflows
-- text-profile workflows

--- a/docs/codex-hooks-tts.md
+++ b/docs/codex-hooks-tts.md
@@ -136,11 +136,11 @@ The `Stop` hook script also accepts:
   those are UI or automation metadata rather than speakable final prose.
 - `CODEX_HOOK_TTS_SKIP_SECTIONS`
   Comma-separated list of final-reply sections to omit from spoken playback.
-  The hook recognizes top-level `Answer`, `Meaning`, `Evidence`, `Details`,
-  and `Risk` headings written as Markdown headings, bold headings, or plain
-  heading lines. For example, `Evidence,Details` keeps those sections in the
-  written reply while omitting their bodies from the text sent to
-  `POST /speech/live`.
+  Defaults to `Evidence,Details`. The hook recognizes top-level `Answer`,
+  `Meaning`, `Evidence`, `Details`, and `Risk` headings written as Markdown
+  headings, bold headings, or plain heading lines. For example,
+  `Evidence,Details` keeps those sections in the written reply while omitting
+  their bodies from the text sent to `POST /speech/live`.
 - `CODEX_HOOK_TTS_SECTION_NOTICE`
   Controls how skipped section presence is announced in speech. Supported
   values are `brief`, `verbose`, and `none`; invalid values fall back to

--- a/docs/codex-hooks-tts.md
+++ b/docs/codex-hooks-tts.md
@@ -35,8 +35,8 @@ Socket marketplace command set:
 
 ```json
 {
-  "PermissionRequest": "node ~/.codex/plugins/cache/socket/speak-swiftly/5.0.11/hooks/permission-request-log.mjs",
-  "Stop": "node ~/.codex/plugins/cache/socket/speak-swiftly/5.0.11/hooks/stop-tts.mjs"
+  "PermissionRequest": "node ~/.codex/plugins/cache/socket/speak-swiftly/5.0.12/hooks/permission-request-log.mjs",
+  "Stop": "node ~/.codex/plugins/cache/socket/speak-swiftly/5.0.12/hooks/stop-tts.mjs"
 }
 ```
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/5.0.11/hooks/permission-request-log.mjs",
+            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/5.0.12/hooks/permission-request-log.mjs",
             "timeout": 15
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/5.0.11/hooks/stop-tts.mjs",
+            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/5.0.12/hooks/stop-tts.mjs",
             "timeout": 15
           }
         ]

--- a/hooks/stop-tts.mjs
+++ b/hooks/stop-tts.mjs
@@ -273,6 +273,15 @@ function stringAttribute(value) {
   return null;
 }
 
+function topicFromCwd(cwd) {
+  if (typeof cwd !== "string" || cwd.trim().length === 0) {
+    return "assistant-final-reply";
+  }
+
+  const basename = path.basename(path.resolve(cwd));
+  return basename.length > 0 ? basename : "assistant-final-reply";
+}
+
 export function speechRequestBody(message, payload, profileName) {
   const {
     session_id: sessionId = null,
@@ -303,7 +312,7 @@ export function speechRequestBody(message, payload, profileName) {
     cwd: typeof cwd === "string" && cwd.length > 0 ? cwd : undefined,
     request_context: {
       source: "Codex Hook",
-      topic: "assistant-final-reply",
+      topic: topicFromCwd(cwd),
       attributes,
     },
   };

--- a/hooks/stop-tts.mjs
+++ b/hooks/stop-tts.mjs
@@ -273,7 +273,7 @@ function stringAttribute(value) {
   return null;
 }
 
-function speechRequestBody(message, payload, profileName) {
+export function speechRequestBody(message, payload, profileName) {
   const {
     session_id: sessionId = null,
     turn_id: turnId = null,
@@ -302,7 +302,7 @@ function speechRequestBody(message, payload, profileName) {
     profile_name: profileName,
     cwd: typeof cwd === "string" && cwd.length > 0 ? cwd : undefined,
     request_context: {
-      source: "codex-stop-hook",
+      source: "Codex Hook",
       topic: "assistant-final-reply",
       attributes,
     },

--- a/hooks/stop-tts.mjs
+++ b/hooks/stop-tts.mjs
@@ -21,7 +21,7 @@ const defaultProfileName = process.env.CODEX_HOOK_TTS_PROFILE_NAME ?? "default-f
 const skipContinuedTurns = (process.env.CODEX_HOOK_TTS_SKIP_CONTINUATIONS ?? "true") !== "false";
 const skipStructuredMessages = (process.env.CODEX_HOOK_TTS_SKIP_STRUCTURED_MESSAGES ?? "true") !== "false";
 const logFullPayload = (process.env.CODEX_HOOK_TTS_LOG_FULL_PAYLOAD ?? "false") === "true";
-const skippedSectionNames = sectionNameSet(process.env.CODEX_HOOK_TTS_SKIP_SECTIONS ?? "");
+const skippedSectionNames = sectionNameSet(process.env.CODEX_HOOK_TTS_SKIP_SECTIONS ?? "Evidence,Details");
 const sectionNoticeMode = normalizeSectionNoticeMode(process.env.CODEX_HOOK_TTS_SECTION_NOTICE ?? "brief");
 const maxSeenTurns = Number.parseInt(process.env.CODEX_HOOK_TTS_MAX_SEEN_TURNS ?? "200", 10);
 const stateLockDir = path.join(stateDir, "stop-tts-seen-turns.lock");

--- a/hooks/stop-tts.test.mjs
+++ b/hooks/stop-tts.test.mjs
@@ -121,7 +121,7 @@ test("speechRequestBody labels Stop hook speech with Codex Hook source", () => {
 
   assert.equal(body.cwd, "/tmp/project");
   assert.equal(body.request_context.source, "Codex Hook");
-  assert.equal(body.request_context.topic, "assistant-final-reply");
+  assert.equal(body.request_context.topic, "project");
   assert.deepEqual(body.request_context.attributes, {
     session_id: "session-1",
     turn_id: "turn-1",
@@ -129,4 +129,10 @@ test("speechRequestBody labels Stop hook speech with Codex Hook source", () => {
     model: "gpt-test",
     hook_event_name: "Stop",
   });
+});
+
+test("speechRequestBody falls back to assistant final reply topic when cwd has no basename", () => {
+  const body = speechRequestBody("Answer\n\nDone.", { cwd: "/" }, "default-femme");
+
+  assert.equal(body.request_context.topic, "assistant-final-reply");
 });

--- a/hooks/stop-tts.test.mjs
+++ b/hooks/stop-tts.test.mjs
@@ -3,7 +3,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { speakableMessageProjection } from "./stop-tts.mjs";
+import { speakableMessageProjection, speechRequestBody } from "./stop-tts.mjs";
 
 test("speakableMessageProjection skips Evidence and Details by default", () => {
   const projection = speakableMessageProjection(
@@ -103,4 +103,30 @@ test("speakableMessageProjection can skip all sections without a spoken notice",
   assert.deepEqual(projection.presentSections, ["Answer"]);
   assert.deepEqual(projection.spokenSections, []);
   assert.deepEqual(projection.skippedSections, ["Answer"]);
+});
+
+test("speechRequestBody labels Stop hook speech with Codex Hook source", () => {
+  const body = speechRequestBody(
+    "Answer\n\nDone.",
+    {
+      session_id: "session-1",
+      turn_id: "turn-1",
+      transcript_path: "/tmp/transcript.jsonl",
+      cwd: "/tmp/project",
+      model: "gpt-test",
+      hook_event_name: "Stop",
+    },
+    "default-femme",
+  );
+
+  assert.equal(body.cwd, "/tmp/project");
+  assert.equal(body.request_context.source, "Codex Hook");
+  assert.equal(body.request_context.topic, "assistant-final-reply");
+  assert.deepEqual(body.request_context.attributes, {
+    session_id: "session-1",
+    turn_id: "turn-1",
+    transcript_path: "/tmp/transcript.jsonl",
+    model: "gpt-test",
+    hook_event_name: "Stop",
+  });
 });

--- a/hooks/stop-tts.test.mjs
+++ b/hooks/stop-tts.test.mjs
@@ -5,6 +5,30 @@ import test from "node:test";
 
 import { speakableMessageProjection } from "./stop-tts.mjs";
 
+test("speakableMessageProjection skips Evidence and Details by default", () => {
+  const projection = speakableMessageProjection(
+    [
+      "**Answer**",
+      "",
+      "Done.",
+      "",
+      "**Evidence**",
+      "",
+      "Dense command output.",
+      "",
+      "**Details**",
+      "",
+      "Extra file inventory.",
+    ].join("\n"),
+  );
+
+  assert.deepEqual(projection.presentSections, ["Answer", "Evidence", "Details"]);
+  assert.deepEqual(projection.spokenSections, ["Answer"]);
+  assert.deepEqual(projection.skippedSections, ["Evidence", "Details"]);
+  assert.doesNotMatch(projection.text, /Dense command output/);
+  assert.doesNotMatch(projection.text, /Extra file inventory/);
+});
+
 test("speakableMessageProjection skips configured sections and keeps a brief notice", () => {
   const projection = speakableMessageProjection(
     [

--- a/scripts/codex-hooks-doctor.mjs
+++ b/scripts/codex-hooks-doctor.mjs
@@ -16,7 +16,7 @@ const pluginNames = [canonicalPluginName, legacyPluginName];
 const preferredPluginKey = `${canonicalPluginName}@socket`;
 const pluginMarketplaces = ["socket", "SpeakSwiftlyServer"];
 const knownPluginKeys = pluginNames.flatMap((name) => pluginMarketplaces.map((marketplace) => `${name}@${marketplace}`));
-const socketCachedHookPath = "~/.codex/plugins/cache/socket/speak-swiftly/5.0.11/hooks";
+const socketCachedHookPath = "~/.codex/plugins/cache/socket/speak-swiftly/5.0.12/hooks";
 const expectedStopHookCommand = `node ${socketCachedHookPath}/stop-tts.mjs`;
 const expectedPermissionHookCommand = `node ${socketCachedHookPath}/permission-request-log.mjs`;
 const repairMode = process.argv.includes("--repair") || process.argv.includes("--repair-plan");

--- a/scripts/repo-maintenance/version-bump.sh
+++ b/scripts/repo-maintenance/version-bump.sh
@@ -42,7 +42,6 @@ fs.writeFileSync(`${manifestPath}\n`.trim(), `${JSON.stringify(manifest, null, 2
 const versionedFiles = [
   "hooks/hooks.json",
   "scripts/codex-hooks-doctor.mjs",
-  "README.md",
   "docs/codex-hooks-tts.md",
   "skills/speak-swiftly-codex-hooks/SKILL.md",
 ];

--- a/skills/speak-swiftly-codex-hooks/SKILL.md
+++ b/skills/speak-swiftly-codex-hooks/SKILL.md
@@ -19,7 +19,7 @@ Use this skill when the task is about Codex lifecycle hooks that send final assi
 
 - Preferred install surface: the Speak Swiftly plugin manifest declares `hooks: "./hooks/hooks.json"`, and installed plugins can bundle lifecycle config through that manifest.
 - Do not copy the repo-local `.codex/hooks.json` into `~/.codex/`; that command sets `CODEX_HOOK_TTS_DATA_DIR` for checkout-scoped development logs and state. Do not add a user-level `~/.codex/hooks.json` Speak Swiftly hook for normal installs.
-- Plugin-managed hook commands must target the installed Socket Codex cache payload path at `~/.codex/plugins/cache/socket/speak-swiftly/5.0.11/hooks/...`. Do not keep stale standalone `SpeakSwiftlyServer` cache commands in the Socket-managed manifest.
+- Plugin-managed hook commands must target the installed Socket Codex cache payload path at `~/.codex/plugins/cache/socket/speak-swiftly/5.0.12/hooks/...`. Do not keep stale standalone `SpeakSwiftlyServer` cache commands in the Socket-managed manifest.
 - Treat `PermissionRequest` as logging-only unless the user explicitly asks to make approval prompts speakable. The probe must not approve, reject, or print text to `stdout`.
 
 ## Doctor Interpretation


### PR DESCRIPTION
## Release

- prepares v5.0.12 from branch `docs/simplify-readme-contributing`
- keeps protected `main` updates behind pull request review and CI
- release tag `v5.0.12` will be created after CI and the review-comment gate pass, so failed or still-discussed release candidates do not get tagged

## Review Loop

Before merge and tagging, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.
