### PR TITLE
release: prepare v6.2.1

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "speak-swiftly",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Codex plugin for local Speak Swiftly speech, playback, runtime operation, and shared MCP access.",
   "author": {
     "name": "Gale",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,9 +68,10 @@ This root file governs the standalone Swift Package Manager repository for `Spea
 
 - This repository supports the Socket-managed Codex plugin path only. Do not add or maintain Claude Code, Anthropic, `.claude`, or `.claude-plugin` support surfaces here; if historical Claude-specific support appears in tracked docs, scripts, manifests, or examples, remove it instead of keeping parity.
 - Treat plugin-managed hooks as the required end-user path for Speak Swiftly Codex TTS. Do not add `~/.codex/hooks.json` as a repair path for normal installs.
-- Current Codex builds require both `features.codex_hooks = true` and `features.plugin_hooks = true` before installed plugin lifecycle hooks become runnable. `codex_hooks` enables the hook system; `plugin_hooks` enables hooks loaded from installed plugins.
-- If the installed plugin manifest and `hooks/hooks.json` are correct but no `Stop` row appears in `~/.codex/speak-swiftly-server/hooks/logs/stop-tts.jsonl`, check `features.plugin_hooks` before changing hook commands, adding global hooks, or blaming the live service.
-- Use `node scripts/codex-hooks-doctor.mjs --repair-plan` as the first audit surface for hook feature flags, installed plugin metadata, duplicate user-level hooks, live runtime reachability, and recent hook logs.
+- Current Codex builds require both `features.hooks = true` and `features.plugin_hooks = true` before installed plugin lifecycle hooks become runnable. `hooks` enables the hook system; `plugin_hooks` enables hooks loaded from installed plugins.
+- Codex 0.129.0 also persists per-hook review decisions under `[hooks.state]` in `~/.codex/config.toml`; missing Speak Swiftly entries there mean the operator needs to approve the plugin-managed `Stop` and `PermissionRequest` hooks in Codex settings before they run.
+- If the installed plugin manifest and `hooks/hooks.json` are correct but no `Stop` row appears in `~/.codex/speak-swiftly-server/hooks/logs/stop-tts.jsonl`, check `features.plugin_hooks` and `[hooks.state]` before changing hook commands, adding global hooks, or blaming the live service.
+- Use `node scripts/codex-hooks-doctor.mjs --repair-plan` as the first audit surface for hook feature flags, hook review state, installed plugin metadata, duplicate user-level hooks, live runtime reachability, and recent hook logs.
 - Keep user-level `~/.codex/hooks.json` Speak Swiftly entries classified as duplicate or legacy repair targets. A missing user-level Stop hook is the healthy state when the installed plugin-managed hook is intended.
 
 ### Communication and Escalation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ xcrun swift run SpeakSwiftlyServerTool healthcheck
 
 The server-owned Application Support config is LaunchAgent-oriented and defaults to `127.0.0.1:7337`. The in-memory default profiles still reserve `7338` for ad hoc standalone executable configs and `7339` for embedded app-owned configs when a config file omits an explicit port.
 
-For Codex plugin or hook changes, keep end-user behavior plugin-managed and use the repo-local `.codex/` files only as a development harness. Current Codex builds require both `features.codex_hooks = true` and `features.plugin_hooks = true` before installed plugin lifecycle hooks run; do not add `~/.codex/hooks.json` as a normal repair path. The hook doctor summarizes the active install, hook feature flags, and voice-profile state:
+For Codex plugin or hook changes, keep end-user behavior plugin-managed and use the repo-local `.codex/` files only as a development harness. Current Codex builds require both `features.hooks = true` and `features.plugin_hooks = true` before installed plugin lifecycle hooks run; do not add `~/.codex/hooks.json` as a normal repair path. Codex 0.129.0 stores per-hook review decisions under `[hooks.state]` in `~/.codex/config.toml`; use the hooks settings panel to approve expected Speak Swiftly hooks instead of bypassing review with a user-level hook. The hook doctor summarizes the active install, hook feature flags, hook review state, and voice-profile state:
 
 ```bash
 node scripts/codex-hooks-doctor.mjs
@@ -249,9 +249,9 @@ Marketplace installation gives Codex the plugin payload: skills, MCP registratio
 
 End users should start with plugin-managed hook setup rather than copying repo-local `.codex` files into their own Codex home. User-level `~/.codex/hooks.json` Speak Swiftly entries are duplicate or legacy repair targets, not the healthy default path.
 
-Current Codex builds require both `features.codex_hooks = true` and `features.plugin_hooks = true` before installed plugin lifecycle hooks become runnable. `codex_hooks` enables the hook system generally; `plugin_hooks` enables hook sources loaded from installed plugins.
+Current Codex builds require both `features.hooks = true` and `features.plugin_hooks = true` before installed plugin lifecycle hooks become runnable. `hooks` enables the hook system generally; `plugin_hooks` enables hook sources loaded from installed plugins. Codex 0.129.0 also persists per-hook review decisions under `[hooks.state]` in `~/.codex/config.toml`; missing Speak Swiftly entries there mean the operator needs to approve the plugin-managed hooks in Codex settings.
 
-Use the hook doctor as the first audit surface for installed plugin metadata, duplicate user-level hooks, live runtime reachability, and recent hook logs:
+Use the hook doctor as the first audit surface for installed plugin metadata, duplicate user-level hooks, hook review state, live runtime reachability, and recent hook logs:
 
 ```bash
 node scripts/codex-hooks-doctor.mjs

--- a/docs/codex-hooks-tts.md
+++ b/docs/codex-hooks-tts.md
@@ -59,9 +59,27 @@ configuration includes:
 
 ```toml
 [features]
-codex_hooks = true
+hooks = true
 plugin_hooks = true
 ```
+
+Codex 0.129.0 also stores per-hook review decisions in `~/.codex/config.toml`
+under `[hooks.state]`. The keys identify the hook source, event, matcher-group
+index, and command index, and each reviewed command gets a `trusted_hash`.
+For the Socket-managed Speak Swiftly plugin, the expected review keys are:
+
+```toml
+[hooks.state."speak-swiftly@socket:hooks/hooks.json:permission_request:0:0"]
+trusted_hash = "sha256:..."
+
+[hooks.state."speak-swiftly@socket:hooks/hooks.json:stop:0:0"]
+trusted_hash = "sha256:..."
+```
+
+If Codex says hooks need review, use the Codex hooks settings panel to review
+the plugin-managed Speak Swiftly `Stop` and `PermissionRequest` hooks. Do not
+add a user-level `~/.codex/hooks.json` fallback to bypass review; review is
+per hook command and lives beside the active Codex configuration.
 
 OpenAI's [Codex hooks documentation](https://developers.openai.com/codex/hooks#where-codex-looks-for-hooks)
 lists `~/.codex/hooks.json` as one of the main hook locations and says
@@ -76,7 +94,7 @@ dedupe state in the shared hook data directory.
 ## Development Harness
 
 - `.codex/config.toml`
-  Enables `features.codex_hooks = true` for this trusted project and wires a
+  Enables `features.hooks = true` for this trusted project and wires a
   `notify` probe command.
 - `.codex/hooks.json`
   Registers the same `Stop` hook script and `PermissionRequest` logging probe
@@ -170,11 +188,13 @@ The doctor reports:
 
 - repo plugin hook metadata
 - repo development-harness hook metadata
+- per-hook Codex review trust state from `[hooks.state]` in
+  `~/.codex/config.toml`
 - user-level `~/.codex/hooks.json` Speak Swiftly hook wiring, when present, as
   duplicate or legacy state to repair
 - legacy or dev-only global hook entries that split state into `.codex/`
 - installed plugin-cache manifests and whether they declare hooks
-- `codex_hooks = true` and enabled Speak Swiftly plugin entries such as `speak-swiftly@socket`
+- `hooks = true` and enabled Speak Swiftly plugin entries such as `speak-swiftly@socket`
 - `plugin_hooks = true`, which is required by current Codex builds before
   installed plugin lifecycle hooks become runnable
 - live runtime reachability through `GET /overview`
@@ -187,6 +207,10 @@ Warnings are expected if a user-level hook points at the repo-local development
 harness, sets `CODEX_HOOK_TTS_DATA_DIR` to `.codex/`, or duplicates the
 plugin-managed `Stop` hook. A missing user-level `Stop` hook is the healthy
 state when the installed plugin-managed hook is the intended live speech path.
+
+Warnings about missing hook review state mean Codex has discovered the hook but
+has not recorded a trusted command hash for that hook source. Open the Codex
+hooks settings panel and approve the expected Speak Swiftly hook commands.
 
 ## Runtime Insights
 

--- a/docs/codex-hooks-tts.md
+++ b/docs/codex-hooks-tts.md
@@ -35,8 +35,8 @@ Socket marketplace command set:
 
 ```json
 {
-  "PermissionRequest": "node ~/.codex/plugins/cache/socket/speak-swiftly/6.2.0/hooks/permission-request-log.mjs",
-  "Stop": "node ~/.codex/plugins/cache/socket/speak-swiftly/6.2.0/hooks/stop-tts.mjs"
+  "PermissionRequest": "node ~/.codex/plugins/cache/socket/speak-swiftly/6.2.1/hooks/permission-request-log.mjs",
+  "Stop": "node ~/.codex/plugins/cache/socket/speak-swiftly/6.2.1/hooks/stop-tts.mjs"
 }
 ```
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/6.2.0/hooks/permission-request-log.mjs",
+            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/6.2.1/hooks/permission-request-log.mjs",
             "timeout": 15
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/6.2.0/hooks/stop-tts.mjs",
+            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/6.2.1/hooks/stop-tts.mjs",
             "timeout": 15
           }
         ]

--- a/scripts/codex-hooks-doctor.mjs
+++ b/scripts/codex-hooks-doctor.mjs
@@ -217,6 +217,83 @@ export function pluginConfigEntries(configText) {
   });
 }
 
+export function hookReviewStateEntries(configText) {
+  if (!configText) return [];
+
+  const sectionPattern = /^\[hooks\.state\."([^"]+)"\]([\s\S]*?)(?=^\[|(?![\s\S]))/gm;
+  const entries = [];
+  let match;
+  while ((match = sectionPattern.exec(configText)) !== null) {
+    const key = match[1];
+    const body = match[2] ?? "";
+    const hashMatch = body.match(/^\s*trusted_hash\s*=\s*"([^"]+)"\s*$/m);
+    entries.push({
+      key,
+      trustedHash: hashMatch?.[1] ?? null,
+    });
+  }
+
+  return entries;
+}
+
+export function expectedHookReviewStateKeys(root = repoRoot) {
+  return [
+    {
+      label: "Repo dev-only PermissionRequest hook",
+      key: `${path.join(root, ".codex", "hooks.json")}:permission_request:0:0`,
+    },
+    {
+      label: "Repo dev-only Stop hook",
+      key: `${path.join(root, ".codex", "hooks.json")}:stop:0:0`,
+    },
+    {
+      label: "Socket plugin PermissionRequest hook",
+      key: "speak-swiftly@socket:hooks/hooks.json:permission_request:0:0",
+    },
+    {
+      label: "Socket plugin Stop hook",
+      key: "speak-swiftly@socket:hooks/hooks.json:stop:0:0",
+    },
+  ];
+}
+
+function summarizeHookReviewState(configText) {
+  const entries = hookReviewStateEntries(configText);
+  if (!configText) {
+    addCheck("warn", "Could not inspect Codex hook review state", `${path.join(codexHome, "config.toml")} is not readable.`);
+    return;
+  }
+
+  if (entries.length === 0) {
+    addCheck(
+      "warn",
+      "Codex hook review state is not present in config.toml",
+      "Codex 0.129.0 stores approved hook command hashes under [hooks.state]. Open the Codex hooks settings panel and review the Speak Swiftly hooks before expecting them to run.",
+    );
+    return;
+  }
+
+  const entriesByKey = new Map(entries.map((entry) => [entry.key, entry]));
+  for (const expected of expectedHookReviewStateKeys()) {
+    const entry = entriesByKey.get(expected.key);
+    if (!entry) {
+      addCheck(
+        "warn",
+        `${expected.label} needs review in Codex settings`,
+        `${expected.key} is missing from [hooks.state]. Open the Codex hooks settings panel and approve the hook if the command is expected.`,
+      );
+    } else if (!entry.trustedHash) {
+      addCheck(
+        "warn",
+        `${expected.label} review entry has no trusted hash`,
+        `${expected.key} exists but does not include trusted_hash.`,
+      );
+    } else {
+      addCheck("ok", `${expected.label} has Codex hook review trust state`, expected.key);
+    }
+  }
+}
+
 function summarizePluginConfig(configText) {
   const entries = pluginConfigEntries(configText);
   const presentEntries = entries.filter((entry) => entry.present);
@@ -411,7 +488,10 @@ async function main() {
   } else {
     addCheck("ok", "Global user Speak Swiftly Stop hook is not configured", globalHookClassification.message);
   }
-  const globalPermissionHookCommands = await inspectHookFile("Global user", path.join(codexHome, "hooks.json"), "PermissionRequest");
+  const globalPermissionHookCommands = await inspectHookFile("Global user", path.join(codexHome, "hooks.json"), "PermissionRequest", {
+    missingSeverity: "info",
+    missingEventSeverity: "info",
+  });
   if (globalPermissionHookCommands.some((command) => command.includes("hooks/permission-request-log.mjs") && !command.includes("CODEX_HOOK_TTS_DATA_DIR"))) {
     addCheck("ok", "Global user PermissionRequest logging probe is centralized", "Logs default to ~/.codex/speak-swiftly-server/hooks/logs/permission-request.jsonl.");
   } else if (globalPermissionHookCommands.length > 0) {
@@ -439,6 +519,7 @@ async function main() {
   }
   const pluginConfig = summarizePluginConfig(configText);
   reportRepairPlan(pluginConfig);
+  summarizeHookReviewState(configText);
 
   const installedManifests = await findInstalledPluginManifests(path.join(codexHome, "plugins", "cache"));
   if (installedManifests.length === 0) {

--- a/scripts/codex-hooks-doctor.test.mjs
+++ b/scripts/codex-hooks-doctor.test.mjs
@@ -6,6 +6,8 @@ import test from "node:test";
 import {
   buildRepairPlan,
   classifyGlobalHookCommands,
+  expectedHookReviewStateKeys,
+  hookReviewStateEntries,
   pluginConfigEntries,
 } from "./codex-hooks-doctor.mjs";
 
@@ -119,4 +121,42 @@ test("classifyGlobalHookCommands treats absent Speak Swiftly hook as plugin-only
 
   assert.equal(classification.status, "absent");
   assert.equal(classification.speakSwiftlyCommands.length, 0);
+});
+
+test("hookReviewStateEntries reads trusted hook hashes from config.toml", () => {
+  const entries = hookReviewStateEntries(`
+[hooks.state]
+
+[hooks.state."/repo/.codex/hooks.json:stop:0:0"]
+trusted_hash = "sha256:abc123"
+
+[hooks.state."speak-swiftly@socket:hooks/hooks.json:permission_request:0:0"]
+trusted_hash = "sha256:def456"
+
+[plugins."speak-swiftly@socket"]
+enabled = true
+`);
+
+  assert.deepEqual(entries, [
+    {
+      key: "/repo/.codex/hooks.json:stop:0:0",
+      trustedHash: "sha256:abc123",
+    },
+    {
+      key: "speak-swiftly@socket:hooks/hooks.json:permission_request:0:0",
+      trustedHash: "sha256:def456",
+    },
+  ]);
+});
+
+test("expectedHookReviewStateKeys includes repo and Socket hook identities", () => {
+  assert.deepEqual(
+    expectedHookReviewStateKeys("/repo").map((entry) => entry.key),
+    [
+      "/repo/.codex/hooks.json:permission_request:0:0",
+      "/repo/.codex/hooks.json:stop:0:0",
+      "speak-swiftly@socket:hooks/hooks.json:permission_request:0:0",
+      "speak-swiftly@socket:hooks/hooks.json:stop:0:0",
+    ],
+  );
 });

--- a/skills/speak-swiftly-codex-hooks/SKILL.md
+++ b/skills/speak-swiftly-codex-hooks/SKILL.md
@@ -20,7 +20,7 @@ Use this skill when the task is about Codex lifecycle hooks that send final assi
 
 - Preferred install surface: the Speak Swiftly plugin manifest declares `hooks: "./hooks/hooks.json"`, and installed plugins can bundle lifecycle config through that manifest.
 - Do not copy the repo-local `.codex/hooks.json` into `~/.codex/`; that command sets `CODEX_HOOK_TTS_DATA_DIR` for checkout-scoped development logs and state. Do not add a user-level `~/.codex/hooks.json` Speak Swiftly hook for normal installs.
-- Plugin-managed hook commands must target the installed Socket Codex cache payload path at `~/.codex/plugins/cache/socket/speak-swiftly/6.2.0/hooks/...`. Do not keep stale standalone `SpeakSwiftlyServer` cache commands in the Socket-managed manifest.
+- Plugin-managed hook commands must target the installed Socket Codex cache payload path at `~/.codex/plugins/cache/socket/speak-swiftly/6.2.1/hooks/...`. Do not keep stale standalone `SpeakSwiftlyServer` cache commands in the Socket-managed manifest.
 - Treat `PermissionRequest` as logging-only unless the user explicitly asks to make approval prompts speakable. The probe must not approve, reject, or print text to `stdout`.
 
 ## Doctor Interpretation

--- a/skills/speak-swiftly-codex-hooks/SKILL.md
+++ b/skills/speak-swiftly-codex-hooks/SKILL.md
@@ -13,7 +13,8 @@ Use this skill when the task is about Codex lifecycle hooks that send final assi
 - Verify the live service before changing hook config: read `speak-swiftly://overview` or run `node scripts/codex-hooks-doctor.mjs --repair-plan` from the repository root.
 - Treat `speak-swiftly@socket` as the preferred plugin entry when both Socket and standalone marketplaces are present.
 - Keep the legacy `speak-swiftly-server@socket` config entry disabled unless the user explicitly asks for legacy-plugin investigation.
-- For plugin-managed hooks, confirm both `features.codex_hooks = true` and `features.plugin_hooks = true` in `~/.codex/config.toml`; current Codex CLI source gates runnable plugin hooks behind the separate `plugin_hooks` feature.
+- For plugin-managed hooks, confirm both `features.hooks = true` and `features.plugin_hooks = true` in `~/.codex/config.toml`; current Codex CLI source gates runnable plugin hooks behind the separate `plugin_hooks` feature.
+- Codex 0.129.0 stores per-hook review decisions under `[hooks.state]` in `~/.codex/config.toml`; if Codex says hooks need review, use the hooks settings panel to approve the Speak Swiftly `Stop` and `PermissionRequest` commands instead of adding a user-level fallback hook.
 
 ## Setup Model
 
@@ -26,6 +27,7 @@ Use this skill when the task is about Codex lifecycle hooks that send final assi
 
 - Warn on user-level hooks that point at `.codex/hooks/stop-tts.mjs`, include `CODEX_HOOK_TTS_DATA_DIR`, or duplicate the plugin-managed `Stop` hook. Treat them as duplicate or legacy repair targets, not fallback hooks.
 - Warn on duplicate enabled plugin entries. Keep the canonical Socket entry and disable or remove duplicate standalone or legacy plugin entries after confirmation.
+- Warn when the expected `speak-swiftly@socket:hooks/hooks.json:stop:0:0` or `permission_request:0:0` entries are missing from `[hooks.state]`; that means the new Codex per-hook review gate probably still needs operator approval.
 - Runtime default voice mismatch is not automatically a hook failure. The hook uses the runtime default voice unless `CODEX_HOOK_TTS_PROFILE_NAME` is set; when an override is configured, confirm that profile exists in the cached voice inventory.
 
 ## Validation


### PR DESCRIPTION
## Release

- prepares v6.2.1 from branch `hooks/review-state-doctor`
- keeps protected `main` updates behind pull request review and CI
- release tag `v6.2.1` will be created after CI and the review-comment gate pass, so failed or still-discussed release candidates do not get tagged

## Review Loop

Before merge and tagging, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.
