### PR TITLE
release: prepare v5.0.13

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "speak-swiftly",
-  "version": "5.0.12",
+  "version": "5.0.13",
   "description": "Codex plugin for local Speak Swiftly speech, playback, runtime operation, and shared MCP access.",
   "author": {
     "name": "Gale",

--- a/docs/codex-hooks-tts.md
+++ b/docs/codex-hooks-tts.md
@@ -220,9 +220,13 @@ state when the installed plugin-managed hook is the intended live speech path.
 
 The hook sends `request_context` with each queued speech request. That keeps
 Codex-originated speech inspectable through the existing `SpeakSwiftlyServer`
-request model without adding a hook-specific server API. The context includes
-the Codex model, permission mode, transcript path, session id, turn id, and
-event name when those fields are available.
+request model without adding a hook-specific server API. Ordinary project
+turns use source `Codex Hook` and a topic derived from the working directory.
+Codex document chat workspaces whose second-to-last working-directory component
+is `Codex`, or whose working directory is under `Documents/Codex`, use source
+`Codex` and topic `Chat`. The context includes the Codex model, permission
+mode, transcript path, session id, turn id, and event name when those fields
+are available.
 
 ## Validation Notes
 

--- a/docs/codex-hooks-tts.md
+++ b/docs/codex-hooks-tts.md
@@ -35,8 +35,8 @@ Socket marketplace command set:
 
 ```json
 {
-  "PermissionRequest": "node ~/.codex/plugins/cache/socket/speak-swiftly/5.0.12/hooks/permission-request-log.mjs",
-  "Stop": "node ~/.codex/plugins/cache/socket/speak-swiftly/5.0.12/hooks/stop-tts.mjs"
+  "PermissionRequest": "node ~/.codex/plugins/cache/socket/speak-swiftly/5.0.13/hooks/permission-request-log.mjs",
+  "Stop": "node ~/.codex/plugins/cache/socket/speak-swiftly/5.0.13/hooks/stop-tts.mjs"
 }
 ```
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/5.0.12/hooks/permission-request-log.mjs",
+            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/5.0.13/hooks/permission-request-log.mjs",
             "timeout": 15
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/5.0.12/hooks/stop-tts.mjs",
+            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/5.0.13/hooks/stop-tts.mjs",
             "timeout": 15
           }
         ]

--- a/hooks/stop-tts.mjs
+++ b/hooks/stop-tts.mjs
@@ -278,8 +278,31 @@ function topicFromCwd(cwd) {
     return "assistant-final-reply";
   }
 
-  const basename = path.basename(path.resolve(cwd));
+  const resolvedCwd = path.resolve(cwd);
+  const basename = path.basename(resolvedCwd);
   return basename.length > 0 ? basename : "assistant-final-reply";
+}
+
+function requestContextIdentity(cwd) {
+  if (typeof cwd === "string" && cwd.trim().length > 0) {
+    const components = path.resolve(cwd).split(path.sep).filter((item) => item.length > 0);
+    const codexIndex = components.lastIndexOf("Codex");
+    const hasPenultimateCodexComponent = components.at(-2) === "Codex";
+    const isDocumentsCodexWorkspace = codexIndex > 0
+      && components.at(codexIndex - 1) === "Documents"
+      && components.length > codexIndex + 1;
+    if (hasPenultimateCodexComponent || isDocumentsCodexWorkspace) {
+      return {
+        source: "Codex",
+        topic: "Chat",
+      };
+    }
+  }
+
+  return {
+    source: "Codex Hook",
+    topic: topicFromCwd(cwd),
+  };
 }
 
 export function speechRequestBody(message, payload, profileName) {
@@ -311,8 +334,7 @@ export function speechRequestBody(message, payload, profileName) {
     profile_name: profileName,
     cwd: typeof cwd === "string" && cwd.length > 0 ? cwd : undefined,
     request_context: {
-      source: "Codex Hook",
-      topic: topicFromCwd(cwd),
+      ...requestContextIdentity(cwd),
       attributes,
     },
   };

--- a/hooks/stop-tts.test.mjs
+++ b/hooks/stop-tts.test.mjs
@@ -131,6 +131,32 @@ test("speechRequestBody labels Stop hook speech with Codex Hook source", () => {
   });
 });
 
+test("speechRequestBody labels Codex document workspaces as Codex Chat", () => {
+  const body = speechRequestBody(
+    "Answer\n\nDone.",
+    {
+      cwd: "/Users/gale/Documents/Codex/heya-codex",
+    },
+    "default-femme",
+  );
+
+  assert.equal(body.request_context.source, "Codex");
+  assert.equal(body.request_context.topic, "Chat");
+});
+
+test("speechRequestBody labels dated Codex document workspaces as Codex Chat", () => {
+  const body = speechRequestBody(
+    "Answer\n\nDone.",
+    {
+      cwd: "/Users/gale/Documents/Codex/2026-05-04/heya-codex",
+    },
+    "default-femme",
+  );
+
+  assert.equal(body.request_context.source, "Codex");
+  assert.equal(body.request_context.topic, "Chat");
+});
+
 test("speechRequestBody falls back to assistant final reply topic when cwd has no basename", () => {
   const body = speechRequestBody("Answer\n\nDone.", { cwd: "/" }, "default-femme");
 

--- a/scripts/codex-hooks-doctor.mjs
+++ b/scripts/codex-hooks-doctor.mjs
@@ -16,7 +16,7 @@ const pluginNames = [canonicalPluginName, legacyPluginName];
 const preferredPluginKey = `${canonicalPluginName}@socket`;
 const pluginMarketplaces = ["socket", "SpeakSwiftlyServer"];
 const knownPluginKeys = pluginNames.flatMap((name) => pluginMarketplaces.map((marketplace) => `${name}@${marketplace}`));
-const socketCachedHookPath = "~/.codex/plugins/cache/socket/speak-swiftly/5.0.12/hooks";
+const socketCachedHookPath = "~/.codex/plugins/cache/socket/speak-swiftly/5.0.13/hooks";
 const expectedStopHookCommand = `node ${socketCachedHookPath}/stop-tts.mjs`;
 const expectedPermissionHookCommand = `node ${socketCachedHookPath}/permission-request-log.mjs`;
 const repairMode = process.argv.includes("--repair") || process.argv.includes("--repair-plan");

--- a/skills/speak-swiftly-codex-hooks/SKILL.md
+++ b/skills/speak-swiftly-codex-hooks/SKILL.md
@@ -19,7 +19,7 @@ Use this skill when the task is about Codex lifecycle hooks that send final assi
 
 - Preferred install surface: the Speak Swiftly plugin manifest declares `hooks: "./hooks/hooks.json"`, and installed plugins can bundle lifecycle config through that manifest.
 - Do not copy the repo-local `.codex/hooks.json` into `~/.codex/`; that command sets `CODEX_HOOK_TTS_DATA_DIR` for checkout-scoped development logs and state. Do not add a user-level `~/.codex/hooks.json` Speak Swiftly hook for normal installs.
-- Plugin-managed hook commands must target the installed Socket Codex cache payload path at `~/.codex/plugins/cache/socket/speak-swiftly/5.0.12/hooks/...`. Do not keep stale standalone `SpeakSwiftlyServer` cache commands in the Socket-managed manifest.
+- Plugin-managed hook commands must target the installed Socket Codex cache payload path at `~/.codex/plugins/cache/socket/speak-swiftly/5.0.13/hooks/...`. Do not keep stale standalone `SpeakSwiftlyServer` cache commands in the Socket-managed manifest.
 - Treat `PermissionRequest` as logging-only unless the user explicitly asks to make approval prompts speakable. The probe must not approve, reject, or print text to `stdout`.
 
 ## Doctor Interpretation


### PR DESCRIPTION
## Release

- prepares v5.0.13 from branch `hooks/codex-chat-context`
- keeps protected `main` updates behind pull request review and CI
- release tag `v5.0.13` will be created after CI and the review-comment gate pass, so failed or still-discussed release candidates do not get tagged

## Review Loop

Before merge and tagging, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.
