### PR TITLE
deps: update SpeakSwiftly to alpha 4

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ceb01ed13d05f67a73cc63ae65f18f87d5e8a60c6e1c20cc2df57d4b6e096695",
+  "originHash" : "fa27c23479524c330c2c0ecd1207aeaeec47248926a8981612c52bc6a72f8310",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/SpeakSwiftly.git",
       "state" : {
-        "revision" : "bafd968673eebb91a03a46f7c6161d457cd0a3e1",
-        "version" : "11.0.0-alpha.3"
+        "revision" : "c8fc53a1273f1e6fa99ab2d695dffa54c92a0678",
+        "version" : "11.0.0-alpha.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.21.1"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.83.0"),
-        .package(url: "https://github.com/gaelic-ghost/SpeakSwiftly.git", from: "11.0.0-alpha.3"),
+        .package(url: "https://github.com/gaelic-ghost/SpeakSwiftly.git", from: "11.0.0-alpha.4"),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "3.31.3"),
         .package(url: "https://github.com/gaelic-ghost/TextForSpeech.git", from: "0.23.0"),
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.1.3"),

--- a/Sources/SSSCore/Host/ServerHost+Requests.swift
+++ b/Sources/SSSCore/Host/ServerHost+Requests.swift
@@ -319,6 +319,7 @@ package extension ServerHost {
                 senderName: configuration.name,
                 sharedToken: sharedToken,
             ),
+            connectionReadinessTimeout: .seconds(15),
         )
         try await sender.send(chunks: chunks)
     }

--- a/Sources/SpeakSwiftlyServer/NetworkAudioReceiverLifecycleService.swift
+++ b/Sources/SpeakSwiftlyServer/NetworkAudioReceiverLifecycleService.swift
@@ -57,6 +57,7 @@ package struct NetworkAudioReceiverLifecycleService: Service {
                 advertisement: .init(name: config.serviceName),
                 port: config.port,
                 sharedToken: config.sharedToken ?? "",
+                connectionReadinessTimeout: .seconds(15),
             )
 
             do {

--- a/Tests/SSSHTTPTests/HTTPControlTests.swift
+++ b/Tests/SSSHTTPTests/HTTPControlTests.swift
@@ -295,6 +295,7 @@ extension ServerTests {
             advertisement: SpeakSwiftly.NetworkAudioServiceAdvertisement(name: "Loopback receiver"),
             port: 0,
             sharedToken: "receiver-token",
+            connectionReadinessTimeout: .seconds(2),
         )
         let inboundStreams = await listener.inboundStreams()
         try await listener.start()

--- a/Tests/SpeakSwiftlyServerEmbeddingTests/HostLifecycleTests.swift
+++ b/Tests/SpeakSwiftlyServerEmbeddingTests/HostLifecycleTests.swift
@@ -223,6 +223,7 @@ import Testing
             senderName: "server-test",
             sharedToken: "test-token",
         ),
+        connectionReadinessTimeout: .seconds(2),
     )
 
     try await sender.send(chunks: chunks)


### PR DESCRIPTION
## Summary
- update SpeakSwiftly to v11.0.0-alpha.4 for bounded Network.framework audio stream readiness waits
- pass explicit LAN sender/listener readiness timeouts in server call sites

## Verification
- xcrun swift test --filter HTTPControlTests
- xcrun swift test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SpeakSwiftly dependency to version 11.0.0-alpha.4.
  * Enhanced network audio streaming configuration with connection readiness timeout settings for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->