### PR TITLE
release: prepare v11.0.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "speak-swiftly",
-  "version": "11.0.0-rc.1",
+  "version": "11.0.0",
   "description": "Codex plugin for local Speak Swiftly speech, playback, runtime operation, and shared MCP access.",
   "author": {
     "name": "Gale",

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ee1964c777ba4e6d7ec995cd4cd8e60cd282377724def02c6c7927ef35bd0240",
+  "originHash" : "e6b15b33b2088c663f8e055da726337ea592790fb5deb494b88c0fa7114b38f6",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gaelic-ghost/SpeakSwiftly.git",
       "state" : {
-        "revision" : "a52e146e7b57cdc6e6fa4b87a5847cbe911ed5c3",
-        "version" : "11.0.0-alpha.7"
+        "revision" : "c88211814092a2368c670a79539090dc17b7fb9a",
+        "version" : "11.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.21.1"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.83.0"),
-        .package(url: "https://github.com/gaelic-ghost/SpeakSwiftly.git", from: "11.0.0-alpha.7"),
+        .package(url: "https://github.com/gaelic-ghost/SpeakSwiftly.git", from: "11.0.0"),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "3.31.3"),
         .package(url: "https://github.com/gaelic-ghost/TextForSpeech.git", from: "0.23.0"),
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.1.3"),

--- a/docs/codex-hooks-tts.md
+++ b/docs/codex-hooks-tts.md
@@ -29,7 +29,7 @@ Socket marketplace command set:
 
 ```json
 {
-  "Stop": "node ~/.codex/plugins/cache/socket/speak-swiftly/11.0.0-rc.1/hooks/stop-tts.mjs"
+  "Stop": "node ~/.codex/plugins/cache/socket/speak-swiftly/11.0.0/hooks/stop-tts.mjs"
 }
 ```
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/11.0.0-rc.1/hooks/stop-tts.mjs",
+            "command": "node ~/.codex/plugins/cache/socket/speak-swiftly/11.0.0/hooks/stop-tts.mjs",
             "timeout": 15
           }
         ]

--- a/skills/speak-swiftly-codex-hooks/SKILL.md
+++ b/skills/speak-swiftly-codex-hooks/SKILL.md
@@ -20,7 +20,7 @@ Use this skill when the task is about Codex lifecycle hooks that send final assi
 
 - Preferred install surface: the Speak Swiftly plugin manifest declares `hooks: "./hooks/hooks.json"`, and installed plugins can bundle lifecycle config through that manifest.
 - Do not copy the repo-local `.codex/hooks.json` into `~/.codex/`; that command sets `CODEX_HOOK_TTS_DATA_DIR` for checkout-scoped development logs and state. Do not add a user-level `~/.codex/hooks.json` Speak Swiftly hook for normal installs.
-- Plugin-managed hook commands must target the installed Socket Codex cache payload path at `~/.codex/plugins/cache/socket/speak-swiftly/11.0.0-rc.1/hooks/...`. Do not keep stale standalone `SpeakSwiftlyServer` cache commands in the Socket-managed manifest.
+- Plugin-managed hook commands must target the installed Socket Codex cache payload path at `~/.codex/plugins/cache/socket/speak-swiftly/11.0.0/hooks/...`. Do not keep stale standalone `SpeakSwiftlyServer` cache commands in the Socket-managed manifest.
 - Keep the shipped plugin hook set limited to the `Stop` hook. Do not add a `PermissionRequest` probe unless the release explicitly reintroduces approval-prompt diagnostics.
 
 ## Doctor Interpretation


### PR DESCRIPTION
## Release

- prepares v11.0.0 from branch `release/v11.0.0`
- keeps protected `main` updates behind pull request review and CI
- release tag `v11.0.0` will be created after CI and the review-comment gate pass, so failed or still-discussed release candidates do not get tagged

## Review Loop

Before merge and tagging, `scripts/repo-maintenance/release.sh` watches CI and stops on review comments unless the maintainer has already addressed or resolved them and reruns with `--review-comments-addressed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Advanced plugin version from release candidate to stable release (11.0.0).
  * Updated dependency from alpha to stable version (11.0.0).
  * Updated configuration and manifest files to reference new stable versions.

* **Documentation**
  * Updated documentation and configuration files to reflect current versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->