### PR TITLE
network-audio: explain local network privacy failures

### DIFF
--- a/Sources/SSSCore/Host/ServerHost+NetworkAudioDestinations.swift
+++ b/Sources/SSSCore/Host/ServerHost+NetworkAudioDestinations.swift
@@ -158,7 +158,11 @@ package extension ServerHost {
                 destination: destination,
             )
         } catch {
-            let message = "SpeakSwiftlyServer could not send LAN audio receiver smoke-test request '\(requestID)' to selected receiver '\(destination.name)'. Likely cause: \(error.localizedDescription)"
+            let message = Self.networkAudioSmokeTestFailureMessage(
+                requestID: requestID,
+                destinationName: destination.name,
+                error: error,
+            )
             recordRecentError(
                 source: "network_audio_smoke_test",
                 code: "send_failed",
@@ -197,6 +201,32 @@ package extension ServerHost {
             ))
             continuation.finish()
         }
+    }
+
+    static func networkAudioSmokeTestFailureMessage(
+        requestID: String,
+        destinationName: String,
+        error: any Error,
+    ) -> String {
+        let description = error.localizedDescription
+        let privacyHint = networkAudioLocalNetworkPrivacyHint(for: description).map { " \($0)" } ?? ""
+        return "SpeakSwiftlyServer could not send LAN audio receiver smoke-test request '\(requestID)' " +
+            "to selected receiver '\(destinationName)'. Likely cause: \(description)\(privacyHint)"
+    }
+
+    static func networkAudioLocalNetworkPrivacyHint(for errorDescription: String) -> String? {
+        let lowercasedDescription = errorDescription.lowercased()
+        guard lowercasedDescription.contains("network is down") ||
+            lowercasedDescription.contains("posixerrorcode(rawvalue: 50)") ||
+            lowercasedDescription.contains("local network prohibited")
+        else {
+            return nil
+        }
+
+        return "On macOS, this can mean Local Network privacy is blocking the LaunchAgent-hosted " +
+            "SpeakSwiftlyServer process from reaching another Mac on the LAN. Check System Settings > " +
+            "Privacy & Security > Local Network for the server's install surface, or run the " +
+            "receiver/sender through an app or plugin bundle that declares LAN access."
     }
 }
 

--- a/Tests/SSSCoreTests/HostStateTests.swift
+++ b/Tests/SSSCoreTests/HostStateTests.swift
@@ -252,6 +252,33 @@ extension ServerTests {
         #expect(preservedManualSelection.lanOutputReady == true)
     }
 
+    @Test func `LAN audio smoke-test failure message explains local network privacy block`() {
+        let message = ServerHost.networkAudioSmokeTestFailureMessage(
+            requestID: "network-audio-smoke-test",
+            destinationName: "Gale MacBook Receiver",
+            error: TestLocalizedError(
+                description: "SpeakSwiftly could not open network audio stream for request 'network-audio-smoke-test' to 192.168.12.149:51021 before the 15 second readiness timeout. Last observed Network.framework state: waiting(POSIXErrorCode(rawValue: 50): Network is down).",
+            ),
+        )
+
+        #expect(message.contains("Gale MacBook Receiver"))
+        #expect(message.contains("Network is down"))
+        #expect(message.contains("Local Network privacy"))
+        #expect(message.contains("LaunchAgent-hosted SpeakSwiftlyServer"))
+        #expect(message.contains("Privacy & Security > Local Network"))
+    }
+
+    @Test func `LAN audio smoke-test failure message does not add privacy hint for ordinary errors`() {
+        let message = ServerHost.networkAudioSmokeTestFailureMessage(
+            requestID: "network-audio-smoke-test",
+            destinationName: "Gale MacBook Receiver",
+            error: TestLocalizedError(description: "The receiver closed the audio stream during the handshake."),
+        )
+
+        #expect(message.contains("The receiver closed the audio stream during the handshake."))
+        #expect(!message.contains("Local Network privacy"))
+    }
+
     @available(macOS 14, *)
     @Test func `playback updates publish latest event and request progress details`() async throws {
         let runtime = MockRuntime(speakBehavior: .holdOpen)
@@ -1293,5 +1320,13 @@ extension ServerTests {
         #expect(await host.resolvedRequestedVoiceProfileName(nil) == "configured-default")
 
         await host.shutdown()
+    }
+}
+
+private struct TestLocalizedError: LocalizedError {
+    let description: String
+
+    var errorDescription: String? {
+        description
     }
 }


### PR DESCRIPTION
## Summary
- add a LAN smoke-test diagnostic hint for macOS Local Network privacy blocks
- keep ordinary smoke-test transport failures unchanged
- cover the privacy-shaped Network.framework failure message in host-state tests

## Verification
- xcrun swift test --filter HostStateTests
- xcrun swift test --filter HTTPControlTests
- xcrun swift test