### PR TITLE
release: mark prerelease GitHub metadata

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -163,6 +163,8 @@ In Progress
 - [ ] Decide whether LaunchAgent-owned startup config should keep using a reloading provider or move to a simpler startup-open path with reload support layered on intentionally later.
 - [ ] Promote the existing MCP E2E client utilities into a reusable repo-owned smoke helper for local checks, CI, and release verification.
 - [ ] Add a maintainer-facing release verification path that confirms the staged release artifact, LaunchAgent install, runtime host overview, and MCP initialize flow all agree.
+- [ ] Add a Mac mini to MacBook LAN audio smoke path that installs or refreshes the mini LaunchAgent, confirms the MacBook receiver is advertised and listening, sends a small generated-audio stream with the shared token, and verifies local receiver playback without running the full real-model E2E matrix.
+- [ ] Update server release automation so SemVer prerelease tags create GitHub prerelease objects and existing prerelease release objects are verified before the flow proceeds; keep the broader reusable repo-tooling followup tied to Socket issue [#61](https://github.com/gaelic-ghost/socket/issues/61).
 
 ### Exit Criteria
 
@@ -224,6 +226,8 @@ In Progress
 - [ ] Investigate a ChatGPT Apps SDK connector path for Speak Swiftly that exposes the server's MCP surface over HTTPS for explicit "speak this text/reply" actions, with a self-hosted Cloudflare Tunnel or equivalent setup path documented for users who want ChatGPT access to their local Mac speech service.
 - [ ] Document the current boundary between Codex hook-driven automatic spoken replies, ChatGPT MCP-tool-driven spoken replies, and native app-managed install/update flows so users and their agents know which surface can actually install, update, or speak automatically.
 - [ ] Add package-building skills that help people's agents embed `SpeakSwiftlyServer`, choose HTTP versus MCP versus `EmbeddedServer`, configure profile roots safely, and validate the resulting app or tool against the repo's public contract.
+- [ ] Add operator-facing LAN receiver guidance and commands for generating a local shared token, enabling or disabling receiver mode, validating Bonjour advertisement, and explaining that receiver changes require a service reload.
+- [ ] Add sender-side LAN output workflow guidance so operators can list discovered receivers, choose a receiver for remote playback, and understand when generated speech is played locally versus streamed to another Mac.
 
 ### Exit Criteria
 
@@ -298,6 +302,8 @@ In Progress
 - [x] Adopt the `SpeakSwiftly 5.0.0-rc.1` / `TextForSpeech 0.19.0` request and text-profile model directly: remove server-local speech normalization context shaping, keep `source_format` as the one explicit request format field, merge `cwd` and `repo_root` into shared `SpeakSwiftly.RequestContext`, and delete the text-profile JSON bridge adapter.
 - [ ] Keep any `EmbeddedServer` surface widening separate and explicit; no `EmbeddedServer` widening until a concrete embedded consumer needs it.
 - [ ] Add client compatibility-gated MCP progress updates so newer clients can subscribe to direct request/playback progress notifications without breaking existing MCP clients that only expect resource-updated notifications and retained request resources.
+- [ ] Add a selected LAN receiver routing surface across HTTP, MCP, and embedded server APIs so a caller can route a generated speech request to a discovered receiver without making `SpeakSwiftly.Runtime` own sessions or LAN connection lifetime.
+- [ ] Expand transport snapshots for `network_audio_receiver` and future LAN sender state with receiver service names, selected endpoint metadata, active stream counts, and recent failure messages that are useful to operators without exposing shared tokens.
 
 ### Exit Criteria
 

--- a/scripts/repo-maintenance/lib/common.sh
+++ b/scripts/repo-maintenance/lib/common.sh
@@ -136,6 +136,50 @@ wait_for_github_release() {
   done
 }
 
+is_semver_prerelease_tag() {
+  tag_name="$1"
+
+  case "$tag_name" in
+    v[0-9]*.[0-9]*.[0-9]*-*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+github_release_prerelease_args() {
+  tag_name="$1"
+
+  if is_semver_prerelease_tag "$tag_name"; then
+    printf '%s\n' "--prerelease"
+  fi
+}
+
+describe_github_release_create_command() {
+  tag_name="$1"
+  prerelease_args="$(github_release_prerelease_args "$tag_name")"
+
+  if [ -n "$prerelease_args" ]; then
+    printf 'gh release create --verify-tag --prerelease\n'
+  else
+    printf 'gh release create --verify-tag\n'
+  fi
+}
+
+verify_github_release_prerelease_metadata() {
+  tag_name="$1"
+
+  if ! is_semver_prerelease_tag "$tag_name"; then
+    return 0
+  fi
+
+  is_prerelease="$(gh release view "$tag_name" --json isPrerelease --jq '.isPrerelease')"
+  [ "$is_prerelease" = "true" ] || die "GitHub release $tag_name exists but is not marked as a prerelease. SemVer prerelease tags must create or preserve GitHub prerelease metadata; run gh release edit $tag_name --prerelease or rerun the release flow after correcting the release object."
+  log "Verified GitHub release $tag_name is marked as a prerelease."
+}
+
 ensure_git_repo() {
   git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "maintain-project-repo must run inside a git worktree rooted at $REPO_ROOT."
 }

--- a/scripts/repo-maintenance/release.sh
+++ b/scripts/repo-maintenance/release.sh
@@ -408,18 +408,25 @@ create_github_release() {
   fi
 
   if [ "$REPO_MAINTENANCE_DRY_RUN" = "true" ]; then
-    log "Would create a GitHub release for $RELEASE_TAG with gh release create --verify-tag."
+    log "Would create a GitHub release for $RELEASE_TAG with $(describe_github_release_create_command "$RELEASE_TAG")."
     return 0
   fi
 
   if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
     log "GitHub release $RELEASE_TAG already exists."
+    verify_github_release_prerelease_metadata "$RELEASE_TAG"
     return 0
   fi
 
-  gh release create "$RELEASE_TAG" --verify-tag --generate-notes
+  prerelease_args="$(github_release_prerelease_args "$RELEASE_TAG")"
+  if [ -n "$prerelease_args" ]; then
+    gh release create "$RELEASE_TAG" --verify-tag --generate-notes "$prerelease_args"
+  else
+    gh release create "$RELEASE_TAG" --verify-tag --generate-notes
+  fi
   log "Created GitHub release $RELEASE_TAG."
   wait_for_github_release "$RELEASE_TAG"
+  verify_github_release_prerelease_metadata "$RELEASE_TAG"
 }
 
 update_live_service() {

--- a/scripts/repo-maintenance/release/40-github-release.sh
+++ b/scripts/repo-maintenance/release/40-github-release.sh
@@ -16,15 +16,22 @@ if ! command -v gh >/dev/null 2>&1; then
 fi
 
 if [ "${REPO_MAINTENANCE_DRY_RUN:-false}" = "true" ]; then
-  log "Would create a GitHub release for $RELEASE_TAG with gh release create --verify-tag."
+  log "Would create a GitHub release for $RELEASE_TAG with $(describe_github_release_create_command "$RELEASE_TAG")."
   exit 0
 fi
 
 if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
   log "GitHub release $RELEASE_TAG already exists."
+  verify_github_release_prerelease_metadata "$RELEASE_TAG"
   exit 0
 fi
 
-gh release create "$RELEASE_TAG" --verify-tag --generate-notes
+prerelease_args="$(github_release_prerelease_args "$RELEASE_TAG")"
+if [ -n "$prerelease_args" ]; then
+  gh release create "$RELEASE_TAG" --verify-tag --generate-notes "$prerelease_args"
+else
+  gh release create "$RELEASE_TAG" --verify-tag --generate-notes
+fi
 log "Created GitHub release $RELEASE_TAG."
 wait_for_github_release "$RELEASE_TAG"
+verify_github_release_prerelease_metadata "$RELEASE_TAG"

--- a/scripts/repo-maintenance/validations/35-release-metadata.sh
+++ b/scripts/repo-maintenance/validations/35-release-metadata.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+set -eu
+
+SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export REPO_MAINTENANCE_COMMON_DIR="$SELF_DIR/../lib"
+. "$SELF_DIR/../lib/common.sh"
+
+expect_prerelease() {
+  tag_name="$1"
+
+  if ! is_semver_prerelease_tag "$tag_name"; then
+    die "Expected $tag_name to be detected as a SemVer prerelease tag."
+  fi
+
+  prerelease_args="$(github_release_prerelease_args "$tag_name")"
+  [ "$prerelease_args" = "--prerelease" ] || die "Expected $tag_name to add --prerelease to GitHub release creation."
+}
+
+expect_final_release() {
+  tag_name="$1"
+
+  if is_semver_prerelease_tag "$tag_name"; then
+    die "Expected $tag_name to be detected as a final SemVer release tag."
+  fi
+
+  prerelease_args="$(github_release_prerelease_args "$tag_name")"
+  [ -z "$prerelease_args" ] || die "Expected $tag_name to avoid GitHub prerelease metadata."
+}
+
+expect_prerelease "v11.0.0-alpha.1"
+expect_prerelease "v11.0.0-beta.1"
+expect_prerelease "v11.0.0-rc.1"
+expect_prerelease "v11.0.0-preview.20260601"
+expect_final_release "v11.0.0"
+
+log "Verified SemVer prerelease tags map to GitHub prerelease metadata."


### PR DESCRIPTION
## Summary

- Add server roadmap followups for LAN receiver routing, operator guidance, live smoke testing, and release metadata cleanup.
- Mark SemVer prerelease GitHub releases with `--prerelease`.
- Verify existing prerelease GitHub release objects are marked as prereleases.
- Add release metadata validation coverage.

## Verification

- `sh scripts/repo-maintenance/validations/35-release-metadata.sh`
- `bash scripts/repo-maintenance/validate-all.sh`
