### PR TITLE
release: prepare v6.1.2

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "speak-swiftly",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "Codex plugin for local Speak Swiftly speech, playback, runtime operation, and shared MCP access.",
   "author": {
     "name": "Gale",

--- a/Tests/SpeakSwiftlyServerLibraryTests/HostStateTests.swift
+++ b/Tests/SpeakSwiftlyServerLibraryTests/HostStateTests.swift
@@ -155,7 +155,7 @@ extension ServerTests {
 
     @available(macOS 14, *)
     @Test func `state completes queued speech jobs and prunes expired entries`() async throws {
-        let runtime = MockRuntime()
+        let runtime = MockRuntime(speakBehavior: .holdOpen)
         let state = await MainActor.run { EmbeddedServer() }
         let host = ServerHost(
             configuration: testConfiguration(completedJobTTLSeconds: 0.05, jobPruneIntervalSeconds: 0.02),
@@ -169,6 +169,8 @@ extension ServerTests {
         try await waitUntilReady(host)
 
         let jobID = try await host.submitSpeak(text: "Hello from the test suite", profileName: "default")
+        #expect(try await waitForActiveRequestID(on: host) == jobID)
+        await runtime.finishHeldSpeak(id: jobID)
         let snapshot = try await waitForJobSnapshot(jobID, on: host)
 
         #expect(snapshot.jobID == jobID)

--- a/Tests/SpeakSwiftlyServerLibraryTests/HostStateTests.swift
+++ b/Tests/SpeakSwiftlyServerLibraryTests/HostStateTests.swift
@@ -158,7 +158,7 @@ extension ServerTests {
         let runtime = MockRuntime(speakBehavior: .holdOpen)
         let state = await MainActor.run { EmbeddedServer() }
         let host = ServerHost(
-            configuration: testConfiguration(completedJobTTLSeconds: 0.05, jobPruneIntervalSeconds: 0.02),
+            configuration: testConfiguration(completedJobTTLSeconds: 2, jobPruneIntervalSeconds: 0.02),
             runtime: runtime,
             runtimeStartupConfigurationStore: testRuntimeStartupConfigurationStore(),
             state: state,
@@ -178,7 +178,7 @@ extension ServerTests {
         #expect(snapshot.terminalEvent != nil)
         #expect(snapshot.history.count >= 3)
 
-        try await Task.sleep(for: .milliseconds(120))
+        try await Task.sleep(for: .milliseconds(2200))
         try await waitUntilJobDisappears(jobID, on: host)
 
         await host.shutdown()

--- a/Tests/SpeakSwiftlyServerLibraryTests/SpeakSwiftlyServerHostTestSupport.swift
+++ b/Tests/SpeakSwiftlyServerLibraryTests/SpeakSwiftlyServerHostTestSupport.swift
@@ -16,7 +16,7 @@ func waitUntilReady(_ host: ServerHost) async throws {
 
 @available(macOS 14, *)
 func waitForJobSnapshot(_ jobID: String, on host: ServerHost) async throws -> JobSnapshot {
-    try await waitUntil(timeout: .seconds(5), pollInterval: .milliseconds(10)) {
+    try await waitUntil(timeout: .seconds(15), pollInterval: .milliseconds(10)) {
         do {
             let snapshot = try await host.jobSnapshot(id: jobID)
             return snapshot.terminalEvent == nil ? nil : snapshot

--- a/docs/codex-hooks-tts.md
+++ b/docs/codex-hooks-tts.md
@@ -126,7 +126,9 @@ The `Stop` hook script also accepts:
 - `CODEX_HOOK_TTS_BASE_URL`
   Override the default `http://127.0.0.1:7337`.
 - `CODEX_HOOK_TTS_PROFILE_NAME`
-  Override the default voice profile name `default-femme`.
+  Force a specific voice profile for hook speech. When unset, the hook omits
+  `profile_name` and lets the running SpeakSwiftlyServer runtime default choose
+  the voice.
 - `CODEX_HOOK_TTS_SKIP_CONTINUATIONS`
   Defaults to `true`. Set to `false` if continued `Stop` turns should be read
   aloud too.
@@ -176,7 +178,7 @@ The doctor reports:
 - `plugin_hooks = true`, which is required by current Codex builds before
   installed plugin lifecycle hooks become runnable
 - live runtime reachability through `GET /overview`
-- runtime default voice profile versus the hook's configured profile
+- runtime default voice profile and any hook voice-profile override
 - cached voice profiles
 - recent centralized user/plugin and repo-local hook log outcomes
 - recent centralized and repo-local permission-request probe outcomes

--- a/docs/codex-hooks-tts.md
+++ b/docs/codex-hooks-tts.md
@@ -35,8 +35,8 @@ Socket marketplace command set:
 
 ```json
 {
-  "PermissionRequest": "node ~/.codex/plugins/cache/socket/speak-swiftly/6.1.1/hooks/permission-request-log.mjs",
-  "Stop": "node ~/.codex/plugins/cache/socket/speak-swiftly/6.1.1/hooks/stop-tts.mjs"
+  "PermissionRequest": "node ~/.codex/plugins/cache/socket/speak-swiftly/6.1.2/hooks/permission-request-log.mjs",
+  "Stop": "node ~/.codex/plugins/cache/socket/speak-swiftly/6.1.2/hooks/stop-tts.mjs"
 }
 ```
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/6.1.1/hooks/permission-request-log.mjs",
+            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/6.1.2/hooks/permission-request-log.mjs",
             "timeout": 15
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/6.1.1/hooks/stop-tts.mjs",
+            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/6.1.2/hooks/stop-tts.mjs",
             "timeout": 15
           }
         ]

--- a/hooks/stop-tts.mjs
+++ b/hooks/stop-tts.mjs
@@ -17,7 +17,7 @@ const logPath = path.join(logDir, "stop-tts.jsonl");
 
 const runtimeBaseUrl = process.env.CODEX_HOOK_TTS_BASE_URL ?? "http://127.0.0.1:7337";
 const liveSpeechEndpoint = new URL("/speech/live", runtimeBaseUrl).toString();
-const defaultProfileName = process.env.CODEX_HOOK_TTS_PROFILE_NAME ?? "default-femme";
+const configuredProfileName = normalizeProfileName(process.env.CODEX_HOOK_TTS_PROFILE_NAME);
 const skipContinuedTurns = (process.env.CODEX_HOOK_TTS_SKIP_CONTINUATIONS ?? "true") !== "false";
 const skipStructuredMessages = (process.env.CODEX_HOOK_TTS_SKIP_STRUCTURED_MESSAGES ?? "true") !== "false";
 const logFullPayload = (process.env.CODEX_HOOK_TTS_LOG_FULL_PAYLOAD ?? "false") === "true";
@@ -103,6 +103,12 @@ async function appendLog(entry) {
 }
 
 function normalizeMessage(input) {
+  if (typeof input !== "string") return null;
+  const trimmed = input.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeProfileName(input) {
   if (typeof input !== "string") return null;
   const trimmed = input.trim();
   return trimmed.length > 0 ? trimmed : null;
@@ -305,7 +311,7 @@ function requestContextIdentity(cwd) {
   };
 }
 
-export function speechRequestBody(message, payload, profileName) {
+export function speechRequestBody(message, payload, profileName = null) {
   const {
     session_id: sessionId = null,
     turn_id: turnId = null,
@@ -329,15 +335,21 @@ export function speechRequestBody(message, payload, profileName) {
       .filter(([, value]) => value !== null),
   );
 
-  return {
+  const body = {
     text: message,
-    profile_name: profileName,
     cwd: typeof cwd === "string" && cwd.length > 0 ? cwd : undefined,
     request_context: {
       ...requestContextIdentity(cwd),
       attributes,
     },
   };
+
+  const normalizedProfileName = normalizeProfileName(profileName);
+  if (normalizedProfileName) {
+    body.profile_name = normalizedProfileName;
+  }
+
+  return body;
 }
 
 async function main() {
@@ -473,7 +485,7 @@ async function main() {
       headers: {
         "content-type": "application/json",
       },
-      body: JSON.stringify(speechRequestBody(speechMessage, payload, defaultProfileName)),
+      body: JSON.stringify(speechRequestBody(speechMessage, payload, configuredProfileName)),
     });
   } catch (error) {
     await appendLog({
@@ -485,7 +497,7 @@ async function main() {
       transcriptPath,
       cwd,
       model,
-      profileName: defaultProfileName,
+      profileName: configuredProfileName,
       endpoint: liveSpeechEndpoint,
       preview: speechMessage.slice(0, 160),
       presentSections: speechProjection.presentSections,
@@ -511,7 +523,7 @@ async function main() {
       status: response.status,
       statusText: response.statusText,
       responseBody,
-      profileName: defaultProfileName,
+      profileName: configuredProfileName,
       endpoint: liveSpeechEndpoint,
       preview: speechMessage.slice(0, 160),
       presentSections: speechProjection.presentSections,
@@ -538,7 +550,7 @@ async function main() {
     cwd,
     model,
     endpoint: liveSpeechEndpoint,
-    profileName: defaultProfileName,
+    profileName: configuredProfileName,
     request: parsedResponse,
     preview: speechMessage.slice(0, 160),
     presentSections: speechProjection.presentSections,

--- a/hooks/stop-tts.test.mjs
+++ b/hooks/stop-tts.test.mjs
@@ -116,9 +116,9 @@ test("speechRequestBody labels Stop hook speech with Codex Hook source", () => {
       model: "gpt-test",
       hook_event_name: "Stop",
     },
-    "default-femme",
   );
 
+  assert.equal(body.profile_name, undefined);
   assert.equal(body.cwd, "/tmp/project");
   assert.equal(body.request_context.source, "Codex Hook");
   assert.equal(body.request_context.topic, "project");
@@ -131,13 +131,18 @@ test("speechRequestBody labels Stop hook speech with Codex Hook source", () => {
   });
 });
 
+test("speechRequestBody includes a configured voice profile override", () => {
+  const body = speechRequestBody("Answer\n\nDone.", { cwd: "/tmp/project" }, " swift-signal ");
+
+  assert.equal(body.profile_name, "swift-signal");
+});
+
 test("speechRequestBody labels Codex document workspaces as Codex Chat", () => {
   const body = speechRequestBody(
     "Answer\n\nDone.",
     {
       cwd: "/Users/gale/Documents/Codex/heya-codex",
-    },
-    "default-femme",
+    }
   );
 
   assert.equal(body.request_context.source, "Codex");
@@ -149,8 +154,7 @@ test("speechRequestBody labels dated Codex document workspaces as Codex Chat", (
     "Answer\n\nDone.",
     {
       cwd: "/Users/gale/Documents/Codex/2026-05-04/heya-codex",
-    },
-    "default-femme",
+    }
   );
 
   assert.equal(body.request_context.source, "Codex");
@@ -158,7 +162,7 @@ test("speechRequestBody labels dated Codex document workspaces as Codex Chat", (
 });
 
 test("speechRequestBody falls back to assistant final reply topic when cwd has no basename", () => {
-  const body = speechRequestBody("Answer\n\nDone.", { cwd: "/" }, "default-femme");
+  const body = speechRequestBody("Answer\n\nDone.", { cwd: "/" });
 
   assert.equal(body.request_context.topic, "assistant-final-reply");
 });

--- a/scripts/codex-hooks-doctor.mjs
+++ b/scripts/codex-hooks-doctor.mjs
@@ -9,7 +9,7 @@ const scriptPath = fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(scriptPath), "..");
 const codexHome = process.env.CODEX_HOME ?? path.join(os.homedir(), ".codex");
 const runtimeBaseUrl = process.env.CODEX_HOOK_TTS_BASE_URL ?? "http://127.0.0.1:7337";
-const expectedProfileName = process.env.CODEX_HOOK_TTS_PROFILE_NAME ?? "default-femme";
+const configuredProfileName = normalizeProfileName(process.env.CODEX_HOOK_TTS_PROFILE_NAME);
 const canonicalPluginName = "speak-swiftly";
 const legacyPluginName = "speak-swiftly-server";
 const pluginNames = [canonicalPluginName, legacyPluginName];
@@ -22,6 +22,12 @@ const expectedPermissionHookCommand = `node ${socketCachedHookPath}/permission-r
 const repairMode = process.argv.includes("--repair") || process.argv.includes("--repair-plan");
 
 const checks = [];
+
+function normalizeProfileName(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
 
 function addCheck(status, title, detail = "") {
   checks.push({ status, title, detail });
@@ -440,21 +446,35 @@ async function main() {
       : "unknown";
     addCheck("ok", "Runtime host endpoint is reachable", runtime.url);
     addCheck("info", "Runtime worker/server state", `worker=${overview.worker_mode ?? "unknown"} server=${overview.server_mode ?? "unknown"} backend=${overview.runtime_backend_transition?.active_speech_backend ?? overview.runtime_configuration?.active_runtime_speech_backend ?? "unknown"}`);
-    addCheck(
-      overview.default_voice_profile_name === expectedProfileName ? "ok" : "warn",
-      "Runtime default voice profile",
-      `runtime=${overview.default_voice_profile_name ?? "unset"} hook=${expectedProfileName}`,
-    );
-    addCheck(profileNames.includes(expectedProfileName) ? "ok" : "fail", "Expected hook voice profile is cached", profileNames);
+    if (configuredProfileName) {
+      addCheck(profileNames.includes(configuredProfileName) ? "ok" : "fail", "Configured hook voice profile is cached", profileNames);
+    } else {
+      addCheck("ok", "Hook voice profile override is not configured", "The hook will omit profile_name and let the runtime default choose the voice.");
+    }
   } else {
     addCheck("warn", "Runtime host endpoint is not reachable", runtime.error ?? `${runtime.status}: ${runtime.text}`);
+  }
+
+  const status = await fetchJSON("/status");
+  if (status.ok) {
+    addCheck(
+      status.value.default_voice_profile ? "ok" : "warn",
+      "Runtime default voice profile",
+      `runtime=${status.value.default_voice_profile ?? "unset"} hook=${configuredProfileName ?? "runtime-default"}`,
+    );
+  } else {
+    addCheck("warn", "Runtime status endpoint is not reachable", status.error ?? `${status.status}: ${status.text}`);
   }
 
   const voices = await fetchJSON("/voices");
   if (voices.ok) {
     const profiles = Array.isArray(voices.value.profiles) ? voices.value.profiles : voices.value;
     const names = Array.isArray(profiles) ? profiles.map((profile) => profile.profile_name).join(", ") : "unknown";
-    addCheck(names.includes(expectedProfileName) ? "ok" : "fail", "Voice profile inventory includes hook profile", names);
+    if (configuredProfileName) {
+      addCheck(names.includes(configuredProfileName) ? "ok" : "fail", "Voice profile inventory includes configured hook profile", names);
+    } else {
+      addCheck("info", "Voice profile inventory", names);
+    }
   } else {
     addCheck("warn", "Voice profile endpoint is not reachable", voices.error ?? `${voices.status}: ${voices.text}`);
   }

--- a/scripts/codex-hooks-doctor.mjs
+++ b/scripts/codex-hooks-doctor.mjs
@@ -16,7 +16,7 @@ const pluginNames = [canonicalPluginName, legacyPluginName];
 const preferredPluginKey = `${canonicalPluginName}@socket`;
 const pluginMarketplaces = ["socket", "SpeakSwiftlyServer"];
 const knownPluginKeys = pluginNames.flatMap((name) => pluginMarketplaces.map((marketplace) => `${name}@${marketplace}`));
-const socketCachedHookPath = "~/.codex/plugins/cache/socket/speak-swiftly/6.1.1/hooks";
+const socketCachedHookPath = "~/.codex/plugins/cache/socket/speak-swiftly/6.1.2/hooks";
 const expectedStopHookCommand = `node ${socketCachedHookPath}/stop-tts.mjs`;
 const expectedPermissionHookCommand = `node ${socketCachedHookPath}/permission-request-log.mjs`;
 const repairMode = process.argv.includes("--repair") || process.argv.includes("--repair-plan");

--- a/skills/speak-swiftly-codex-hooks/SKILL.md
+++ b/skills/speak-swiftly-codex-hooks/SKILL.md
@@ -26,7 +26,7 @@ Use this skill when the task is about Codex lifecycle hooks that send final assi
 
 - Warn on user-level hooks that point at `.codex/hooks/stop-tts.mjs`, include `CODEX_HOOK_TTS_DATA_DIR`, or duplicate the plugin-managed `Stop` hook. Treat them as duplicate or legacy repair targets, not fallback hooks.
 - Warn on duplicate enabled plugin entries. Keep the canonical Socket entry and disable or remove duplicate standalone or legacy plugin entries after confirmation.
-- Runtime default voice mismatch is not automatically a hook failure. The hook uses `CODEX_HOOK_TTS_PROFILE_NAME` or `default-femme`; confirm the profile exists in the cached voice inventory.
+- Runtime default voice mismatch is not automatically a hook failure. The hook uses the runtime default voice unless `CODEX_HOOK_TTS_PROFILE_NAME` is set; when an override is configured, confirm that profile exists in the cached voice inventory.
 
 ## Validation
 

--- a/skills/speak-swiftly-codex-hooks/SKILL.md
+++ b/skills/speak-swiftly-codex-hooks/SKILL.md
@@ -19,7 +19,7 @@ Use this skill when the task is about Codex lifecycle hooks that send final assi
 
 - Preferred install surface: the Speak Swiftly plugin manifest declares `hooks: "./hooks/hooks.json"`, and installed plugins can bundle lifecycle config through that manifest.
 - Do not copy the repo-local `.codex/hooks.json` into `~/.codex/`; that command sets `CODEX_HOOK_TTS_DATA_DIR` for checkout-scoped development logs and state. Do not add a user-level `~/.codex/hooks.json` Speak Swiftly hook for normal installs.
-- Plugin-managed hook commands must target the installed Socket Codex cache payload path at `~/.codex/plugins/cache/socket/speak-swiftly/6.1.1/hooks/...`. Do not keep stale standalone `SpeakSwiftlyServer` cache commands in the Socket-managed manifest.
+- Plugin-managed hook commands must target the installed Socket Codex cache payload path at `~/.codex/plugins/cache/socket/speak-swiftly/6.1.2/hooks/...`. Do not keep stale standalone `SpeakSwiftlyServer` cache commands in the Socket-managed manifest.
 - Treat `PermissionRequest` as logging-only unless the user explicitly asks to make approval prompts speakable. The probe must not approve, reject, or print text to `stdout`.
 
 ## Doctor Interpretation


### PR DESCRIPTION
## Release

- prepares v6.1.2 from branch `hooks/use-runtime-default-profile`
- keeps protected `main` updates behind pull request review and CI
- release tag `v6.1.2` will be created after CI and the review-comment gate pass, so failed or still-discussed release candidates do not get tagged

## Review Loop

Before merge and tagging, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.
