### PR TITLE
deps: update SpeakSwiftly to alpha 5

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fa27c23479524c330c2c0ecd1207aeaeec47248926a8981612c52bc6a72f8310",
+  "originHash" : "ba56bb5fe67978bfca5c34f602aa2d11b96da4f3094e11b846ab9b876e0e12b3",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/SpeakSwiftly.git",
       "state" : {
-        "revision" : "c8fc53a1273f1e6fa99ab2d695dffa54c92a0678",
-        "version" : "11.0.0-alpha.4"
+        "revision" : "ecf214613ddb9da4dfffa697b44b4122d7c758b6",
+        "version" : "11.0.0-alpha.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.21.1"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.83.0"),
-        .package(url: "https://github.com/gaelic-ghost/SpeakSwiftly.git", from: "11.0.0-alpha.4"),
+        .package(url: "https://github.com/gaelic-ghost/SpeakSwiftly.git", from: "11.0.0-alpha.5"),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "3.31.3"),
         .package(url: "https://github.com/gaelic-ghost/TextForSpeech.git", from: "0.23.0"),
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.1.3"),


### PR DESCRIPTION
## What changed
- Updates SpeakSwiftlyServer to depend on SpeakSwiftly 11.0.0-alpha.5.
- Locks Package.resolved to the alpha.5 tag that avoids the Network.framework readiness timeout task crash.

## Verification
- `xcrun swift test`
