### PR TITLE
deps: update SpeakSwiftly to alpha 6

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ba56bb5fe67978bfca5c34f602aa2d11b96da4f3094e11b846ab9b876e0e12b3",
+  "originHash" : "7e82536d4a84e81fead151db803ec051c284b065a60865cf1b7ff332f21dc044",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/SpeakSwiftly.git",
       "state" : {
-        "revision" : "ecf214613ddb9da4dfffa697b44b4122d7c758b6",
-        "version" : "11.0.0-alpha.5"
+        "revision" : "beefdb606c924611921c3e05b6f632cd67915c05",
+        "version" : "11.0.0-alpha.6"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.21.1"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.83.0"),
-        .package(url: "https://github.com/gaelic-ghost/SpeakSwiftly.git", from: "11.0.0-alpha.5"),
+        .package(url: "https://github.com/gaelic-ghost/SpeakSwiftly.git", from: "11.0.0-alpha.6"),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "3.31.3"),
         .package(url: "https://github.com/gaelic-ghost/TextForSpeech.git", from: "0.23.0"),
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.1.3"),


### PR DESCRIPTION
## Summary
- update SpeakSwiftly dependency to v11.0.0-alpha.6
- refresh Package.resolved to the published diagnostics release

## Verification
- xcrun swift test --filter HTTPControlTests
- xcrun swift test --filter HostStateTests (one timing timeout, single affected test passed on rerun)
- xcrun swift test