### PR TITLE
api: propagate remote stream cancellation

### DIFF
--- a/Sources/SSSCore/Host/RemoteSpeechStreamClient.swift
+++ b/Sources/SSSCore/Host/RemoteSpeechStreamClient.swift
@@ -21,7 +21,20 @@ package typealias RemoteGeneratedAudioStreamProvider = @Sendable (
     RemoteSpeechStreamRequest,
     RemoteGenerationService,
     String,
-) -> SpeakSwiftly.GeneratedAudioChunkStream
+) -> RemoteSpeechStreamSession
+
+package struct RemoteSpeechStreamSession {
+    package let chunks: SpeakSwiftly.GeneratedAudioChunkStream
+    package let cancelUpstream: @Sendable () async throws -> Void
+
+    package init(
+        chunks: SpeakSwiftly.GeneratedAudioChunkStream,
+        cancelUpstream: @escaping @Sendable () async throws -> Void = {},
+    ) {
+        self.chunks = chunks
+        self.cancelUpstream = cancelUpstream
+    }
+}
 
 package enum RemoteSpeechStreamClient {
     package static func stream(
@@ -29,8 +42,9 @@ package enum RemoteSpeechStreamClient {
         service: RemoteGenerationService,
         sharedToken: String,
         session: URLSession = .shared,
-    ) -> SpeakSwiftly.GeneratedAudioChunkStream {
-        AsyncThrowingStream { continuation in
+    ) -> RemoteSpeechStreamSession {
+        let cancellation = RemoteSpeechStreamCancellation()
+        let chunks = AsyncThrowingStream<SpeakSwiftly.GeneratedAudioChunk, Error> { continuation in
             let task = Task {
                 do {
                     let urlRequest = try makeURLRequest(
@@ -52,6 +66,11 @@ package enum RemoteSpeechStreamClient {
                         )
                     }
 
+                    if let upstreamRequestID = httpResponse.value(forHTTPHeaderField: "X-SpeakSwiftly-Request-ID"),
+                       !upstreamRequestID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        await cancellation.recordUpstreamRequestID(upstreamRequestID)
+                    }
+
                     for try await line in bytes.lines {
                         let chunk = try GeneratedAudioHTTPStreamCodec.decodeLine(line)
                         continuation.yield(chunk)
@@ -65,10 +84,29 @@ package enum RemoteSpeechStreamClient {
                 }
             }
 
+            Task {
+                await cancellation.recordStreamTask(task)
+            }
             continuation.onTermination = { _ in
                 task.cancel()
             }
         }
+
+        return RemoteSpeechStreamSession(
+            chunks: chunks,
+            cancelUpstream: {
+                guard let upstreamRequestID = await cancellation.cancelAndReturnUpstreamRequestID() else {
+                    return
+                }
+
+                try await cancelRemoteRequest(
+                    requestID: upstreamRequestID,
+                    service: service,
+                    sharedToken: sharedToken,
+                    session: session,
+                )
+            },
+        )
     }
 
     private static func makeURLRequest(
@@ -91,5 +129,63 @@ package enum RemoteSpeechStreamClient {
         urlRequest.setValue(sharedToken, forHTTPHeaderField: RemoteGenerationConfig.streamTokenHeaderName)
         urlRequest.httpBody = try JSONEncoder().encode(request)
         return urlRequest
+    }
+
+    private static func cancelRemoteRequest(
+        requestID: String,
+        service: RemoteGenerationService,
+        sharedToken: String,
+        session: URLSession,
+    ) async throws {
+        guard let baseURL = URL(string: service.baseURL) else {
+            throw SpeakSwiftly.Error(
+                code: .invalidRequest,
+                message: "SpeakSwiftlyServer cannot cancel remote generation request '\(requestID)' because '\(service.baseURL)' is not a valid remote server base URL.",
+            )
+        }
+
+        let endpointURL = baseURL
+            .appending(path: "requests")
+            .appending(path: requestID)
+        var urlRequest = URLRequest(url: endpointURL)
+        urlRequest.httpMethod = "DELETE"
+        urlRequest.setValue(sharedToken, forHTTPHeaderField: RemoteGenerationConfig.streamTokenHeaderName)
+
+        let (_, response) = try await session.data(for: urlRequest)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw SpeakSwiftly.Error(
+                code: .internalError,
+                message: "SpeakSwiftlyServer remote cancellation request for upstream request '\(requestID)' at '\(service.baseURL)' did not return an HTTP response.",
+            )
+        }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            throw SpeakSwiftly.Error(
+                code: .internalError,
+                message: "SpeakSwiftlyServer remote cancellation request for upstream request '\(requestID)' at '\(service.baseURL)' returned HTTP \(httpResponse.statusCode). Likely cause: the remote server already completed, does not know the request id, or rejected the shared token.",
+            )
+        }
+    }
+}
+
+private actor RemoteSpeechStreamCancellation {
+    private var upstreamRequestID: String?
+    private var streamTask: Task<Void, Never>?
+    private var cancellationRequested = false
+
+    func recordStreamTask(_ task: Task<Void, Never>) {
+        streamTask = task
+        if cancellationRequested {
+            task.cancel()
+        }
+    }
+
+    func recordUpstreamRequestID(_ requestID: String) {
+        upstreamRequestID = requestID
+    }
+
+    func cancelAndReturnUpstreamRequestID() -> String? {
+        cancellationRequested = true
+        streamTask?.cancel()
+        return upstreamRequestID
     }
 }

--- a/Sources/SSSCore/Host/ServerHost+Requests.swift
+++ b/Sources/SSSCore/Host/ServerHost+Requests.swift
@@ -78,8 +78,12 @@ package extension ServerHost {
                     continuation: continuation,
                 )
             }
+            registerRemoteGenerationRequestTask(task, requestID: requestID)
             continuation.onTermination = { _ in
                 task.cancel()
+                Task {
+                    await self.clearRemoteGenerationRequestTask(id: requestID)
+                }
             }
         }
         let handle = RuntimeRequestHandle(
@@ -103,6 +107,10 @@ package extension ServerHost {
     ) async {
         continuation.yield(.started(.init(id: requestID, kind: .generateSpeech)))
         continuation.yield(.progress(.init(id: requestID, stage: .bufferingAudio)))
+        var remoteSession: RemoteSpeechStreamSession?
+        defer {
+            clearRemoteGenerationRequestTask(id: requestID)
+        }
         do {
             guard let sharedToken = remoteGenerationConfig.sharedToken else {
                 throw SpeakSwiftly.Error(
@@ -111,7 +119,7 @@ package extension ServerHost {
                 )
             }
 
-            let chunks = remoteGeneratedAudioStreamProvider(
+            let session = remoteGeneratedAudioStreamProvider(
                 .init(
                     text: text,
                     profileName: profileName,
@@ -122,13 +130,20 @@ package extension ServerHost {
                 service,
                 sharedToken,
             )
+            remoteSession = session
             try await routeRemoteGeneratedAudio(
-                chunks: chunks,
+                chunks: session.chunks,
                 requestID: requestID,
             )
+            try Task.checkCancellation()
             continuation.yield(.completed(.empty))
             continuation.finish()
         } catch is CancellationError {
+            await cancelRemoteGenerationUpstream(
+                remoteSession,
+                requestID: requestID,
+                service: service,
+            )
             continuation.finish(
                 throwing: SpeakSwiftly.Error(
                     code: .requestCancelled,
@@ -143,6 +158,44 @@ package extension ServerHost {
                     code: .internalError,
                     message: "SpeakSwiftlyServer could not complete remote generation request '\(requestID)' from '\(service.serviceName ?? service.baseURL)'. Likely cause: \(error.localizedDescription)",
                 ),
+            )
+        }
+    }
+
+    func registerRemoteGenerationRequestTask(_ task: Task<Void, Never>, requestID: String) {
+        remoteGenerationRequestTasks[requestID] = task
+        if jobs[requestID]?.terminalEvent != nil {
+            task.cancel()
+            remoteGenerationRequestTasks[requestID] = nil
+        }
+    }
+
+    func clearRemoteGenerationRequestTask(id: String) {
+        remoteGenerationRequestTasks[id] = nil
+    }
+
+    func cancelRemoteGenerationUpstream(
+        _ remoteSession: RemoteSpeechStreamSession?,
+        requestID: String,
+        service: RemoteGenerationService,
+    ) async {
+        guard let remoteSession else {
+            return
+        }
+
+        do {
+            try await remoteSession.cancelUpstream()
+        } catch let error as SpeakSwiftly.Error {
+            recordRecentError(
+                source: "remote_generation",
+                code: error.code.rawValue,
+                message: error.message,
+            )
+        } catch {
+            recordRecentError(
+                source: "remote_generation",
+                code: SpeakSwiftly.ErrorCode.internalError.rawValue,
+                message: "SpeakSwiftlyServer could not propagate cancellation for remote generation request '\(requestID)' to '\(service.serviceName ?? service.baseURL)'. Likely cause: \(error.localizedDescription)",
             )
         }
     }

--- a/Sources/SSSCore/Host/ServerHost+RuntimeControls.swift
+++ b/Sources/SSSCore/Host/ServerHost+RuntimeControls.swift
@@ -262,6 +262,10 @@ package extension ServerHost {
     }
 
     func cancelQueuedOrActiveRequest(requestID: String) async throws -> QueueCancellationResponse {
+        if let response = cancelRemoteGenerationRequestIfTracked(requestID: requestID) {
+            return response
+        }
+
         let handle = await runtime.cancelRequest(requestID)
         return try await queueCancellationResponse(handle: handle)
     }
@@ -271,6 +275,11 @@ package extension ServerHost {
         scope: RequestCancellationScope?,
     ) async throws -> QueueCancellationResponse {
         if let scope {
+            if scope == .generation,
+               let response = cancelRemoteGenerationRequestIfTracked(requestID: requestID) {
+                return response
+            }
+
             return try await cancelQueuedOrActiveRequest(scope.queueType, requestID: requestID)
         }
 
@@ -299,5 +308,15 @@ package extension ServerHost {
         }
 
         return .init(cancelledRequestID: cancelledRequestID)
+    }
+
+    private func cancelRemoteGenerationRequestIfTracked(requestID: String) -> QueueCancellationResponse? {
+        guard let task = remoteGenerationRequestTasks[requestID] else {
+            return nil
+        }
+
+        task.cancel()
+        remoteGenerationRequestTasks[requestID] = nil
+        return .init(cancelledRequestID: requestID)
     }
 }

--- a/Sources/SSSCore/Host/ServerHost+RuntimeLifecycle.swift
+++ b/Sources/SSSCore/Host/ServerHost+RuntimeLifecycle.swift
@@ -48,10 +48,18 @@ package extension ServerHost {
         playbackTask?.cancel()
         let requestMonitorTasks = requestMonitorTasks
         self.requestMonitorTasks.removeAll()
+        let remoteGenerationRequestTasks = remoteGenerationRequestTasks
+        self.remoteGenerationRequestTasks.removeAll()
+        for task in remoteGenerationRequestTasks.values {
+            task.cancel()
+        }
         for task in requestMonitorTasks.values {
             task.cancel()
         }
         await runtime.shutdown()
+        for task in remoteGenerationRequestTasks.values {
+            await task.value
+        }
         for task in requestMonitorTasks.values {
             await task.value
         }

--- a/Sources/SSSCore/Host/ServerHost.swift
+++ b/Sources/SSSCore/Host/ServerHost.swift
@@ -105,6 +105,7 @@ package actor ServerHost {
     var playbackTask: Task<Void, Never>?
     var publishTask: Task<Void, Never>?
     var requestMonitorTasks = [String: Task<Void, Never>]()
+    var remoteGenerationRequestTasks = [String: Task<Void, Never>]()
     var workerMode = "starting"
     var workerStage = "starting"
     var startupError: String?

--- a/Tests/SSSHTTPTests/HTTPWorkflowTests.swift
+++ b/Tests/SSSHTTPTests/HTTPWorkflowTests.swift
@@ -653,12 +653,14 @@ extension ServerTests {
                 #expect(request.qwenPreModelTextChunking == true)
                 #expect(service.baseURL == "http://GMM4.local:7338")
                 #expect(sharedToken == "remote-token")
-                return AsyncThrowingStream { continuation in
-                    for chunk in remoteChunks {
-                        continuation.yield(chunk)
-                    }
-                    continuation.finish()
-                }
+                return RemoteSpeechStreamSession(
+                    chunks: AsyncThrowingStream { continuation in
+                        for chunk in remoteChunks {
+                            continuation.yield(chunk)
+                        }
+                        continuation.finish()
+                    },
+                )
             },
             remoteGeneratedAudioPlaybackSink: { chunks in
                 for try await chunk in chunks {
@@ -690,6 +692,168 @@ extension ServerTests {
             #expect(snapshot.status == "completed")
             let playedChunks = await collector.chunks()
             #expect(playedChunks == remoteChunks)
+        }
+
+        await host.shutdown()
+    }
+
+    @available(macOS 14, *)
+    @Test func `cancelling remote generation request propagates cancellation upstream`() async throws {
+        let runtime = MockRuntime()
+        let cancellationRecorder = RemoteGenerationCancellationRecorder()
+        let firstChunk = SpeakSwiftly.GeneratedAudioChunk(
+            requestID: "remote-generation-cancelled",
+            sequenceNumber: 0,
+            sampleRate: 24000,
+            channelCount: 1,
+            samples: [0.1],
+        )
+        let configuration = testConfiguration()
+        let state = await MainActor.run { EmbeddedServer() }
+        let host = ServerHost(
+            configuration: configuration,
+            runtime: runtime,
+            remoteGenerationConfig: .init(
+                allowRemoteStreamRequests: false,
+                sharedToken: "remote-token",
+            ),
+            remoteGeneratedAudioStreamProvider: { _, _, _ in
+                RemoteSpeechStreamSession(
+                    chunks: AsyncThrowingStream { continuation in
+                        let task = Task {
+                            await cancellationRecorder.recordProviderStarted()
+                            continuation.yield(firstChunk)
+                            try? await Task.sleep(for: .seconds(30))
+                            continuation.finish()
+                        }
+                        continuation.onTermination = { _ in
+                            task.cancel()
+                        }
+                    },
+                    cancelUpstream: {
+                        await cancellationRecorder.recordCancellation()
+                    },
+                )
+            },
+            remoteGeneratedAudioPlaybackSink: { chunks in
+                for try await _ in chunks {}
+            },
+            runtimeStartupConfigurationStore: testRuntimeStartupConfigurationStore(),
+            state: state,
+        )
+
+        await host.start()
+        await runtime.publishStatus(.residentModelReady)
+        try await waitUntilReady(host)
+
+        let app = assembleHBApp(configuration: testHTTPConfig(configuration), host: host)
+        try await app.test(.router) { client in
+            let response = try await client.execute(
+                uri: "/speech/live",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: byteBuffer(#"{"text":"Cancel remote route","profile_name":"default","generation_location":{"kind":"remote","remote":{"base_url":"http://GMM4.local:7338","service_name":"GMM4"}}}"#),
+            )
+            let responseJSON = try jsonObject(from: response.body)
+            let requestID = try #require(responseJSON["request_id"] as? String)
+            #expect(response.status == .accepted)
+            try await cancellationRecorder.waitUntilProviderStarted()
+
+            let cancelResponse = try await client.execute(
+                uri: "/requests/\(requestID)",
+                method: .delete,
+            )
+            let cancelJSON = try jsonObject(from: cancelResponse.body)
+            #expect(cancelResponse.status == .ok)
+            #expect(cancelJSON["cancelled_request_id"] as? String == requestID)
+
+            try await cancellationRecorder.waitUntilCancelled()
+            let snapshot = try await waitForJobSnapshot(requestID, on: host)
+            switch snapshot.terminalEvent {
+                case let .failed(failure):
+                    #expect(failure.code == SpeakSwiftly.ErrorCode.requestCancelled.rawValue)
+                default:
+                    Issue.record("Expected the cancelled remote generation request to terminate with a request_cancelled failure.")
+            }
+        }
+
+        await host.shutdown()
+    }
+
+    @available(macOS 14, *)
+    @Test func `scoped generation cancellation propagates remote generation cancellation upstream`() async throws {
+        let runtime = MockRuntime()
+        let cancellationRecorder = RemoteGenerationCancellationRecorder()
+        let configuration = testConfiguration()
+        let state = await MainActor.run { EmbeddedServer() }
+        let host = ServerHost(
+            configuration: configuration,
+            runtime: runtime,
+            remoteGenerationConfig: .init(
+                allowRemoteStreamRequests: false,
+                sharedToken: "remote-token",
+            ),
+            remoteGeneratedAudioStreamProvider: { _, _, _ in
+                RemoteSpeechStreamSession(
+                    chunks: AsyncThrowingStream { continuation in
+                        let task = Task {
+                            await cancellationRecorder.recordProviderStarted()
+                            continuation.yield(
+                                SpeakSwiftly.GeneratedAudioChunk(
+                                    requestID: "remote-generation-scoped-cancelled",
+                                    sequenceNumber: 0,
+                                    sampleRate: 24000,
+                                    channelCount: 1,
+                                    samples: [0.1],
+                                ),
+                            )
+                            try? await Task.sleep(for: .seconds(30))
+                            continuation.finish()
+                        }
+                        continuation.onTermination = { _ in
+                            task.cancel()
+                        }
+                    },
+                    cancelUpstream: {
+                        await cancellationRecorder.recordCancellation()
+                    },
+                )
+            },
+            remoteGeneratedAudioPlaybackSink: { chunks in
+                for try await _ in chunks {
+                    await cancellationRecorder.recordPlayedChunk()
+                }
+            },
+            runtimeStartupConfigurationStore: testRuntimeStartupConfigurationStore(),
+            state: state,
+        )
+
+        await host.start()
+        await runtime.publishStatus(.residentModelReady)
+        try await waitUntilReady(host)
+
+        let app = assembleHBApp(configuration: testHTTPConfig(configuration), host: host)
+        try await app.test(.router) { client in
+            let response = try await client.execute(
+                uri: "/speech/live",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: byteBuffer(#"{"text":"Cancel remote route","profile_name":"default","generation_location":{"kind":"remote","remote":{"base_url":"http://GMM4.local:7338","service_name":"GMM4"}}}"#),
+            )
+            let responseJSON = try jsonObject(from: response.body)
+            let requestID = try #require(responseJSON["request_id"] as? String)
+            #expect(response.status == .accepted)
+            try await cancellationRecorder.waitUntilProviderStarted()
+
+            let cancelResponse = try await client.execute(
+                uri: "/requests/\(requestID)?scope=generation",
+                method: .delete,
+            )
+            let cancelJSON = try jsonObject(from: cancelResponse.body)
+            #expect(cancelResponse.status == .ok)
+            #expect(cancelJSON["cancelled_request_id"] as? String == requestID)
+
+            try await cancellationRecorder.waitUntilCancelled()
         }
 
         await host.shutdown()
@@ -805,5 +969,43 @@ private actor GeneratedAudioChunkCollector {
 
     func chunks() -> [SpeakSwiftly.GeneratedAudioChunk] {
         values
+    }
+}
+
+private actor RemoteGenerationCancellationRecorder {
+    private var providerStarted = false
+    private var cancellationCount = 0
+    private var playedChunkCount = 0
+
+    func recordProviderStarted() {
+        providerStarted = true
+    }
+
+    func recordCancellation() {
+        cancellationCount += 1
+    }
+
+    func recordPlayedChunk() {
+        playedChunkCount += 1
+    }
+
+    func waitUntilProviderStarted() async throws {
+        let _: Bool = try await waitUntil(timeout: .seconds(1), pollInterval: .milliseconds(10)) {
+            await self.hasProviderStarted()
+        }
+    }
+
+    func waitUntilCancelled() async throws {
+        let _: Bool = try await waitUntil(timeout: .seconds(1), pollInterval: .milliseconds(10)) {
+            await self.hasSingleCancellation()
+        }
+    }
+
+    private func hasProviderStarted() -> Bool {
+        providerStarted || playedChunkCount > 0
+    }
+
+    private func hasSingleCancellation() -> Bool {
+        cancellationCount == 1
     }
 }

--- a/Tests/SSSMCPTests/MCPValidationTests.swift
+++ b/Tests/SSSMCPTests/MCPValidationTests.swift
@@ -200,12 +200,14 @@ extension ServerTests {
                 #expect(request.profileName == "default")
                 #expect(service.serviceName == "GMM4")
                 #expect(sharedToken == "remote-token")
-                return AsyncThrowingStream { continuation in
-                    for chunk in remoteChunks {
-                        continuation.yield(chunk)
-                    }
-                    continuation.finish()
-                }
+                return RemoteSpeechStreamSession(
+                    chunks: AsyncThrowingStream { continuation in
+                        for chunk in remoteChunks {
+                            continuation.yield(chunk)
+                        }
+                        continuation.finish()
+                    },
+                )
             },
             remoteGeneratedAudioPlaybackSink: { chunks in
                 for try await chunk in chunks {


### PR DESCRIPTION
## Summary
- add remote stream sessions with explicit upstream cancellation
- let host-owned remote generation jobs cancel through the existing request cancellation route
- cover unscoped and generation-scoped remote cancellation

## Verification
- xcrun swift build
- xcrun swift test --filter HTTPWorkflowTests
- xcrun swift test --filter MCPValidationTests
- xcrun swift test
- bash scripts/repo-maintenance/validate-all.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote speech generation requests can now be cancelled while in progress, with cancellation properly propagated to the upstream server.

* **Improvements**
  * Enhanced request lifecycle management and tracking for remote generation operations to ensure proper resource cleanup and task coordination.

* **Tests**
  * Added tests verifying that remote generation request cancellation works correctly and properly propagates cancellation upstream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->