### PR TITLE
release: prepare v8.0.5

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "speak-swiftly",
-  "version": "8.0.4",
+  "version": "8.0.5",
   "description": "Codex plugin for local Speak Swiftly speech, playback, runtime operation, and shared MCP access.",
   "author": {
     "name": "Gale",

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cd192ab2cd95e805d5c7b2077687080b71556c830a3a0a3ee88a3fb17d13553a",
+  "originHash" : "9e3090227aa8ebda26c6179aa63a3a15262a9f7608fd815f947d97b897bcca22",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/SpeakSwiftly.git",
       "state" : {
-        "revision" : "cc5918c47978ad7771fddb905a51e36fb010d681",
-        "version" : "9.0.2"
+        "revision" : "91cc8df38a0b234d44b4678f84d56b6998777b54",
+        "version" : "9.0.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.21.1"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
-        .package(url: "https://github.com/gaelic-ghost/SpeakSwiftly.git", from: "9.0.2"),
+        .package(url: "https://github.com/gaelic-ghost/SpeakSwiftly.git", from: "9.0.3"),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "3.31.3"),
         .package(url: "https://github.com/gaelic-ghost/TextForSpeech.git", from: "0.22.1"),
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.1.3"),

--- a/docs/codex-hooks-tts.md
+++ b/docs/codex-hooks-tts.md
@@ -29,7 +29,7 @@ Socket marketplace command set:
 
 ```json
 {
-  "Stop": "node ~/.codex/plugins/cache/socket/speak-swiftly/8.0.4/hooks/stop-tts.mjs"
+  "Stop": "node ~/.codex/plugins/cache/socket/speak-swiftly/8.0.5/hooks/stop-tts.mjs"
 }
 ```
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/8.0.4/hooks/stop-tts.mjs",
+            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/8.0.5/hooks/stop-tts.mjs",
             "timeout": 15
           }
         ]

--- a/skills/speak-swiftly-codex-hooks/SKILL.md
+++ b/skills/speak-swiftly-codex-hooks/SKILL.md
@@ -20,7 +20,7 @@ Use this skill when the task is about Codex lifecycle hooks that send final assi
 
 - Preferred install surface: the Speak Swiftly plugin manifest declares `hooks: "./hooks/hooks.json"`, and installed plugins can bundle lifecycle config through that manifest.
 - Do not copy the repo-local `.codex/hooks.json` into `~/.codex/`; that command sets `CODEX_HOOK_TTS_DATA_DIR` for checkout-scoped development logs and state. Do not add a user-level `~/.codex/hooks.json` Speak Swiftly hook for normal installs.
-- Plugin-managed hook commands must target the installed Socket Codex cache payload path at `~/.codex/plugins/cache/socket/speak-swiftly/8.0.4/hooks/...`. Do not keep stale standalone `SpeakSwiftlyServer` cache commands in the Socket-managed manifest.
+- Plugin-managed hook commands must target the installed Socket Codex cache payload path at `~/.codex/plugins/cache/socket/speak-swiftly/8.0.5/hooks/...`. Do not keep stale standalone `SpeakSwiftlyServer` cache commands in the Socket-managed manifest.
 - Keep the shipped plugin hook set limited to the `Stop` hook. Do not add a `PermissionRequest` probe unless the release explicitly reintroduces approval-prompt diagnostics.
 
 ## Doctor Interpretation


### PR DESCRIPTION
## Release

- prepares v8.0.5 from branch `release/speakswiftly-9-0-3`
- keeps protected `main` updates behind pull request review and CI
- release tag `v8.0.5` will be created after CI and the review-comment gate pass, so failed or still-discussed release candidates do not get tagged

## Review Loop

Before merge and tagging, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.
