### PR TITLE
api: expose remote generation status

### DIFF
--- a/API.md
+++ b/API.md
@@ -60,6 +60,7 @@ HTTP runtime and health routes:
 HTTP speech, request, generation, and artifact routes:
 
 - `POST /speech/live`
+- `POST /speech/stream`
 - `POST /speech/files`
 - `POST /speech/batches`
 - `GET /requests`
@@ -210,7 +211,7 @@ Accepted MCP tool results use:
 - `request_resource_uri`
 - `status_resource_uri`
 
-State-oriented routes and resources return JSON snapshots. Examples include host overview, runtime status, saved runtime configuration, voice profile lists, text-profile state, generation queues, retained requests, generation jobs, generation artifacts, playback state, and playback queue.
+State-oriented routes and resources return JSON snapshots. Examples include host overview, runtime status, saved runtime configuration, voice profile lists, text-profile state, generation queues, retained requests, generation jobs, generation artifacts, playback state, and playback queue. `GET /overview` includes a `remote_generation` object with token-safe operator fields: `state`, `stream_requests_enabled`, `shared_token_configured`, `stream_token_header_name`, and `active_outbound_request_count`.
 
 Playback milestones are normalized into snake_case event names such as `active_request_changed`, `queue_changed`, `first_chunk`, `preroll_ready`, `rebuffer_started`, `rebuffer_resumed`, `completed`, `output_device_changed`, and `interruption_changed`.
 
@@ -219,6 +220,7 @@ Playback milestones are normalized into snake_case event names such as `active_r
 Important API models include:
 
 - host snapshots: overview, status, transport status, recent errors, queue summaries, and cached profile state
+- remote-generation status: stream route enablement, token presence, the expected token header name, and active outbound remote-generation request count without exposing token values
 - request records: request ID, kind, state, accepted time, last update, retained events, and terminal result
 - generation records: generation queue, jobs, job items, artifacts, artifact IDs, retained file paths, and job failures
 - playback records: playback state, active request, queued requests, buffer stability, and latest playback event

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -305,7 +305,9 @@ In Progress
 - [ ] Keep any `EmbeddedServer` surface widening separate and explicit; no `EmbeddedServer` widening until a concrete embedded consumer needs it.
 - [ ] Add client compatibility-gated MCP progress updates so newer clients can subscribe to direct request/playback progress notifications without breaking existing MCP clients that only expect resource-updated notifications and retained request resources.
 - [x] Add first-pass remote generation hardening by gating `/speech/stream` behind `app.remoteGeneration.allowRemoteStreamRequests` and a shared token header that is separate from LAN receiver playback tokens.
-- [ ] Add remaining remote generation hardening: cancellation propagation from the caller server to the generator server, richer in-flight stream status, and LAN receiver token/operator UX for non-local playback.
+- [x] Propagate remote generation cancellation from the caller server to the generator server when a host-owned remote request is cancelled.
+- [x] Add token-safe `remote_generation` overview status with stream enablement, token-presence, token-header, and active outbound request count.
+- [ ] Add remaining remote generation hardening: LAN receiver token/operator UX for non-local playback and deeper in-flight stream details when the next smoke tests show which fields operators actually need.
 - [ ] Expand transport snapshots for `network_audio_receiver` and future LAN sender state with receiver service names, selected endpoint metadata, active stream counts, and recent failure messages that are useful to operators without exposing shared tokens.
 
 ### Exit Criteria

--- a/Sources/SSSCore/Host/EmbeddedServerSnapshots.swift
+++ b/Sources/SSSCore/Host/EmbeddedServerSnapshots.swift
@@ -294,6 +294,37 @@ public struct RecentErrorSnapshot: Codable, Sendable, Equatable {
     }
 }
 
+/// Token-safe remote generation status for operator and app display.
+public struct RemoteGenerationStatusSnapshot: Codable, Sendable, Equatable {
+    public let state: String
+    public let streamRequestsEnabled: Bool
+    public let sharedTokenConfigured: Bool
+    public let streamTokenHeaderName: String
+    public let activeOutboundRequestCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case state
+        case streamRequestsEnabled = "stream_requests_enabled"
+        case sharedTokenConfigured = "shared_token_configured"
+        case streamTokenHeaderName = "stream_token_header_name"
+        case activeOutboundRequestCount = "active_outbound_request_count"
+    }
+
+    package init(
+        state: String,
+        streamRequestsEnabled: Bool,
+        sharedTokenConfigured: Bool,
+        streamTokenHeaderName: String,
+        activeOutboundRequestCount: Int,
+    ) {
+        self.state = state
+        self.streamRequestsEnabled = streamRequestsEnabled
+        self.sharedTokenConfigured = sharedTokenConfigured
+        self.streamTokenHeaderName = streamTokenHeaderName
+        self.activeOutboundRequestCount = activeOutboundRequestCount
+    }
+}
+
 /// The active and next-start runtime configuration state exposed by the host.
 public struct RuntimeConfigurationSnapshot: Codable, Sendable, Equatable {
     enum CodingKeys: String, CodingKey {
@@ -347,6 +378,7 @@ public struct HostStateSnapshot: Codable, Sendable, Equatable {
     public let runtimeBackendTransition: RuntimeBackendTransitionSnapshot
     public let currentGenerationJobs: [CurrentGenerationJobSnapshot]
     public let runtimeConfiguration: RuntimeConfigurationSnapshot
+    public let remoteGeneration: RemoteGenerationStatusSnapshot
     public let transports: [TransportStatusSnapshot]
     public let networkAudioDestinations: [NetworkAudioDestinationSnapshot]
     public let networkAudioReceiverSelection: NetworkAudioReceiverSelectionSnapshot
@@ -361,6 +393,7 @@ public struct HostStateSnapshot: Codable, Sendable, Equatable {
         case runtimeBackendTransition = "runtime_backend_transition"
         case currentGenerationJobs = "current_generation_jobs"
         case runtimeConfiguration = "runtime_configuration"
+        case remoteGeneration = "remote_generation"
         case transports
         case networkAudioDestinations = "network_audio_destinations"
         case networkAudioReceiverSelection = "network_audio_receiver_selection"

--- a/Sources/SSSCore/Host/QueueResponseModels.swift
+++ b/Sources/SSSCore/Host/QueueResponseModels.swift
@@ -206,6 +206,7 @@ package struct StatusSnapshot: Encodable {
         case runtimeBackendTransition = "runtime_backend_transition"
         case currentGenerationJobs = "current_generation_jobs"
         case runtimeConfiguration = "runtime_configuration"
+        case remoteGeneration = "remote_generation"
         case transports
         case networkAudioDestinations = "network_audio_destinations"
         case networkAudioReceiverSelection = "network_audio_receiver_selection"
@@ -232,6 +233,7 @@ package struct StatusSnapshot: Encodable {
     package let runtimeBackendTransition: RuntimeBackendTransitionSnapshot
     package let currentGenerationJobs: [CurrentGenerationJobSnapshot]
     package let runtimeConfiguration: RuntimeConfigurationSnapshot
+    package let remoteGeneration: RemoteGenerationStatusSnapshot
     package let transports: [TransportStatusSnapshot]
     package let networkAudioDestinations: [NetworkAudioDestinationSnapshot]
     package let networkAudioReceiverSelection: NetworkAudioReceiverSelectionSnapshot

--- a/Sources/SSSCore/Host/ServerHost+RuntimeControls.swift
+++ b/Sources/SSSCore/Host/ServerHost+RuntimeControls.swift
@@ -29,6 +29,7 @@ package extension ServerHost {
             runtimeBackendTransition: hostState.runtimeBackendTransition,
             currentGenerationJobs: hostState.currentGenerationJobs,
             runtimeConfiguration: hostState.runtimeConfiguration,
+            remoteGeneration: hostState.remoteGeneration,
             transports: hostState.transports,
             networkAudioDestinations: hostState.networkAudioDestinations,
             networkAudioReceiverSelection: hostState.networkAudioReceiverSelection,
@@ -42,6 +43,25 @@ package extension ServerHost {
             activeDuckMediaVolume: activeDuckMediaVolume,
             activeDefaultVoiceProfileName: activeDefaultVoiceProfileName,
             configuredDefaultVoiceProfileName: configuration.defaultVoiceProfileName,
+        )
+    }
+
+    func remoteGenerationStatusSnapshot() -> RemoteGenerationStatusSnapshot {
+        let sharedTokenConfigured = remoteGenerationConfig.sharedToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        let state = if remoteGenerationConfig.allowRemoteStreamRequests == false {
+            "disabled"
+        } else if sharedTokenConfigured {
+            "ready"
+        } else {
+            "misconfigured"
+        }
+
+        return .init(
+            state: state,
+            streamRequestsEnabled: remoteGenerationConfig.allowRemoteStreamRequests,
+            sharedTokenConfigured: sharedTokenConfigured,
+            streamTokenHeaderName: RemoteGenerationConfig.streamTokenHeaderName,
+            activeOutboundRequestCount: remoteGenerationRequestTasks.count,
         )
     }
 

--- a/Sources/SSSCore/Host/ServerHost+RuntimeLifecycle.swift
+++ b/Sources/SSSCore/Host/ServerHost+RuntimeLifecycle.swift
@@ -211,6 +211,7 @@ package extension ServerHost {
             runtimeBackendTransition: runtimeBackendTransitionSnapshot(),
             currentGenerationJobs: currentGenerationJobSnapshots(),
             runtimeConfiguration: runtimeConfigurationSnapshot(),
+            remoteGeneration: remoteGenerationStatusSnapshot(),
             transports: transportSnapshots(),
             networkAudioDestinations: networkAudioDestinations,
             networkAudioReceiverSelection: networkAudioReceiverSelectionSnapshot(),

--- a/Sources/SSSCore/Host/ServerHostDefaultSnapshots.swift
+++ b/Sources/SSSCore/Host/ServerHostDefaultSnapshots.swift
@@ -58,6 +58,14 @@ package enum ServerHostDefaultSnapshots {
         persistedConfigurationWillAffectNextRuntimeStart: true,
     )
 
+    package static let remoteGeneration = RemoteGenerationStatusSnapshot(
+        state: "disabled",
+        streamRequestsEnabled: false,
+        sharedTokenConfigured: false,
+        streamTokenHeaderName: RemoteGenerationConfig.streamTokenHeaderName,
+        activeOutboundRequestCount: 0,
+    )
+
     package static let networkAudioReceiverSelection = NetworkAudioReceiverSelectionSnapshot(
         selectedDestinationID: nil,
         selectedDestination: nil,

--- a/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/Operator-Surfaces.md
+++ b/Sources/SpeakSwiftlyServer/SpeakSwiftlyServer.docc/Articles/Operator-Surfaces.md
@@ -33,7 +33,7 @@ The companion executable walkthrough starts at <doc:Using-The-Command-Line-Tool>
 
 The HTTP and MCP surfaces are transport adapters around the same host state and runtime operations. They are the right choice when another process, a local service manager, or an external client should own the session.
 
-The server-to-server generated-audio stream route is disabled by default. Enable `app.remoteGeneration.allowRemoteStreamRequests` and provide `app.remoteGeneration.sharedToken` only when this machine should generate speech for another SpeakSwiftlyServer over `/speech/stream`; callers must send that token in `X-SpeakSwiftly-Remote-Generation-Token`.
+The server-to-server generated-audio stream route is disabled by default. Enable `app.remoteGeneration.allowRemoteStreamRequests` and provide `app.remoteGeneration.sharedToken` only when this machine should generate speech for another SpeakSwiftlyServer over `/speech/stream`; callers must send that token in `X-SpeakSwiftly-Remote-Generation-Token`. Shared host snapshots expose this as `remote_generation`, including whether stream requests are enabled, whether a shared token is configured, the expected token header name, and the active outbound remote-generation request count. The snapshot intentionally does not expose token values.
 
 The LAN audio receiver is also a transport adapter, but it is intentionally receiver-only in this release. Enable `app.networkAudioReceiver` when this machine should advertise itself over Bonjour, accept generated-audio chunk streams from another SpeakSwiftly host after the shared-token handshake, and play those chunks locally. The transport appears in shared host snapshots as `network_audio_receiver`, including listener state and active inbound stream count.
 

--- a/Tests/SSSCoreTests/HostStateTests.swift
+++ b/Tests/SSSCoreTests/HostStateTests.swift
@@ -142,6 +142,7 @@ extension ServerTests {
                         activeRuntimeMatchesNextRuntime: true,
                         persistedConfigurationWillAffectNextRuntimeStart: true,
                     ),
+                    remoteGeneration: ServerHostDefaultSnapshots.remoteGeneration,
                     transports: [],
                     networkAudioDestinations: [],
                     networkAudioReceiverSelection: ServerHostDefaultSnapshots.networkAudioReceiverSelection,
@@ -153,6 +154,12 @@ extension ServerTests {
         #expect(hostPlayback["state"] as? String == playbackBody["state"] as? String)
         #expect((hostPlayback["active_request"] as? [String: Any])?["id"] as? String == "request-1")
         #expect(hostPlayback["stable_buffered_audio_ms"] as? Int == playbackBody["stable_buffered_audio_ms"] as? Int)
+        let remoteGenerationBody = try #require(hostStateJSON["remote_generation"] as? [String: Any])
+        #expect(remoteGenerationBody["state"] as? String == "disabled")
+        #expect(remoteGenerationBody["stream_requests_enabled"] as? Bool == false)
+        #expect(remoteGenerationBody["shared_token_configured"] as? Bool == false)
+        #expect(remoteGenerationBody["stream_token_header_name"] as? String == RemoteGenerationConfig.streamTokenHeaderName)
+        #expect(remoteGenerationBody["active_outbound_request_count"] as? Int == 0)
 
         let queueJSON = try jsonObject(from: JSONEncoder().encode(QueueSnapshotResponse(snapshot: queue)))
         #expect(queueJSON["queue_type"] as? String == "playback")

--- a/Tests/SSSHTTPTests/HTTPWorkflowTests.swift
+++ b/Tests/SSSHTTPTests/HTTPWorkflowTests.swift
@@ -55,6 +55,13 @@ extension ServerTests {
             #expect((runtimeRefresh["playback_queue_refreshed_at"] as? String)?.isEmpty == false)
             #expect((runtimeRefresh["playback_state_refreshed_at"] as? String)?.isEmpty == false)
             #expect((runtimeRefresh["completed_at"] as? String)?.isEmpty == false)
+            let remoteGeneration = try #require(runtimeHostJSON["remote_generation"] as? [String: Any])
+            #expect(remoteGeneration["state"] as? String == "disabled")
+            #expect(remoteGeneration["stream_requests_enabled"] as? Bool == false)
+            #expect(remoteGeneration["shared_token_configured"] as? Bool == false)
+            #expect(remoteGeneration["stream_token_header_name"] as? String == RemoteGenerationConfig.streamTokenHeaderName)
+            #expect(remoteGeneration["active_outbound_request_count"] as? Int == 0)
+            #expect(remoteGeneration["shared_token"] == nil)
 
             let runtimeConfigResponse = try await client.execute(uri: "/configuration", method: .get)
             let runtimeConfigJSON = try jsonObject(from: runtimeConfigResponse.body)


### PR DESCRIPTION
## Summary
- add token-safe remote_generation status to shared host and overview snapshots
- document the new operator fields and keep token values hidden
- update roadmap hardening items for cancellation and status progress

## Verification
- xcrun swift build
- xcrun swift test --filter HostStateTests
- xcrun swift test --filter HTTPWorkflowTests
- xcrun swift test
- bash scripts/repo-maintenance/validate-all.sh