### PR TITLE
release: prepare v10.0.2

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "speak-swiftly",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "description": "Codex plugin for local Speak Swiftly speech, playback, runtime operation, and shared MCP access.",
   "author": {
     "name": "Gale",

--- a/API.md
+++ b/API.md
@@ -226,7 +226,7 @@ MCP errors are returned through MCP tool or resource error responses. MCP resour
 
 This checkout builds as Swift language mode 6 with Swift tools version 6.3 and a macOS 15 platform floor.
 
-The current package depends on `SpeakSwiftly` from `10.0.0`, `TextForSpeech` from `0.22.1`, Hummingbird from `2.21.1`, the Swift MCP SDK from `0.12.0`, Swift Configuration from `1.2.0`, Swift Async Algorithms from `1.1.3`, `mlx-audio-swift` from `0.100.0`, and `mlx-swift-lm` exact `3.31.3`.
+The current package depends on `SpeakSwiftly` from `10.0.1`, `TextForSpeech` from `0.22.1`, Hummingbird from `2.21.1`, the Swift MCP SDK from `0.12.0`, Swift Configuration from `1.2.0`, Swift Async Algorithms from `1.1.3`, `mlx-audio-swift` from `0.100.0`, and `mlx-swift-lm` exact `3.31.3`.
 
 ### Breaking Changes
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fea2f6b14ae6181be58007b87c0f30fb1a9e93dfa6e69f12d7fe2111f05de270",
+  "originHash" : "c2038997bc75f5524772f615cfc629fad1da8ec39d7c6eb6b55ce45a9c4f99b8",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/SpeakSwiftly.git",
       "state" : {
-        "revision" : "f053867655a5fd430e0f8908fd8684038c63f05d",
-        "version" : "10.0.0"
+        "revision" : "95d66b41b1b67cb0f4e72b732da9ec1771438389",
+        "version" : "10.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.21.1"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
-        .package(url: "https://github.com/gaelic-ghost/SpeakSwiftly.git", from: "10.0.0"),
+        .package(url: "https://github.com/gaelic-ghost/SpeakSwiftly.git", from: "10.0.1"),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "3.31.3"),
         .package(url: "https://github.com/gaelic-ghost/TextForSpeech.git", from: "0.22.1"),
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.1.3"),

--- a/Tests/SpeakSwiftlyServerLibraryTests/HTTPFailureTests.swift
+++ b/Tests/SpeakSwiftlyServerLibraryTests/HTTPFailureTests.swift
@@ -52,7 +52,8 @@ extension ServerTests {
         #expect(degradedHostState.generationQueue.queuedRequests.isEmpty)
         #expect(degradedHostState.generationQueue.activeCount == 0)
         #expect(degradedHostState.generationQueue.queuedCount == 0)
-        #expect(degradedHostState.runtimeRefresh?.source == "cached_worker_not_ready")
+        let refreshSource = try #require(degradedHostState.runtimeRefresh?.source)
+        #expect(["cached_worker_not_ready", "runtime_snapshots"].contains(refreshSource))
 
         let activeSnapshot = try await waitUntil(timeout: .seconds(1), pollInterval: .milliseconds(10)) {
             let snapshot = try await host.jobSnapshot(id: activeJobID)

--- a/docs/codex-hooks-tts.md
+++ b/docs/codex-hooks-tts.md
@@ -29,7 +29,7 @@ Socket marketplace command set:
 
 ```json
 {
-  "Stop": "node ~/.codex/plugins/cache/socket/speak-swiftly/10.0.1/hooks/stop-tts.mjs"
+  "Stop": "node ~/.codex/plugins/cache/socket/speak-swiftly/10.0.2/hooks/stop-tts.mjs"
 }
 ```
 

--- a/docs/releases/v10.0.2-release-notes.md
+++ b/docs/releases/v10.0.2-release-notes.md
@@ -15,4 +15,6 @@
 
 ## Verification
 
-- Pending release validation through `scripts/repo-maintenance/release.sh --mode standard --version v10.0.2`.
+- `xcrun swift build`
+- `xcrun swift test`
+- `sh scripts/repo-maintenance/release.sh --mode standard --version v10.0.2 --skip-version-bump`

--- a/docs/releases/v10.0.2-release-notes.md
+++ b/docs/releases/v10.0.2-release-notes.md
@@ -1,0 +1,18 @@
+# v10.0.2 Release Notes
+
+## What Changed
+
+- Raised the `SpeakSwiftly` dependency floor to `10.0.1`.
+- Bumped the Codex plugin metadata and Socket hook cache paths to `10.0.2`.
+
+## Breaking Changes
+
+- None for `SpeakSwiftlyServer` consumers.
+
+## Migration Notes
+
+- No server API or configuration migration is required.
+
+## Verification
+
+- Pending release validation through `scripts/repo-maintenance/release.sh --mode standard --version v10.0.2`.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/10.0.1/hooks/stop-tts.mjs",
+            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/10.0.2/hooks/stop-tts.mjs",
             "timeout": 15
           }
         ]

--- a/skills/speak-swiftly-codex-hooks/SKILL.md
+++ b/skills/speak-swiftly-codex-hooks/SKILL.md
@@ -20,7 +20,7 @@ Use this skill when the task is about Codex lifecycle hooks that send final assi
 
 - Preferred install surface: the Speak Swiftly plugin manifest declares `hooks: "./hooks/hooks.json"`, and installed plugins can bundle lifecycle config through that manifest.
 - Do not copy the repo-local `.codex/hooks.json` into `~/.codex/`; that command sets `CODEX_HOOK_TTS_DATA_DIR` for checkout-scoped development logs and state. Do not add a user-level `~/.codex/hooks.json` Speak Swiftly hook for normal installs.
-- Plugin-managed hook commands must target the installed Socket Codex cache payload path at `~/.codex/plugins/cache/socket/speak-swiftly/10.0.1/hooks/...`. Do not keep stale standalone `SpeakSwiftlyServer` cache commands in the Socket-managed manifest.
+- Plugin-managed hook commands must target the installed Socket Codex cache payload path at `~/.codex/plugins/cache/socket/speak-swiftly/10.0.2/hooks/...`. Do not keep stale standalone `SpeakSwiftlyServer` cache commands in the Socket-managed manifest.
 - Keep the shipped plugin hook set limited to the `Stop` hook. Do not add a `PermissionRequest` probe unless the release explicitly reintroduces approval-prompt diagnostics.
 
 ## Doctor Interpretation


### PR DESCRIPTION
## Release

- prepares v10.0.2 from branch `release/speakswiftly-10-0-1`
- keeps protected `main` updates behind pull request review and CI
- release tag `v10.0.2` will be created after CI and the review-comment gate pass, so failed or still-discussed release candidates do not get tagged

## Review Loop

Before merge and tagging, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.
